### PR TITLE
Support both "key" and "key:value" forms for both labels and taints

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -263,10 +263,11 @@ type MissionOptions
     member self.PubnetParallelCatchupStartingLedger = pubnetParallelCatchupStartingLedger
 
 
-let splitLabel (lab: string) : (string * string) =
+let splitLabel (lab: string) : (string * string option) =
     match lab.Split ':' with
-    | [| a; b |] -> (a, b)
-    | _ -> failwith ("unexpected label '" + lab + "', need string of form 'key:value'")
+    | [| x |] -> (x, None)
+    | [| a; b |] -> (a, Some b)
+    | _ -> failwith ("unexpected label '" + lab + "', need string of form 'key' or 'key:value'")
 
 [<EntryPoint>]
 let main argv =
@@ -417,7 +418,7 @@ let main argv =
                                unevenSched = mission.UnevenSched
                                requireNodeLabels = List.map splitLabel (List.ofSeq mission.RequireNodeLabels)
                                avoidNodeLabels = List.map splitLabel (List.ofSeq mission.AvoidNodeLabels)
-                               tolerateNodeTaints = List.ofSeq mission.TolerateNodeTaints
+                               tolerateNodeTaints = List.map splitLabel (List.ofSeq mission.TolerateNodeTaints)
                                apiRateLimit = mission.ApiRateLimit
                                pubnetData = mission.PubnetData
                                tier1Keys = mission.Tier1Keys

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -49,9 +49,9 @@ type MissionContext =
       coreResources: CoreResources
       keepData: bool
       unevenSched: bool
-      requireNodeLabels: ((string * string) list)
-      avoidNodeLabels: ((string * string) list)
-      tolerateNodeTaints: string list
+      requireNodeLabels: ((string * string option) list)
+      avoidNodeLabels: ((string * string option) list)
+      tolerateNodeTaints: ((string * string option) list)
       apiRateLimit: int
       pubnetData: string option
       tier1Keys: string option


### PR DESCRIPTION
Previously supercluster supported a sort of mixed set of options around taints and labels:

  - `--avoid-node-labels` and `--require-node-labels` supported arguments of the form `key:value` only, not just `key`
  - `--tolerate-node-taint` supported arguments of the form `key` only, not `key:value`

There is a meaningful interpretation for both forms of both arguments (key-existence or non-existence in the plain `key` form; key-value equality or inequality in the `key:value` form). So this PR extends both argument paths to support both forms.

The most important part of this change is bug-avoidance: previously if you specified `--tolerate-node-taint=key:value` you would get an extremely unexpected and bad behaviour where supercluster would set a pod's taint tolerance to the existence of a key named `key:value` (that is, it did not split such pairs at all, just passed them through as key-names). This is not what anyone would want or expect ever, and is no longer possible.