### PR TITLE
Minor startup cfgmap cleanups

### DIFF
--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -130,9 +130,9 @@ type Tests(output: ITestOutputHelper) =
         let cmdStr = ShAnd(cmds).ToString()
 
         let exp =
-            "{ stellar-core new-db --conf \"/cfg-startup-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-startup.cfg\" && "
-            + "{ stellar-core new-hist local --conf \"/cfg-startup-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-startup.cfg\" || true; } && "
-            + "stellar-core force-scp --conf \"/cfg-startup-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-startup.cfg\"; }"
+            "{ stellar-core new-db --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-startup.cfg\" && "
+            + "{ stellar-core new-hist local --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-startup.cfg\" || true; } && "
+            + "stellar-core force-scp --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-startup.cfg\"; }"
 
         Assert.Equal(exp, cmdStr)
 

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -87,7 +87,7 @@ type Tests(output: ITestOutputHelper) =
 
     [<Fact>]
     member __.``TOML Config looks reasonable``() =
-        let cfg = nCfg.StellarCoreCfg(coreSet, 1, false)
+        let cfg = nCfg.StellarCoreCfg(coreSet, 1, MainCoreContainer)
         let toml = cfg.ToString()
         let peer0DNS = (nCfg.PeerDnsName coreSet 0).StringName
         let peer1DNS = (nCfg.PeerDnsName coreSet 1).StringName
@@ -117,9 +117,9 @@ type Tests(output: ITestOutputHelper) =
         Assert.Contains("OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING = [30, 70]", toml)
         Assert.Contains("HTTP_PORT = " + CfgVal.httpPort.ToString(), toml)
 
-        // Test startup config
-        let cfgStartup = nCfg.StellarCoreCfg(coreSet, 1, true)
-        Assert.Contains("HTTP_PORT = 0", cfgStartup.ToString())
+        // Test init config
+        let initCfg = nCfg.StellarCoreCfg(coreSet, 1, InitCoreContainer)
+        Assert.Contains("HTTP_PORT = 0", initCfg.ToString())
 
     [<Fact>]
     member __.``Core init commands look reasonable``() =
@@ -130,9 +130,9 @@ type Tests(output: ITestOutputHelper) =
         let cmdStr = ShAnd(cmds).ToString()
 
         let exp =
-            "{ stellar-core new-db --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-startup.cfg\" && "
-            + "{ stellar-core new-hist local --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-startup.cfg\" || true; } && "
-            + "stellar-core force-scp --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-startup.cfg\"; }"
+            "{ stellar-core new-db --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-init.cfg\" && "
+            + "{ stellar-core new-hist local --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-init.cfg\" || true; } && "
+            + "stellar-core force-scp --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-init.cfg\"; }"
 
         Assert.Equal(exp, cmdStr)
 
@@ -193,7 +193,7 @@ type Tests(output: ITestOutputHelper) =
              let sdfCoreSetName = CoreSetName "www-stellar-org"
              Assert.Contains(coreSets, (fun cs -> cs.name = sdfCoreSetName))
              let sdfCoreSet = List.find (fun cs -> cs.name = sdfCoreSetName) coreSets
-             let cfg = nCfg.StellarCoreCfg(sdfCoreSet, 0, false)
+             let cfg = nCfg.StellarCoreCfg(sdfCoreSet, 0, MainCoreContainer)
              let toml = cfg.ToString()
              Assert.Contains("[QUORUM_SET.sub1]", toml)
              Assert.Contains("[HISTORY.local]", toml)

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -131,8 +131,7 @@ type Tests(output: ITestOutputHelper) =
 
         let exp =
             "{ stellar-core new-db --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-init.cfg\" && "
-            + "{ stellar-core new-hist local --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-init.cfg\" || true; } && "
-            + "stellar-core force-scp --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-init.cfg\"; }"
+            + "{ stellar-core new-hist local --conf \"/cfg-${STELLAR_CORE_PEER_SHORT_NAME}/stellar-core-init.cfg\" || true; }; }"
 
         Assert.Equal(exp, cmdStr)
 

--- a/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
+++ b/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
@@ -39,7 +39,7 @@ let databaseInplaceUpgrade (context: MissionContext) =
                       { newDb = false
                         newHist = false
                         initialCatchup = false
-                        forceScp = false
+                        waitForConsensus = true
                         fetchDBFromPeer = fetchFromPeer } }
 
     context.Execute

--- a/src/FSLibrary/MissionVersionMixConsensus.fs
+++ b/src/FSLibrary/MissionVersionMixConsensus.fs
@@ -38,7 +38,7 @@ let versionMixConsensus (context: MissionContext) =
                       { newDb = false
                         newHist = false
                         initialCatchup = false
-                        forceScp = true
+                        waitForConsensus = false
                         fetchDBFromPeer = fetchFromPeer } }
 
     let oldCoreSet =
@@ -52,7 +52,7 @@ let versionMixConsensus (context: MissionContext) =
                       { newDb = false
                         newHist = false
                         initialCatchup = false
-                        forceScp = true
+                        waitForConsensus = false
                         fetchDBFromPeer = fetchFromPeer } }
 
     context.Execute

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -190,9 +190,8 @@ type StellarCoreCfg =
         t.Add("ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING", self.accelerateTime) |> ignore
         t.Add("ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING", self.generateLoad) |> ignore
 
-        match self.inMemoryMode with
-        | false -> ()
-        | true -> t.Add("METADATA_OUTPUT_STREAM", CfgVal.metaStreamPath) |> ignore
+        if self.inMemoryMode then
+            t.Add("METADATA_OUTPUT_STREAM", CfgVal.metaStreamPath) |> ignore
 
         match self.network.missionContext.simulateApplyWeight, self.network.missionContext.simulateApplyDuration with
         | None, None -> ()

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -40,7 +40,7 @@ module CfgVal =
                            ShBare("/" + peerCfgFileName) |]
 
     let peerStartupNameEnvCfgFileWord : ShWord =
-        ShWord.ShPieces [| ShBare("/cfg-startup-")
+        ShWord.ShPieces [| ShBare("/cfg-")
                            ShVar(ShName peerNameEnvVarName)
                            ShBare("/" + peerStartupCfgFileName) |]
 
@@ -51,9 +51,6 @@ module CfgVal =
 
     let cfgVolumeName peerOrJobName = sprintf "cfg-%s" peerOrJobName
     let cfgVolumePath peerOrJobName = "/" + (cfgVolumeName peerOrJobName)
-
-    let cfgStartupVolumeName peerOrJobName = sprintf "cfg-startup-%s" peerOrJobName
-    let cfgStartupVolumePath peerOrJobName = "/" + (cfgStartupVolumeName peerOrJobName)
 
     let jobCfgVolumeName = "cfg-job"
     let jobCfgVolumePath = "/" + jobCfgVolumeName

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -31,7 +31,7 @@ module CfgVal =
     let asanOptionsEnvVarName = "ASAN_OPTIONS"
     let asanOptionsEnvVarValue = "quarantine_size_mb=1:malloc_context_size=5"
     let peerCfgFileName = "stellar-core.cfg"
-    let peerStartupCfgFileName = "stellar-core-startup.cfg"
+    let peerInitCfgFileName = "stellar-core-init.cfg"
     let peerDelayCfgFileName = "install-delays.sh"
 
     let peerNameEnvCfgFileWord : ShWord =
@@ -39,10 +39,10 @@ module CfgVal =
                            ShVar(ShName peerNameEnvVarName)
                            ShBare("/" + peerCfgFileName) |]
 
-    let peerStartupNameEnvCfgFileWord : ShWord =
+    let peerNameEnvInitCfgFileWord : ShWord =
         ShWord.ShPieces [| ShBare("/cfg-")
                            ShVar(ShName peerNameEnvVarName)
-                           ShBare("/" + peerStartupCfgFileName) |]
+                           ShBare("/" + peerInitCfgFileName) |]
 
     let peerNameEnvDelayCfgFileWord : ShWord =
         ShWord.ShPieces [| ShBare("/cfg-")
@@ -102,6 +102,10 @@ let curlGetCmd (uri: System.Uri) : string = sprintf "curl -sf %s{0} -o {1}" (uri
 
 let curlGetCmdFromPeer (peer: PeerDnsName) : string = curlGetCmd (System.UriBuilder("http", peer.StringName).Uri)
 
+type CoreContainerType =
+    | InitCoreContainer
+    | MainCoreContainer
+
 // Represents the contents of a stellar-core.cfg file, along with method to
 // write it out to TOML.
 type StellarCoreCfg =
@@ -130,7 +134,7 @@ type StellarCoreCfg =
       maxSlotsToRemember: int
       maxBatchWriteCount: int
       inMemoryMode: bool
-      startup: bool }
+      containerType: CoreContainerType }
 
     member self.ToTOML() : TomlTable =
         let t = Toml.Create()
@@ -156,9 +160,9 @@ type StellarCoreCfg =
 
         t.Add("DATABASE", self.database.ToString()) |> ignore
 
-        match self.startup with
-        | false -> t.Add("HTTP_PORT", int64 (CfgVal.httpPort)) |> ignore
-        | true -> t.Add("HTTP_PORT", 0) |> ignore
+        match self.containerType with
+        | MainCoreContainer -> t.Add("HTTP_PORT", int64 (CfgVal.httpPort)) |> ignore
+        | InitCoreContainer -> t.Add("HTTP_PORT", 0) |> ignore
 
         t.Add("PUBLIC_HTTP_PORT", true) |> ignore
         t.Add("BUCKET_DIR_PATH", CfgVal.bucketsPath) |> ignore
@@ -387,9 +391,9 @@ type NetworkCfg with
           maxSlotsToRemember = opts.maxSlotsToRemember
           maxBatchWriteCount = opts.maxBatchWriteCount
           inMemoryMode = opts.inMemoryMode
-          startup = false }
+          containerType = MainCoreContainer }
 
-    member self.StellarCoreCfg(c: CoreSet, i: int, setNolisten: bool) : StellarCoreCfg =
+    member self.StellarCoreCfg(c: CoreSet, i: int, ctype: CoreContainerType) : StellarCoreCfg =
         { network = self
           database = self.getDbUrl c.options
           networkPassphrase = self.networkPassphrase
@@ -421,4 +425,4 @@ type NetworkCfg with
           maxSlotsToRemember = c.options.maxSlotsToRemember
           maxBatchWriteCount = c.options.maxBatchWriteCount
           inMemoryMode = c.options.inMemoryMode
-          startup = setNolisten }
+          containerType = ctype }

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -72,42 +72,42 @@ type CoreSetInitialization =
     { newDb: bool
       newHist: bool
       initialCatchup: bool
-      forceScp: bool
+      waitForConsensus: bool
       fetchDBFromPeer: (CoreSetName * int) option }
 
     static member Default =
         { newDb = true
           newHist = true
           initialCatchup = false
-          forceScp = true
+          waitForConsensus = false
           fetchDBFromPeer = None }
 
     static member DefaultNoForceSCP =
         { newDb = true
           newHist = true
           initialCatchup = false
-          forceScp = false
+          waitForConsensus = true
           fetchDBFromPeer = None }
 
     static member CatchupNoForceSCP =
         { newDb = true
           newHist = true
           initialCatchup = true
-          forceScp = false
+          waitForConsensus = true
           fetchDBFromPeer = None }
 
     static member OnlyNewDb =
         { newDb = true
           newHist = false
           initialCatchup = false
-          forceScp = false
+          waitForConsensus = true
           fetchDBFromPeer = None }
 
     static member NoInitCmds =
         { newDb = false
           newHist = false
           initialCatchup = false
-          forceScp = false
+          waitForConsensus = true
           fetchDBFromPeer = None }
 
 type GeoLoc = { lat: float; lon: float }
@@ -157,7 +157,8 @@ type CoreSetOptions =
       maxBatchWriteCount: int
       inMemoryMode: bool }
 
-    member self.WithForceSCP(f: bool) = { self with initialization = { self.initialization with forceScp = f } }
+    member self.WithWaitForConsensus(w: bool) =
+        { self with initialization = { self.initialization with waitForConsensus = w } }
 
     static member GetDefault(image: string) =
         { nodeCount = 3

--- a/src/FSLibrary/StellarDataDump.fs
+++ b/src/FSLibrary/StellarDataDump.fs
@@ -76,7 +76,6 @@ type StellarFormation with
         self.DumpPeerCommandLogs destination "new-db" p
         self.DumpPeerCommandLogs destination "new-hist" p
         self.DumpPeerCommandLogs destination "catchup" p
-        self.DumpPeerCommandLogs destination "force-scp" p
         self.DumpPeerCommandLogs destination "run" p
 
     member self.BackupDatabaseToHistory(p: Peer) =

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -268,7 +268,7 @@ let CoreContainerForCommand
         volumeMounts = CoreContainerVolumeMounts peerOrJobNames configOpt
     )
 
-let WithLivenessProbe (container: V1Container) (probeTimeout: int) : V1Container =
+let WithProbes (container: V1Container) (probeTimeout: int) : V1Container =
     let httpPortStr = IntstrIntOrString(value = CfgVal.httpPort.ToString())
 
     let liveProbe =
@@ -644,7 +644,7 @@ type NetworkCfg with
         let res = self.missionContext.coreResources
 
         let containers =
-            [| WithLivenessProbe
+            [| WithProbes
                 (CoreContainerForCommand imageName cfgOpt res runCmdMaybeInMemory initCommands peerNames)
                 self.missionContext.probeTimeout
                HistoryContainer self.missionContext.nginxImage |]

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -617,10 +617,11 @@ type NetworkCfg with
             else
                 runCmd
 
-        let runCmdMaybeInMemory =
-            match coreSet.options.inMemoryMode with
-            | true -> Array.append runCmd [| "--in-memory" |]
-            | false -> runCmd
+        let runCmd =
+            if coreSet.options.inMemoryMode then
+                Array.append runCmd [| "--in-memory" |]
+            else
+                runCmd
 
         let usePostgres = (coreSet.options.dbType = Postgres)
         let exportToPrometheus = self.missionContext.exportToPrometheus
@@ -629,7 +630,7 @@ type NetworkCfg with
 
         let containers =
             [| WithProbes
-                (CoreContainerForCommand imageName cfgOpt res runCmdMaybeInMemory initCommands peerNames)
+                (CoreContainerForCommand imageName cfgOpt res runCmd initCommands peerNames)
                 self.missionContext.probeTimeout
                HistoryContainer self.missionContext.nginxImage |]
 

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -282,15 +282,14 @@ let WithLivenessProbe (container: V1Container) (probeTimeout: int) : V1Container
     container.LivenessProbe <- liveProbe
 
     // Allow 10 minute buffer to startup core (this may involve lengthy operations such as bucket application)
-    if withStartupProbe then
-        let startupProbe =
-            V1Probe(
-                periodSeconds = System.Nullable<int>(5),
-                failureThreshold = System.Nullable<int>(120),
-                httpGet = V1HTTPGetAction(path = "/info", port = httpPortStr)
-            )
+    let startupProbe =
+        V1Probe(
+            periodSeconds = System.Nullable<int>(5),
+            failureThreshold = System.Nullable<int>(120),
+            httpGet = V1HTTPGetAction(path = "/info", port = httpPortStr)
+        )
 
-        container.StartupProbe <- startupProbe
+    container.StartupProbe <- startupProbe
 
     container
 
@@ -648,7 +647,6 @@ type NetworkCfg with
             [| WithLivenessProbe
                 (CoreContainerForCommand imageName cfgOpt res runCmdMaybeInMemory initCommands peerNames)
                 self.missionContext.probeTimeout
-                true
                HistoryContainer self.missionContext.nginxImage |]
 
         let containers =

--- a/src/FSLibrary/StellarNetworkCfg.fs
+++ b/src/FSLibrary/StellarNetworkCfg.fs
@@ -82,9 +82,6 @@ type NetworkCfg =
 
     member self.PeerCfgMapName (cs: CoreSet) (i: int) : string = sprintf "%s-cfg-map" (self.PodName cs i).StringName
 
-    member self.PeerDelayCfgMapName (cs: CoreSet) (i: int) : string =
-        sprintf "%s-delay-cfg-map" (self.PodName cs i).StringName
-
     member self.JobCfgMapName : string = sprintf "%s-job-cfg-map" self.Nonce
 
     member self.HistoryCfgMapName : string = sprintf "%s-history-cfg-map" self.Nonce

--- a/src/FSLibrary/StellarNetworkCfg.fs
+++ b/src/FSLibrary/StellarNetworkCfg.fs
@@ -82,9 +82,6 @@ type NetworkCfg =
 
     member self.PeerCfgMapName (cs: CoreSet) (i: int) : string = sprintf "%s-cfg-map" (self.PodName cs i).StringName
 
-    member self.PeerCfgMapStartupName (cs: CoreSet) (i: int) : string =
-        sprintf "%s-cfg-map-startup" (self.PodName cs i).StringName
-
     member self.PeerDelayCfgMapName (cs: CoreSet) (i: int) : string =
         sprintf "%s-delay-cfg-map" (self.PodName cs i).StringName
 

--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -276,8 +276,8 @@ let FullPubnetCoreSets (context: MissionContext) (manualclose: bool) : CoreSet l
                           nodeLocs = Some [ getGeoLocOrDefault n ]
                           preferredPeersMap = Some(keysToPreferredPeersMap keys) }
 
-                let shouldForceScp = not manualclose
-                let coreSetOpts = coreSetOpts.WithForceSCP shouldForceScp
+                let shouldWaitForConsensus = manualclose
+                let coreSetOpts = coreSetOpts.WithWaitForConsensus shouldWaitForConsensus
                 makeCoreSetWithExplicitKeys hdn coreSetOpts keys)
             miscNodes
 
@@ -297,8 +297,8 @@ let FullPubnetCoreSets (context: MissionContext) (manualclose: bool) : CoreSet l
                           nodeLocs = Some(List.map getGeoLocOrDefault nodeList)
                           preferredPeersMap = Some(keysToPreferredPeersMap keys) }
 
-                let shouldForceScp = not manualclose
-                let coreSetOpts = coreSetOpts.WithForceSCP shouldForceScp
+                let shouldWaitForConsensus = manualclose
+                let coreSetOpts = coreSetOpts.WithWaitForConsensus shouldWaitForConsensus
                 makeCoreSetWithExplicitKeys hdn coreSetOpts keys)
             groupedOrgNodes
 
@@ -343,7 +343,7 @@ let PubnetCoreSetOptions (image: string) =
           historyGetCommands = PubnetGetCommands
           peersDns = PubnetPeers
           accelerateTime = false
-          initialization = { CoreSetInitialization.Default with forceScp = false }
+          initialization = { CoreSetInitialization.Default with waitForConsensus = true }
           dumpDatabase = false }
 
 let TestnetGetCommands =
@@ -378,5 +378,5 @@ let TestnetCoreSetOptions (image: string) =
           historyGetCommands = TestnetGetCommands
           peersDns = TestnetPeers
           accelerateTime = false
-          initialization = { CoreSetInitialization.Default with forceScp = false }
+          initialization = { CoreSetInitialization.Default with waitForConsensus = true }
           dumpDatabase = false }


### PR DESCRIPTION
Bunch of self-contained and hopefully self-explanatory cleanups (some following previous PR, some noticed along the way). No functional change except we stop pointlessly calling `force-scp` and getting a deprecation warning.