### PR TITLE
Tail pod logs shortly after creation.

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -283,7 +283,7 @@ let main argv =
 
             let ctx =
                 { kube = kube
-                  destination = DefaultDestination
+                  destination = Destination("destination")
                   image = "stellar/stellar-core"
                   oldImage = None
                   netdelayImage = ""

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="StellarFormation.fs" />
     <Compile Include="StellarRemoteCommandExec.fs" />
     <Compile Include="StellarDataDump.fs" />
+    <Compile Include="StellarStatefulSets.fs" />
     <Compile Include="StellarJobExec.fs" />
     <Compile Include="StellarPerformanceReporter.fs" />
     <Compile Include="StellarSupercluster.fs" />

--- a/src/FSLibrary/MissionAcceptanceUnitTests.fs
+++ b/src/FSLibrary/MissionAcceptanceUnitTests.fs
@@ -23,5 +23,5 @@ let acceptanceUnitTests (context: MissionContext) =
         (Some(opts))
         None
         (fun formation ->
-            formation.RunSingleJob context.destination [| "test"; "[acceptance]~[.]" |] context.image false
+            formation.RunSingleJob [| "test"; "[acceptance]~[.]" |] context.image false
             |> formation.CheckAllJobsSucceeded)

--- a/src/FSLibrary/MissionBenchmarkBaseline.fs
+++ b/src/FSLibrary/MissionBenchmarkBaseline.fs
@@ -9,6 +9,7 @@ open StellarCoreSet
 open StellarMissionContext
 open StellarPerformanceReporter
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let benchmarkBaseline (context: MissionContext) =

--- a/src/FSLibrary/MissionBenchmarkConsensusOnly.fs
+++ b/src/FSLibrary/MissionBenchmarkConsensusOnly.fs
@@ -9,6 +9,7 @@ open StellarCoreSet
 open StellarMissionContext
 open StellarPerformanceReporter
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 

--- a/src/FSLibrary/MissionBenchmarkIncreaseTxRate.fs
+++ b/src/FSLibrary/MissionBenchmarkIncreaseTxRate.fs
@@ -9,6 +9,7 @@ open StellarCoreSet
 open StellarMissionContext
 open StellarPerformanceReporter
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 

--- a/src/FSLibrary/MissionBootAndSync.fs
+++ b/src/FSLibrary/MissionBootAndSync.fs
@@ -8,6 +8,7 @@ open StellarCoreSet
 open StellarMissionContext
 open StellarSupercluster
 open StellarFormation
+open StellarStatefulSets
 
 let bootAndSync (context: MissionContext) =
     let coreSet = MakeLiveCoreSet "core" (CoreSetOptions.GetDefault context.image)

--- a/src/FSLibrary/MissionCatchupHelpers.fs
+++ b/src/FSLibrary/MissionCatchupHelpers.fs
@@ -9,6 +9,7 @@ open StellarCorePeer
 open StellarCoreSet
 open StellarMissionContext
 open StellarFormation
+open StellarStatefulSets
 open Logging
 
 type CatchupMissionOptions = { generatorImage: string; catchupImage: string; versionImage: string }

--- a/src/FSLibrary/MissionComplexTopology.fs
+++ b/src/FSLibrary/MissionComplexTopology.fs
@@ -7,6 +7,7 @@ module MissionComplexTopology
 open StellarCoreSet
 open StellarMissionContext
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 open StellarCoreHTTP
 

--- a/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
+++ b/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
@@ -9,6 +9,7 @@ open StellarCorePeer
 open StellarCoreSet
 open StellarMissionContext
 open StellarFormation
+open StellarStatefulSets
 open StellarDataDump
 open StellarSupercluster
 

--- a/src/FSLibrary/MissionHistoryGenerateAndCatchup.fs
+++ b/src/FSLibrary/MissionHistoryGenerateAndCatchup.fs
@@ -9,6 +9,7 @@ open StellarCoreHTTP
 open StellarCorePeer
 open StellarMissionContext
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let historyGenerateAndCatchup (context: MissionContext) =

--- a/src/FSLibrary/MissionHistoryPubnetCompleteCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetCompleteCatchup.fs
@@ -9,6 +9,7 @@ open StellarMissionContext
 open StellarNetworkCfg
 open StellarNetworkData
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let historyPubnetCompleteCatchup (context: MissionContext) =

--- a/src/FSLibrary/MissionHistoryPubnetMinimumCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetMinimumCatchup.fs
@@ -9,6 +9,7 @@ open StellarMissionContext
 open StellarNetworkCfg
 open StellarNetworkData
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let historyPubnetMinimumCatchup (context: MissionContext) =

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
@@ -56,7 +56,6 @@ let historyPubnetParallelCatchup (context: MissionContext) =
         (fun (formation: StellarFormation) ->
             (formation.RunParallelJobs
                 parallelism
-                context.destination
                 (fun _ ->
                     (match jobQueue with
                      | [] -> None

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupExtrawide.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupExtrawide.fs
@@ -43,5 +43,5 @@ let historyPubnetParallelCatchupExtrawide (context: MissionContext) =
         (Some(opts))
         (Some(SDFMainNet))
         (fun (formation: StellarFormation) ->
-            (formation.RunParallelJobsInRandomOrder parallelism context.destination jobArr context.image)
+            (formation.RunParallelJobsInRandomOrder parallelism jobArr context.image)
             |> formation.CheckAllJobsSucceeded)

--- a/src/FSLibrary/MissionHistoryPubnetPerformance.fs
+++ b/src/FSLibrary/MissionHistoryPubnetPerformance.fs
@@ -26,7 +26,6 @@ let historyPubnetPerformance (context: MissionContext) =
         (fun (formation: StellarFormation) ->
 
             (formation.RunSingleJobWithTimeout
-                context.destination
                 (Some(TimeSpan.FromMinutes(10.0)))
                 [| "catchup"; "20000000/0" |]
                 context.image
@@ -34,7 +33,6 @@ let historyPubnetPerformance (context: MissionContext) =
             |> formation.CheckAllJobsSucceeded
 
             (formation.RunSingleJobWithTimeout
-                context.destination
                 (Some(TimeSpan.FromHours(4.0)))
                 [| "catchup"; "20050000/50000" |]
                 context.image

--- a/src/FSLibrary/MissionHistoryPubnetRecentCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetRecentCatchup.fs
@@ -9,6 +9,7 @@ open StellarMissionContext
 open StellarNetworkCfg
 open StellarNetworkData
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let historyPubnetRecentCatchup (context: MissionContext) =

--- a/src/FSLibrary/MissionHistoryTestnetCompleteCatchup.fs
+++ b/src/FSLibrary/MissionHistoryTestnetCompleteCatchup.fs
@@ -9,6 +9,7 @@ open StellarMissionContext
 open StellarNetworkCfg
 open StellarNetworkData
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let historyTestnetCompleteCatchup (context: MissionContext) =

--- a/src/FSLibrary/MissionHistoryTestnetMinimumCatchup.fs
+++ b/src/FSLibrary/MissionHistoryTestnetMinimumCatchup.fs
@@ -9,6 +9,7 @@ open StellarMissionContext
 open StellarNetworkCfg
 open StellarNetworkData
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let historyTestnetMinimumCatchup (context: MissionContext) =

--- a/src/FSLibrary/MissionHistoryTestnetParallelCatchup.fs
+++ b/src/FSLibrary/MissionHistoryTestnetParallelCatchup.fs
@@ -42,5 +42,5 @@ let historyTestnetParallelCatchup (context: MissionContext) =
         (Some(opts))
         (Some(SDFTestNet))
         (fun (formation: StellarFormation) ->
-            (formation.RunParallelJobsInRandomOrder parallelism context.destination jobArr context.image)
+            (formation.RunParallelJobsInRandomOrder parallelism jobArr context.image)
             |> formation.CheckAllJobsSucceeded)

--- a/src/FSLibrary/MissionHistoryTestnetPerformance.fs
+++ b/src/FSLibrary/MissionHistoryTestnetPerformance.fs
@@ -37,7 +37,6 @@ let historyTestnetPerformance (context: MissionContext) =
         (fun (formation: StellarFormation) ->
 
             (formation.RunSingleJobWithTimeout
-                context.destination
                 (Some(TimeSpan.FromMinutes(10.0)))
                 [| "catchup"; sprintf "%d/0" firstLedger |]
                 context.image
@@ -45,7 +44,6 @@ let historyTestnetPerformance (context: MissionContext) =
             |> formation.CheckAllJobsSucceeded
 
             (formation.RunSingleJobWithTimeout
-                context.destination
                 (Some(TimeSpan.FromHours(4.0)))
                 [| "catchup"; sprintf "%d/%d" secondLedger delta |]
                 context.image

--- a/src/FSLibrary/MissionHistoryTestnetRecentCatchup.fs
+++ b/src/FSLibrary/MissionHistoryTestnetRecentCatchup.fs
@@ -9,6 +9,7 @@ open StellarMissionContext
 open StellarNetworkCfg
 open StellarNetworkData
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let historyTestnetRecentCatchup (context: MissionContext) =

--- a/src/FSLibrary/MissionInMemoryMode.fs
+++ b/src/FSLibrary/MissionInMemoryMode.fs
@@ -8,6 +8,7 @@ open StellarCoreSet
 open StellarMissionContext
 open StellarFormation
 open StellarSupercluster
+open StellarStatefulSets
 open StellarCoreHTTP
 
 let runInMemoryMode (context: MissionContext) =

--- a/src/FSLibrary/MissionLoadGeneration.fs
+++ b/src/FSLibrary/MissionLoadGeneration.fs
@@ -7,6 +7,7 @@ module MissionLoadGeneration
 open StellarCoreSet
 open StellarMissionContext
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 open StellarCoreHTTP
 

--- a/src/FSLibrary/MissionLoadGenerationWithSpikes.fs
+++ b/src/FSLibrary/MissionLoadGenerationWithSpikes.fs
@@ -7,6 +7,7 @@ module MissionLoadGenerationWithSpikes
 open StellarCoreSet
 open StellarMissionContext
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 open StellarCoreHTTP
 

--- a/src/FSLibrary/MissionProtocolUpgradePubnet.fs
+++ b/src/FSLibrary/MissionProtocolUpgradePubnet.fs
@@ -11,6 +11,7 @@ open StellarMissionContext
 open StellarNetworkCfg
 open StellarNetworkData
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let protocolUpgradePubnet (context: MissionContext) =

--- a/src/FSLibrary/MissionProtocolUpgradeTestnet.fs
+++ b/src/FSLibrary/MissionProtocolUpgradeTestnet.fs
@@ -11,6 +11,7 @@ open StellarMissionContext
 open StellarNetworkCfg
 open StellarNetworkData
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 
 let protocolUpgradeTestnet (context: MissionContext) =

--- a/src/FSLibrary/MissionSimplePayment.fs
+++ b/src/FSLibrary/MissionSimplePayment.fs
@@ -9,6 +9,7 @@ open StellarMissionContext
 open StellarSupercluster
 open StellarTransaction
 open StellarFormation
+open StellarStatefulSets
 
 let simplePayment (context: MissionContext) =
     let coreSet = MakeLiveCoreSet "core" (CoreSetOptions.GetDefault context.image)

--- a/src/FSLibrary/MissionSimulatePubnet.fs
+++ b/src/FSLibrary/MissionSimulatePubnet.fs
@@ -10,6 +10,7 @@ module MissionSimulatePubnet
 open StellarCoreSet
 open StellarMissionContext
 open StellarFormation
+open StellarStatefulSets
 open StellarNetworkData
 open StellarSupercluster
 open StellarCoreHTTP

--- a/src/FSLibrary/MissionVersionMixConsensus.fs
+++ b/src/FSLibrary/MissionVersionMixConsensus.fs
@@ -10,6 +10,7 @@ open StellarCoreSet
 open StellarMissionContext
 open StellarTransaction
 open StellarFormation
+open StellarStatefulSets
 open StellarDataDump
 open StellarSupercluster
 

--- a/src/FSLibrary/MissionVersionNewCatchupToOld.fs
+++ b/src/FSLibrary/MissionVersionNewCatchupToOld.fs
@@ -7,6 +7,7 @@ module MissionVersionMixNewCatchupToOld
 open MissionCatchupHelpers
 open StellarMissionContext
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 open StellarCoreHTTP
 

--- a/src/FSLibrary/MissionVersionOldCatchupToNew.fs
+++ b/src/FSLibrary/MissionVersionOldCatchupToNew.fs
@@ -7,6 +7,7 @@ module MissionVersionMixOldCatchupToNew
 open MissionCatchupHelpers
 open StellarMissionContext
 open StellarFormation
+open StellarStatefulSets
 open StellarSupercluster
 open StellarCoreHTTP
 

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -19,7 +19,12 @@ module CfgVal =
     let labels = Map.ofSeq [ "app", "stellar-core" ]
     let labelSelector = "app = stellar-core"
     let stellarCoreBinPath = "stellar-core"
-    let stellarCoreContainerName (cmd: string) = "stellar-core-" + cmd
+    let allCoreContainerCmds = [| "new-hist"; "new-db"; "catchup"; "run" |]
+
+    let stellarCoreContainerName (cmd: string) =
+        assert (Array.contains cmd allCoreContainerCmds)
+        "stellar-core-" + cmd
+
     let dataVolumeName = "data-volume"
     let dataVolumePath = "/data"
     let databasePath = dataVolumePath + "/stellar.db"

--- a/src/FSLibrary/StellarDestination.fs
+++ b/src/FSLibrary/StellarDestination.fs
@@ -17,27 +17,31 @@ type Destination(path: string) =
         else
             Directory.CreateDirectory(path) |> ignore
 
-    member private self.GetExistingNsPath(ns: string) : string =
-        let fullPath = Path.Combine [| path; ns |]
-        Directory.CreateDirectory(fullPath) |> ignore
-        path
+    member public self.RemoveIfExists name =
+        let fullPath = Path.Combine [| path; name |]
 
-    member public self.WriteStream ns name (stream: Stream) =
-        let fullPath =
-            Path.Combine [| self.GetExistingNsPath ns
-                            name |]
+        if File.Exists fullPath then
+            LogInfo "Deleting %s" fullPath
+            File.Delete fullPath
 
+    member public self.WriteStream name (stream: Stream) =
+        let fullPath = Path.Combine [| path; name |]
         LogInfo "Copying data stream to %s" fullPath
         let fileStream = File.OpenWrite fullPath
         stream.CopyTo(fileStream)
         fileStream.Close()
 
-    member public self.WriteString (ns: string) (name: string) (content: string) : unit =
-        let fullPath =
-            Path.Combine [| self.GetExistingNsPath ns
-                            name |]
+    member public self.WriteStreamAsync name (stream: Stream) =
+        let fullPath = Path.Combine [| path; name |]
+        LogInfo "Asynchronously copying data stream to %s" fullPath
+        let fileStream = File.OpenWrite fullPath
 
+        async {
+            do! stream.CopyToAsync(fileStream) |> Async.AwaitTask
+            fileStream.Close()
+        }
+
+    member public self.WriteString (name: string) (content: string) : unit =
+        let fullPath = Path.Combine [| path; name |]
         LogInfo "Writing data to %s" fullPath
         File.WriteAllText(fullPath, content)
-
-let DefaultDestination = Destination(System.IO.Path.GetTempPath())

--- a/src/FSLibrary/StellarFormation.fs
+++ b/src/FSLibrary/StellarFormation.fs
@@ -52,6 +52,8 @@ type StellarFormation
     member self.sleepUntilNextRateLimitedApiCallTime() =
         ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (networkCfg.missionContext.apiRateLimit)
 
+    member self.Destination = self.NetworkCfg.missionContext.destination
+
     member self.NamespaceContent = namespaceContent
 
     member self.NextJobNum : int =
@@ -63,6 +65,8 @@ type StellarFormation
     member self.Kube = kube
     member self.NetworkCfg = networkCfg
     member self.SetNetworkCfg(n: NetworkCfg) = networkCfg <- n
+    member self.StatefulSets = statefulSets
+    member self.SetStatefulSets(s: V1StatefulSet list) = statefulSets <- s
 
     member self.CleanNamespace() =
         LogInfo "Cleaning all resources from namespace '%s'" networkCfg.NamespaceProperty
@@ -89,20 +93,6 @@ type StellarFormation
 
     member self.KeepData() = keepData <- true
 
-    // implementation of IDisposable
-    interface System.IDisposable with
-        member self.Dispose() =
-            self.Cleanup(true)
-            System.GC.SuppressFinalize(self)
-
-    // override of finalizer
-    override self.Finalize() = self.Cleanup(false)
-
-    override self.ToString() : string =
-        let name = networkCfg.ServiceName
-        let ns = networkCfg.NamespaceProperty
-        sprintf "%s/%s" ns name
-
     member self.GetEventsForObject(name: string) =
         let ns = self.NetworkCfg.NamespaceProperty
         let fs = sprintf "involvedObject.name=%s" name
@@ -120,170 +110,6 @@ type StellarFormation
                 && not <| ev.Message.Contains("Startup probe failed"))
             events
 
-    // Watches the provided StatefulSet until the count of ready replicas equals the
-    // count of configured replicas. This normally represents "successful startup".
-    member self.WaitForAllReplicasReady(ss: V1StatefulSet) =
-        let name = ss.Metadata.Name
-        let ns = ss.Metadata.NamespaceProperty
-        let mutable forbiddenEvent = None
-        use event = new System.Threading.ManualResetEventSlim(false)
-
-        // This pattern of a recursive handler-install routine that reinstalls
-        // itself when `onClosed` fires is necessary because watches
-        // automatically time out after 100 seconds and the connection closes.
-        let rec installHandler () =
-            LogInfo "Waiting for replicas on %s/%s" ns name
-
-            let handler (ety: WatchEventType) (ss: V1StatefulSet) =
-                LogInfo "Saw event for statefulset %s: %s" name (ety.ToString())
-
-                if not event.IsSet then
-                    // First we check to see if we've been woken up because a FailedCreate + forbidden
-                    // event occurred; this happens typically when we exceed quotas on a cluster or
-                    // some other policy reason.
-
-                    for ev in self.GetEventsForObject(name).Items do
-                        if ev.Reason = "FailedCreate" && ev.Message.Contains("forbidden") then
-                            // If so, we record the causal event and wake up the waiter.
-                            forbiddenEvent <- Some(ev)
-                            event.Set()
-                    // Assuming we weren't failed, we look to see how the sts is doing in terms
-                    // of creating the number of ready replicas we asked for.
-                    let n = ss.Status.ReadyReplicas.GetValueOrDefault(0)
-                    let k = ss.Spec.Replicas.GetValueOrDefault(0)
-                    LogInfo "StatefulSet %s/%s: %d/%d replicas ready" ns name n k
-                    if n = k then event.Set()
-
-            let action = System.Action<WatchEventType, V1StatefulSet>(handler)
-            let reinstall = System.Action(installHandler)
-
-            if not event.IsSet then
-                self.sleepUntilNextRateLimitedApiCallTime ()
-
-                kube.WatchNamespacedStatefulSetAsync(
-                    name = name,
-                    ``namespace`` = ns,
-                    onEvent = action,
-                    onClosed = reinstall
-                )
-                |> ignore
-
-        installHandler ()
-        event.Wait() |> ignore
-
-        match forbiddenEvent with
-        | None -> ()
-        | Some (ev) -> failwith (sprintf "Statefulset %s pod creation forbidden: %s" name ev.Message)
-
-        LogInfo "All replicas on %s/%s ready" ns name
-
-    // Watches the provided StatefulSet until the count of ready replicas equals the
-    // count of configured replicas. This normally represents "successful startup".
-    member self.WaitForAllReplicasOnAllSetsReady() =
-        if not statefulSets.IsEmpty then
-            LogInfo "Waiting for replicas on %s" (self.ToString())
-
-            for ss in statefulSets do
-                self.WaitForAllReplicasReady ss
-
-            LogInfo "All replicas on %s ready" (self.ToString())
-
-    member self.WithLive name (live: bool) =
-        networkCfg <- networkCfg.WithLive name live
-        let coreSet = networkCfg.FindCoreSet name
-        let stsName = networkCfg.StatefulSetName coreSet
-        self.sleepUntilNextRateLimitedApiCallTime ()
-
-        let ss =
-            kube.ReplaceNamespacedStatefulSet(
-                body = networkCfg.ToStatefulSet coreSet,
-                name = stsName.StringName,
-                namespaceParameter = networkCfg.NamespaceProperty
-            )
-
-        let newSets = statefulSets |> List.filter (fun x -> x.Metadata.Name <> stsName.StringName)
-        statefulSets <- ss :: newSets
-        self.WaitForAllReplicasReady ss
-
-    member self.Start name = self.WithLive name true
-
-    member self.Stop name = self.WithLive name false
-
-    member self.WaitUntilReady() = networkCfg.EachPeer(fun p -> p.WaitUntilReady())
-
-    member self.WaitUntilAllLiveSynced() = networkCfg.EachPeer(fun p -> p.WaitUntilSynced())
-
-    member self.WaitUntilSynced(coreSetList: CoreSet list) =
-        coreSetList
-        |> List.iter
-            (fun coreSet ->
-                if coreSet.CurrentCount = 0 then
-                    failwith ("Coreset " + coreSet.name.StringName + " is not live"))
-
-        networkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.WaitUntilSynced())
-
-    member self.WaitUntilConnected(coreSetList: CoreSet list) =
-        networkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.WaitUntilConnected)
-
-    member self.EnsureAllNodesInSync(coreSetList: CoreSet list) =
-        networkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.EnsureInSync)
-
-    member self.ManualClose(coreSetList: CoreSet list) =
-        networkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.ManualClose())
-
-    // When upgrading multiple nodes, configure upgrade time a bit ahead to ensure nodes have enough
-    // of a buffer to set upgrades
-    member self.UpgradeProtocol (coreSetList: CoreSet list) (version: int) =
-        let upgradeTime = System.DateTime.UtcNow.AddSeconds(15.0)
-        networkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.UpgradeProtocol version upgradeTime)
-        let peer = networkCfg.GetPeer coreSetList.[0] 0
-        peer.WaitForProtocol(version) |> ignore
-
-    member self.UpgradeProtocolToLatest(coreSetList: CoreSet list) =
-        let peer = networkCfg.GetPeer coreSetList.[0] 0
-        let latest = peer.GetSupportedProtocolVersion()
-        self.UpgradeProtocol coreSetList latest
-
-    member self.UpgradeMaxTxSize (coreSetList: CoreSet list) (maxTxSize: int) =
-        let upgradeTime = System.DateTime.UtcNow.AddSeconds(15.0)
-        networkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.UpgradeMaxTxSize maxTxSize upgradeTime)
-        let peer = networkCfg.GetPeer coreSetList.[0] 0
-        peer.WaitForMaxTxSetSize maxTxSize |> ignore
-
-    member self.ReportStatus() = ReportAllPeerStatus networkCfg
-
-    member self.CreateAccount (coreSet: CoreSet) (u: Username) =
-        let peer = networkCfg.GetPeer coreSet 0
-        let tx = peer.TxCreateAccount u
-        LogInfo "creating account for %O on %O" u self
-        peer.SubmitSignedTransaction tx |> ignore
-        peer.WaitForNextLedger() |> ignore
-        let acc = peer.GetAccount(u)
-
-        LogInfo
-            "created account for %O on %O with seq %d, balance %d"
-            u
-            self
-            acc.SequenceNumber
-            (peer.GetTestAccBalance(u.ToString()))
-
-    member self.Pay (coreSet: CoreSet) (src: Username) (dst: Username) =
-        let peer = networkCfg.GetPeer coreSet 0
-        let tx = peer.TxPayment src dst
-        let seq = peer.GetTestAccSeq(src.ToString())
-
-        LogInfo "paying from account %O to %O on %O" src dst self
-        peer.SubmitSignedTransaction tx |> ignore
-        peer.WaitForNextSeq(src.ToString()) seq |> ignore
-
-        LogInfo
-            "sent payment from %O (%O) to %O (%O) on %O"
-            src
-            (peer.GetSeqAndBalance src)
-            dst
-            (peer.GetSeqAndBalance dst)
-            self
-
     member self.CheckNoAbnormalKubeEvents(p: Peer) =
         let name = p.PodName.StringName
 
@@ -292,29 +118,16 @@ type StellarFormation
             LogError "Found abnormal event: %s" estr
             failwith estr
 
-    member self.CheckNoErrorsAndPairwiseConsistency() =
-        let cs = List.filter (fun cs -> cs.live = true) networkCfg.CoreSetList
+    // implementation of IDisposable
+    interface System.IDisposable with
+        member self.Dispose() =
+            self.Cleanup(true)
+            System.GC.SuppressFinalize(self)
 
-        if not (List.isEmpty cs) then
-            let peer = networkCfg.GetPeer cs.[0] 0
+    // override of finalizer
+    override self.Finalize() = self.Cleanup(false)
 
-            networkCfg.EachPeer
-                (fun p ->
-                    // REVERTME: Temporarily disable abnormal-event checking
-                    // self.CheckNoAbnormalKubeEvents p
-                    p.CheckNoErrorMetrics(includeTxInternalErrors = false)
-                    p.CheckConsistencyWith peer)
-
-    member self.CheckUsesLatestProtocolVersion() = networkCfg.EachPeer(fun p -> p.CheckUsesLatestProtocolVersion())
-
-    member self.RunLoadgen (coreSet: CoreSet) (loadGen: LoadGen) =
-        let peer = networkCfg.GetPeer coreSet 0
-        LogInfo "Loadgen: %s" (peer.GenerateLoad loadGen)
-        peer.WaitForLoadGenComplete loadGen
-
-    member self.RunLoadgenAndCheckNoErrors(coreSet: CoreSet) =
-        let peer = networkCfg.GetPeer coreSet 0
-        let loadGen = { DefaultAccountCreationLoadGen with accounts = 10000 }
-        LogInfo "Loadgen: %s" (peer.GenerateLoad loadGen)
-        peer.WaitForLoadGenComplete loadGen
-        self.CheckNoErrorsAndPairwiseConsistency()
+    override self.ToString() : string =
+        let name = networkCfg.ServiceName
+        let ns = networkCfg.NamespaceProperty
+        sprintf "%s/%s" ns name

--- a/src/FSLibrary/StellarPerformanceReporter.fs
+++ b/src/FSLibrary/StellarPerformanceReporter.fs
@@ -142,13 +142,16 @@ type PerformanceReporter(networkCfg: NetworkCfg) =
                 let newPeerData = List.append data.[p.PodName] [ metrics ]
                 data <- Map.add p.PodName newPeerData data)
 
-    member self.DumpPerformanceMetrics(destination: Destination) =
-        let dumpPeerPerformanceMetrics (destination: Destination) ns (p: Peer) =
+    member self.DumpPerformanceMetrics() =
+        let destination = networkCfg.missionContext.destination
+        let ns = networkCfg.NamespaceProperty
+
+        let dumpPeerPerformanceMetrics (p: Peer) =
             let toCsvRow (x: PerformanceRow) = x.ToCsvRow()
             let name = p.PodName
 
             if data.ContainsKey name then
                 let csv = new PerformanceCsv(data.[name] |> (Seq.map toCsvRow) |> Seq.toList)
-                destination.WriteString ns (sprintf "%s.perf" name.StringName) (csv.SaveToString('\t'))
+                destination.WriteString(sprintf "%s.perf" name.StringName) (csv.SaveToString('\t'))
 
-        networkCfg.EachPeer(dumpPeerPerformanceMetrics destination networkCfg.NamespaceProperty)
+        networkCfg.EachPeer(dumpPeerPerformanceMetrics)

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -1,4 +1,4 @@
-// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -1,0 +1,218 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+module StellarStatefulSets
+
+open k8s
+open k8s.Models
+open Logging
+open StellarFormation
+open StellarDataDump
+open StellarCoreSet
+open StellarKubeSpecs
+open StellarCorePeer
+open StellarCoreHTTP
+open StellarTransaction
+open System
+
+type StellarFormation with
+
+    member self.GetCoreSetForStatefulSet(ss: V1StatefulSet) =
+        List.find (fun cs -> (self.NetworkCfg.StatefulSetName cs).StringName = ss.Name()) self.NetworkCfg.CoreSetList
+
+    // Watches the provided StatefulSet until the count of ready replicas equals the
+    // count of configured replicas. This normally represents "successful startup".
+    member self.WaitForAllReplicasReady(ss: V1StatefulSet) =
+        let name = ss.Metadata.Name
+        let ns = ss.Metadata.NamespaceProperty
+        let mutable forbiddenEvent = None
+        use event = new System.Threading.ManualResetEventSlim(false)
+
+        // This pattern of a recursive handler-install routine that reinstalls
+        // itself when `onClosed` fires is necessary because watches
+        // automatically time out after 100 seconds and the connection closes.
+        let rec installHandler () =
+            LogInfo "Waiting for replicas on %s/%s" ns name
+
+            let handler (ety: WatchEventType) (ss: V1StatefulSet) =
+                LogInfo "Saw event for statefulset %s: %s" name (ety.ToString())
+
+                if not event.IsSet then
+                    // First we check to see if we've been woken up because a FailedCreate + forbidden
+                    // event occurred; this happens typically when we exceed quotas on a cluster or
+                    // some other policy reason.
+
+                    for ev in self.GetEventsForObject(name).Items do
+                        if ev.Reason = "FailedCreate" && ev.Message.Contains("forbidden") then
+                            // If so, we record the causal event and wake up the waiter.
+                            forbiddenEvent <- Some(ev)
+                            event.Set()
+                    // Assuming we weren't failed, we look to see how the sts is doing in terms
+                    // of creating the number of ready replicas we asked for.
+                    let n = ss.Status.ReadyReplicas.GetValueOrDefault(0)
+                    let k = ss.Spec.Replicas.GetValueOrDefault(0)
+                    LogInfo "StatefulSet %s/%s: %d/%d replicas ready" ns name n k
+                    if n = k then event.Set()
+
+            let action = System.Action<WatchEventType, V1StatefulSet>(handler)
+            let reinstall = System.Action(installHandler)
+
+            if not event.IsSet then
+                self.sleepUntilNextRateLimitedApiCallTime ()
+
+                self.Kube.WatchNamespacedStatefulSetAsync(
+                    name = name,
+                    ``namespace`` = ns,
+                    onEvent = action,
+                    onClosed = reinstall
+                )
+                |> ignore
+
+        installHandler ()
+        event.Wait() |> ignore
+
+        match forbiddenEvent with
+        | None -> ()
+        | Some (ev) -> failwith (sprintf "Statefulset %s pod creation forbidden: %s" name ev.Message)
+
+        self.LaunchLogTailingTasksForCoreSet(self.GetCoreSetForStatefulSet ss)
+
+        LogInfo "All replicas on %s/%s ready" ns name
+
+    // Watches the provided StatefulSet until the count of ready replicas equals the
+    // count of configured replicas. This normally represents "successful startup".
+    member self.WaitForAllReplicasOnAllSetsReady() =
+        if not self.StatefulSets.IsEmpty then
+            LogInfo "Waiting for replicas on %s" (self.ToString())
+
+            for ss in self.StatefulSets do
+                self.WaitForAllReplicasReady ss
+
+            LogInfo "All replicas on %s ready" (self.ToString())
+
+    member self.WithLive name (live: bool) =
+        self.SetNetworkCfg(self.NetworkCfg.WithLive name live)
+        let coreSet = self.NetworkCfg.FindCoreSet name
+        let stsName = self.NetworkCfg.StatefulSetName coreSet
+        self.sleepUntilNextRateLimitedApiCallTime ()
+
+        let ss =
+            self.Kube.ReplaceNamespacedStatefulSet(
+                body = self.NetworkCfg.ToStatefulSet coreSet,
+                name = stsName.StringName,
+                namespaceParameter = self.NetworkCfg.NamespaceProperty
+            )
+
+        let newSets =
+            self.StatefulSets
+            |> List.filter (fun x -> x.Metadata.Name <> stsName.StringName)
+
+        self.SetStatefulSets(ss :: newSets)
+        self.WaitForAllReplicasReady ss
+
+    member self.Start name = self.WithLive name true
+
+    member self.Stop name = self.WithLive name false
+
+    member self.WaitUntilReady() = self.NetworkCfg.EachPeer(fun p -> p.WaitUntilReady())
+
+    member self.WaitUntilAllLiveSynced() = self.NetworkCfg.EachPeer(fun p -> p.WaitUntilSynced())
+
+    member self.WaitUntilSynced(coreSetList: CoreSet list) =
+        coreSetList
+        |> List.iter
+            (fun coreSet ->
+                if coreSet.CurrentCount = 0 then
+                    failwith ("Coreset " + coreSet.name.StringName + " is not live"))
+
+        self.NetworkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.WaitUntilSynced())
+
+    member self.WaitUntilConnected(coreSetList: CoreSet list) =
+        self.NetworkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.WaitUntilConnected)
+
+    member self.EnsureAllNodesInSync(coreSetList: CoreSet list) =
+        self.NetworkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.EnsureInSync)
+
+    member self.ManualClose(coreSetList: CoreSet list) =
+        self.NetworkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.ManualClose())
+
+    // When upgrading multiple nodes, configure upgrade time a bit ahead to ensure nodes have enough
+    // of a buffer to set upgrades
+    member self.UpgradeProtocol (coreSetList: CoreSet list) (version: int) =
+        let upgradeTime = System.DateTime.UtcNow.AddSeconds(15.0)
+        self.NetworkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.UpgradeProtocol version upgradeTime)
+        let peer = self.NetworkCfg.GetPeer coreSetList.[0] 0
+        peer.WaitForProtocol(version) |> ignore
+
+    member self.UpgradeProtocolToLatest(coreSetList: CoreSet list) =
+        let peer = self.NetworkCfg.GetPeer coreSetList.[0] 0
+        let latest = peer.GetSupportedProtocolVersion()
+        self.UpgradeProtocol coreSetList latest
+
+    member self.UpgradeMaxTxSize (coreSetList: CoreSet list) (maxTxSize: int) =
+        let upgradeTime = System.DateTime.UtcNow.AddSeconds(15.0)
+        self.NetworkCfg.EachPeerInSets(coreSetList |> Array.ofList) (fun p -> p.UpgradeMaxTxSize maxTxSize upgradeTime)
+        let peer = self.NetworkCfg.GetPeer coreSetList.[0] 0
+        peer.WaitForMaxTxSetSize maxTxSize |> ignore
+
+    member self.ReportStatus() = ReportAllPeerStatus self.NetworkCfg
+
+    member self.CreateAccount (coreSet: CoreSet) (u: Username) =
+        let peer = self.NetworkCfg.GetPeer coreSet 0
+        let tx = peer.TxCreateAccount u
+        LogInfo "creating account for %O on %O" u self
+        peer.SubmitSignedTransaction tx |> ignore
+        peer.WaitForNextLedger() |> ignore
+        let acc = peer.GetAccount(u)
+
+        LogInfo
+            "created account for %O on %O with seq %d, balance %d"
+            u
+            self
+            acc.SequenceNumber
+            (peer.GetTestAccBalance(u.ToString()))
+
+    member self.Pay (coreSet: CoreSet) (src: Username) (dst: Username) =
+        let peer = self.NetworkCfg.GetPeer coreSet 0
+        let tx = peer.TxPayment src dst
+        let seq = peer.GetTestAccSeq(src.ToString())
+
+        LogInfo "paying from account %O to %O on %O" src dst self
+        peer.SubmitSignedTransaction tx |> ignore
+        peer.WaitForNextSeq(src.ToString()) seq |> ignore
+
+        LogInfo
+            "sent payment from %O (%O) to %O (%O) on %O"
+            src
+            (peer.GetSeqAndBalance src)
+            dst
+            (peer.GetSeqAndBalance dst)
+            self
+
+    member self.CheckNoErrorsAndPairwiseConsistency() =
+        let cs = List.filter (fun cs -> cs.live = true) self.NetworkCfg.CoreSetList
+
+        if not (List.isEmpty cs) then
+            let peer = self.NetworkCfg.GetPeer cs.[0] 0
+
+            self.NetworkCfg.EachPeer
+                (fun p ->
+                    // REVERTME: Temporarily disable abnormal-event checking
+                    // self.CheckNoAbnormalKubeEvents p
+                    p.CheckNoErrorMetrics(includeTxInternalErrors = false)
+                    p.CheckConsistencyWith peer)
+
+    member self.CheckUsesLatestProtocolVersion() = self.NetworkCfg.EachPeer(fun p -> p.CheckUsesLatestProtocolVersion())
+
+    member self.RunLoadgen (coreSet: CoreSet) (loadGen: LoadGen) =
+        let peer = self.NetworkCfg.GetPeer coreSet 0
+        LogInfo "Loadgen: %s" (peer.GenerateLoad loadGen)
+        peer.WaitForLoadGenComplete loadGen
+
+    member self.RunLoadgenAndCheckNoErrors(coreSet: CoreSet) =
+        let peer = self.NetworkCfg.GetPeer coreSet 0
+        let loadGen = { DefaultAccountCreationLoadGen with accounts = 10000 }
+        LogInfo "Loadgen: %s" (peer.GenerateLoad loadGen)
+        peer.WaitForLoadGenComplete loadGen
+        self.CheckNoErrorsAndPairwiseConsistency()

--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -13,6 +13,7 @@ open StellarDataDump
 open StellarMissionContext
 open StellarNetworkCfg
 open StellarFormation
+open StellarStatefulSets
 open StellarCoreSet
 open StellarKubeSpecs
 open StellarNamespaceContent
@@ -212,7 +213,8 @@ type MissionContext with
 
     member self.MakeFormation (coreSetList: CoreSet list) (passphrase: NetworkPassphrase option) : StellarFormation =
         let networkCfg = MakeNetworkCfg self coreSetList passphrase
-        self.kube.MakeFormation networkCfg
+        let formation = self.kube.MakeFormation networkCfg
+        formation
 
     member self.MakeFormationForJob
         (opts: CoreSetOptions option)
@@ -233,7 +235,7 @@ type MissionContext with
             try
                 run formation
             finally
-                formation.DumpJobData self.destination
+                formation.DumpJobData()
         with x ->
             (if self.keepData then formation.KeepData()
              reraise ())
@@ -251,7 +253,7 @@ type MissionContext with
                 run formation
                 formation.CheckNoErrorsAndPairwiseConsistency()
             finally
-                formation.DumpData self.destination
+                formation.DumpData()
         with x ->
             (if self.keepData then formation.KeepData()
              reraise ())
@@ -270,8 +272,8 @@ type MissionContext with
                 run formation performanceReporter
                 formation.CheckNoErrorsAndPairwiseConsistency()
             finally
-                performanceReporter.DumpPerformanceMetrics self.destination
-                formation.DumpData self.destination
+                performanceReporter.DumpPerformanceMetrics()
+                formation.DumpData()
         with x ->
             (if self.keepData then formation.KeepData()
              reraise ())


### PR DESCRIPTION
The main point of this change is to record logs asynchronously from pods once the pods are active (into a "<pod>-tail.log" file written incrementally). We still do a full log extraction (and previous-container log extraction) at the end of the run, which I think we should probably keep doing in case there is a pod restart (this code doesn't trap restarts, and I expect it will stop tailing correctly in such a case). If we get as far as doing the final extraction, we also delete the tail log so there is less redundancy, though I could be talked into keeping both "just in case" some container execution shows up in one and not the other.

Anyway, to achieve this I had to make 2 big disruptive changes:
  - Move a big chunk of code from StellarFormation.fs into a new file StellarStatefulSets.fs because of F# acyclic module depdendncy rules
  - Add `open StellarStatefulSets` to every mission that uses the methods in that code

While I was working, I also did a bit of cleanup:
  - removed some annoying redundant plumbing-around of `destination`
  - removed some not-actually-used namespace-prefixing of files in destination
  - consolidated the list of core commands into a single place

As a result, the PR is bigger and messier than I'd have liked, and if it's too hard to review I can try splitting it up and redoing it, but .. it is 7pm on a Friday and I'm a bit tired, and I think it's possible that a reviewer might tolerate its messiness armed with the explanation of the combined set of changes explained here. Let me know!