### PR TITLE
Fail on abnormal events

### DIFF
--- a/src/FSLibrary/MissionHistoryPubnetMinimumCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetMinimumCatchup.fs
@@ -17,7 +17,8 @@ let historyPubnetMinimumCatchup (context: MissionContext) =
     let set =
         { PubnetCoreSetOptions context.image with
               nodeCount = 1
-              catchupMode = CatchupRecent(0) }
+              catchupMode = CatchupRecent(0)
+              invariantChecks = AllInvariantsExceptBucketConsistencyChecks }
 
     let coreSet = MakeLiveCoreSet "core" set
 

--- a/src/FSLibrary/MissionHistoryPubnetRecentCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetRecentCatchup.fs
@@ -17,7 +17,8 @@ let historyPubnetRecentCatchup (context: MissionContext) =
     let set =
         { PubnetCoreSetOptions context.image with
               nodeCount = 1
-              catchupMode = CatchupRecent(1001) }
+              catchupMode = CatchupRecent(1001)
+              invariantChecks = AllInvariantsExceptBucketConsistencyChecks }
 
     let coreSet = MakeLiveCoreSet "core" set
 


### PR DESCRIPTION
Two-parter related to recent uncaught failure:
  - Treat the presence of any abnormal events during a run as a cause to fail the run
  - Disable the bucketlist consistency invariant on more pubnet missions as it's too expensive (and was causing health-check failures -- abnormal events that are now errors due to the previous change)