### PR TITLE
Add in-memory option for pubnet parallel catchup

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -77,7 +77,8 @@ type MissionOptions
         tier1OrgsToAdd: int,
         nonTier1NodesToAdd: int,
         randomSeed: int,
-        pubnetParallelCatchupStartingLedger: int
+        pubnetParallelCatchupStartingLedger: int,
+        inMemoryParallelCatchup: bool
     ) =
 
     [<Option('k', "kubeconfig", HelpText = "Kubernetes config file", Required = false, Default = "~/.kube/config")>]
@@ -278,6 +279,12 @@ type MissionOptions
              Default = 0)>]
     member self.PubnetParallelCatchupStartingLedger = pubnetParallelCatchupStartingLedger
 
+    [<Option("in-memory-parallel-catchup",
+             HelpText = "parallel catchup with captive core",
+             Required = false,
+             Default = false)>]
+    member self.InMemoryParallelCatchup = inMemoryParallelCatchup
+
 
 let splitLabel (lab: string) : (string * string option) =
     match lab.Split ':' with
@@ -361,7 +368,8 @@ let main argv =
                   nonTier1NodesToAdd = 0
                   randomSeed = 0
                   networkSizeLimit = 0
-                  pubnetParallelCatchupStartingLedger = 0 }
+                  pubnetParallelCatchupStartingLedger = 0
+                  inMemoryParallelCatchup = false }
 
             let nCfg = MakeNetworkCfg ctx [] None
             use formation = kube.MakeEmptyFormation nCfg
@@ -449,7 +457,8 @@ let main argv =
                                nonTier1NodesToAdd = mission.NonTier1NodesToAdd
                                networkSizeLimit = mission.NetworkSizeLimit
                                randomSeed = mission.RandomSeed
-                               pubnetParallelCatchupStartingLedger = mission.PubnetParallelCatchupStartingLedger }
+                               pubnetParallelCatchupStartingLedger = mission.PubnetParallelCatchupStartingLedger
+                               inMemoryParallelCatchup = mission.InMemoryParallelCatchup }
 
                          allMissions.[m] missionContext
 

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -86,7 +86,8 @@ let ctx : MissionContext =
       tier1OrgsToAdd = 0
       nonTier1NodesToAdd = 0
       randomSeed = 0
-      pubnetParallelCatchupStartingLedger = 0 }
+      pubnetParallelCatchupStartingLedger = 0
+      inMemoryParallelCatchup = false }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2021-01-05.json"
 let pubkeys = __SOURCE_DIRECTORY__ + "/../../../data/tier1keys.json"
@@ -394,7 +395,7 @@ type Tests(output: ITestOutputHelper) =
     member __.``Parallel catchup ranges are reasonable``() =
 
         // startingLedger = 0
-        let jobArr1 = getCatchupRanges 5 0 19 1
+        let jobArr1 = getCatchupRanges 5 0 19 1 false
         Assert.Equal(4, jobArr1.Length)
         Assert.Equal("4/6", jobArr1.[0].[1])
         Assert.Equal("9/6", jobArr1.[1].[1])
@@ -403,13 +404,13 @@ type Tests(output: ITestOutputHelper) =
 
         // next range would end at startingLedger(50), but it's
         // already contained in the previously calculated range (56/8)
-        let jobArr2 = getCatchupRanges 6 50 62 2
+        let jobArr2 = getCatchupRanges 6 50 62 2 false
         Assert.Equal(2, jobArr2.Length)
         Assert.Equal("56/8", jobArr2.[0].[1])
         Assert.Equal("62/8", jobArr2.[1].[1])
 
 
-        let jobArr3 = getCatchupRanges 5 50 61 1
+        let jobArr3 = getCatchupRanges 5 50 61 1 false
         Assert.Equal(3, jobArr3.Length)
         Assert.Equal("51/6", jobArr3.[0].[1])
         Assert.Equal("56/6", jobArr3.[1].[1])

--- a/src/FSLibrary/MissionCatchupHelpers.fs
+++ b/src/FSLibrary/MissionCatchupHelpers.fs
@@ -171,7 +171,13 @@ let doCatchup (context: MissionContext) (formation: StellarFormation) (catchupSe
     doCatchupForVersion context formation catchupSets version
 
 
-let getCatchupRanges (ledgersPerJob: int) (startingLedger: int) (latestLedgerNum: int) (overlapLedgers: int) =
+let getCatchupRanges
+    (ledgersPerJob: int)
+    (startingLedger: int)
+    (latestLedgerNum: int)
+    (overlapLedgers: int)
+    (inMemory: bool)
+    =
     // we require some overlap
     assert (overlapLedgers > 0)
 
@@ -180,7 +186,14 @@ let getCatchupRanges (ledgersPerJob: int) (startingLedger: int) (latestLedgerNum
 
     while endRange > startingLedger do
         let range = sprintf "%d/%d" (endRange) (ledgersPerJob + overlapLedgers)
-        ranges <- Array.append [| [| "catchup"; range |] |] ranges
+
+        let cmd =
+            if inMemory then
+                [| "catchup"; range; "--in-memory" |]
+            else
+                [| "catchup"; range |]
+
+        ranges <- Array.append [| cmd |] ranges
         endRange <- endRange - ledgersPerJob
 
     ranges

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
@@ -28,7 +28,7 @@ let historyPubnetParallelCatchup (context: MissionContext) =
     let latestLedgerNum = GetLatestPubnetLedgerNumber()
     let ledgersPerJob = checkpointsPerJob * ledgersPerCheckpoint
     let startingLedger = max context.pubnetParallelCatchupStartingLedger 0
-    let parallelism = if context.inMemoryParallelCatchup then 60 else 128
+    let parallelism = if context.inMemoryParallelCatchup then 48 else 128
     let overlapCheckpoints = 5
     let overlapLedgers = overlapCheckpoints * ledgersPerCheckpoint
 

--- a/src/FSLibrary/MissionHistoryTestnetParallelCatchup.fs
+++ b/src/FSLibrary/MissionHistoryTestnetParallelCatchup.fs
@@ -23,7 +23,7 @@ let historyTestnetParallelCatchup (context: MissionContext) =
     let overlapCheckpoints = 5
     let overlapLedgers = overlapCheckpoints * ledgersPerCheckpoint
 
-    let jobArr = getCatchupRanges ledgersPerJob 0 totalLedgers overlapLedgers
+    let jobArr = getCatchupRanges ledgersPerJob 0 totalLedgers overlapLedgers false
 
     LogInfo
         "Running %d jobs (%d-way parallel) of %d checkpoints each, to catch up to ledger %d"

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -105,6 +105,11 @@ let SimulatePubnetCoreResourceRequirements : V1ResourceRequirements =
     // 0.025vCPU request and 0.5vCPU limit to each.
     makeResourceRequirements 25 64 500 400
 
+let InMemoryParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
+    // When doing in memory parallel catchup, we give each container
+    // 256MB RAM and 0.1 vCPUs, bursting to 1vCPU and 14GB
+    makeResourceRequirements 100 256 1000 14000
+
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
     // 256MB RAM and 0.1 vCPUs, bursting to 1vCPU and 600MB
@@ -253,6 +258,7 @@ let CoreContainerForCommand
         | SmallTestResources -> SmallTestCoreResourceRequirements
         | AcceptanceTestResources -> AcceptanceTestCoreResourceRequirements
         | SimulatePubnetResources -> SimulatePubnetCoreResourceRequirements
+        | InMemoryParallelCatchupResources -> InMemoryParallelCatchupCoreResourceRequirements
         | ParallelCatchupResources -> ParallelCatchupCoreResourceRequirements
         | NonParallelCatchupResources -> NonParallelCatchupCoreResourceRequirements
         | UpgradeResources -> UpgradeCoreResourceRequirements

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -107,8 +107,8 @@ let SimulatePubnetCoreResourceRequirements : V1ResourceRequirements =
 
 let InMemoryParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing in memory parallel catchup, we give each container
-    // 256MB RAM and 0.1 vCPUs, bursting to 1vCPU and 14GB
-    makeResourceRequirements 100 256 1000 14000
+    // 256MB RAM and 0.1 vCPUs, bursting to 1vCPU and 21GB
+    makeResourceRequirements 100 256 1000 21000
 
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
@@ -565,7 +565,7 @@ type NetworkCfg with
         let jobCfgVol =
             V1Volume(name = CfgVal.jobCfgVolumeName, configMap = V1ConfigMapVolumeSource(name = self.JobCfgMapName))
 
-        let dataVol = V1Volume(name = CfgVal.dataVolumeName, emptyDir = V1EmptyDirVolumeSource())
+        let dataVol = V1Volume(name = CfgVal.dataVolumeName, emptyDir = V1EmptyDirVolumeSource(medium = "Memory"))
 
         let res = self.missionContext.coreResources
 

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -18,6 +18,7 @@ type CoreResources =
     | SmallTestResources
     | AcceptanceTestResources
     | SimulatePubnetResources
+    | InMemoryParallelCatchupResources
     | ParallelCatchupResources
     | NonParallelCatchupResources
     | UpgradeResources
@@ -63,4 +64,5 @@ type MissionContext =
       nonTier1NodesToAdd: int
       randomSeed: int
       networkSizeLimit: int
-      pubnetParallelCatchupStartingLedger: int }
+      pubnetParallelCatchupStartingLedger: int
+      inMemoryParallelCatchup: bool }


### PR DESCRIPTION
This will allow us to test parallel catchup with captive core.