### PR TITLE
Temporarily comment-out startup-probe and abnormal-event detection.

### DIFF
--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -117,9 +117,10 @@ type Tests(output: ITestOutputHelper) =
         Assert.Contains("OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING = [30, 70]", toml)
         Assert.Contains("HTTP_PORT = " + CfgVal.httpPort.ToString(), toml)
 
-        // Test init config
-        let initCfg = nCfg.StellarCoreCfg(coreSet, 1, InitCoreContainer)
-        Assert.Contains("HTTP_PORT = 0", initCfg.ToString())
+    // Test init config
+    // REVERTME: temporarily avoid looking for HTTP_PORT=0 on InitContainers
+    // let initCfg = nCfg.StellarCoreCfg(coreSet, 1, InitCoreContainer)
+    // Assert.Contains("HTTP_PORT = 0", initCfg.ToString())
 
     [<Fact>]
     member __.``Core init commands look reasonable``() =

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -161,8 +161,8 @@ type StellarCoreCfg =
         t.Add("DATABASE", self.database.ToString()) |> ignore
 
         match self.containerType with
-        | MainCoreContainer -> t.Add("HTTP_PORT", int64 (CfgVal.httpPort)) |> ignore
-        | InitCoreContainer -> t.Add("HTTP_PORT", 0) |> ignore
+        // REVERTME: temporarily use same nonzero port for both container types.
+        | _ -> t.Add("HTTP_PORT", int64 (CfgVal.httpPort)) |> ignore
 
         t.Add("PUBLIC_HTTP_PORT", true) |> ignore
         t.Add("BUCKET_DIR_PATH", CfgVal.bucketsPath) |> ignore

--- a/src/FSLibrary/StellarFormation.fs
+++ b/src/FSLibrary/StellarFormation.fs
@@ -300,7 +300,8 @@ type StellarFormation
 
             networkCfg.EachPeer
                 (fun p ->
-                    self.CheckNoAbnormalKubeEvents p
+                    // REVERTME: Temporarily disable abnormal-event checking
+                    // self.CheckNoAbnormalKubeEvents p
                     p.CheckNoErrorMetrics(includeTxInternalErrors = false)
                     p.CheckConsistencyWith peer)
 

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -289,7 +289,8 @@ let WithProbes (container: V1Container) (probeTimeout: int) : V1Container =
             httpGet = V1HTTPGetAction(path = "/info", port = httpPortStr)
         )
 
-    container.StartupProbe <- startupProbe
+    // REVERTME: Temporarily disable startup probes
+    // container.StartupProbe <- startupProbe
 
     container
 


### PR DESCRIPTION
These are not yet stable approaches to error detection in CI and we need CI to be stable presently.