### PR TITLE
Add the option to scale the pubnet in `SimulatePubnet`

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -71,6 +71,9 @@ type MissionOptions
         simulateApplyDuration: seq<string>,
         simulateApplyWeight: seq<string>,
         networkSizeLimit: int,
+        tier1OrgsToAdd: int,
+        nonTier1NodesToAdd: int,
+        randomSeed: int,
         pubnetParallelCatchupStartingLedger: int
     ) =
 
@@ -238,6 +241,19 @@ type MissionOptions
              Required = false)>]
     member self.SimulateApplyWeight = simulateApplyWeight
 
+    [<Option("tier-1-orgs-to-add",
+             HelpText = "The number of tier-1 organizations to add while scaling the network in SimulatePubnet",
+             Required = false)>]
+    member self.Tier1OrgsToAdd = tier1OrgsToAdd
+
+    [<Option("non-tier-1-nodes-to-add",
+             HelpText = "The number of non-tier-1 nodes to add while scaling the network in SimulatePubnet",
+             Required = false)>]
+    member self.NonTier1NodesToAdd = nonTier1NodesToAdd
+
+    [<Option("random-seed", HelpText = "The seed used for a random number generator.", Required = false)>]
+    member self.RandomSeed = randomSeed
+
     [<Option("network-size-limit",
              HelpText = "The number of nodes to run in SimulatePubnet",
              Required = false,
@@ -321,6 +337,9 @@ let main argv =
                   installNetworkDelay = None
                   simulateApplyDuration = None
                   simulateApplyWeight = None
+                  tier1OrgsToAdd = 0
+                  nonTier1NodesToAdd = 0
+                  randomSeed = 0
                   networkSizeLimit = 0
                   pubnetParallelCatchupStartingLedger = 0 }
 
@@ -403,7 +422,10 @@ let main argv =
                                installNetworkDelay = mission.InstallNetworkDelay
                                simulateApplyDuration = processInputSeq mission.SimulateApplyDuration
                                simulateApplyWeight = processInputSeq mission.SimulateApplyWeight
+                               tier1OrgsToAdd = mission.Tier1OrgsToAdd
+                               nonTier1NodesToAdd = mission.NonTier1NodesToAdd
                                networkSizeLimit = mission.NetworkSizeLimit
+                               randomSeed = mission.RandomSeed
                                pubnetParallelCatchupStartingLedger = mission.PubnetParallelCatchupStartingLedger }
 
                          allMissions.[m] missionContext

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -80,6 +80,9 @@ let ctx : MissionContext =
               + "/../FSLibrary/csv-type-samples/sample-loadgen-op-count-distribution.csv"
           )
       networkSizeLimit = 100
+      tier1OrgsToAdd = 0
+      nonTier1NodesToAdd = 0
+      randomSeed = 0
       pubnetParallelCatchupStartingLedger = 0 }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2021-01-05.json"

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -56,5 +56,8 @@ type MissionContext =
       installNetworkDelay: bool option
       simulateApplyDuration: seq<int> option
       simulateApplyWeight: seq<int> option
+      tier1OrgsToAdd: int
+      nonTier1NodesToAdd: int
+      randomSeed: int
       networkSizeLimit: int
       pubnetParallelCatchupStartingLedger: int }

--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -352,18 +352,12 @@ let FullPubnetCoreSets (context: MissionContext) (manualclose: bool) : CoreSet l
     // If the given node has geolocation info, use it.
     // Otherwise, pseudo-randomly select one from the list of geolocations that we are aware of.
     // As mentioned above, this assignment is weighted. (i.e., A common geolocation is more likely to be selected.)
-    // Since the assignment depends on the pubnet public key,
+    // Since the assignment depends on the Random object with a fixed seed,
     // this assignment is persistent across different runs.
     let getGeoLocOrDefault (n: PubnetNode.Root) : GeoLoc =
         match n.SbGeoData with
         | Some geoData -> { lat = float geoData.Latitude; lon = float geoData.Longitude }
-        | None ->
-            let len = Array.length geoLocations
-            // A deterministic, fairly elementary hashing function that adds the ASCII code
-            // of each character.
-            // All we need is a deterministic, mostly randomized mapping.
-            let h = n.PublicKey |> Seq.sumBy int
-            geoLocations.[h % len]
+        | None -> geoLocations.[random.Next(0, Array.length geoLocations)]
 
     let makeCoreSetWithExplicitKeys (hdn: HomeDomainName) (options: CoreSetOptions) (keys: KeyPair array) =
         { name = CoreSetName(hdn.StringName)


### PR DESCRIPTION
This PR contains changes that allow users to scale the quorums and topology of the pubnet in a "reasonable" way to test a larger network than the network data they have.

More specifically, a user of this program may use the new flags `tier1NodesToAdd` and `nonTier1NodesToAdd` to specify the number of tier1 and non-tier1 nodes that they would like to add to the existing network, and `StellarNetworkData.fs` will add new nodes and connect them in a realistic way to allow simulations of large networks without having to create large networks manually. Furthermore, the code creates a full-tier1 quorum set containing all the existing tier-1 nodes and the new tier-1 nodes, and make each node use that.

The scaling is done pseudo-randomly, and the user may specify the random seed by the `random-seed` flag. The same seed will lead to the exact same network.