### PR TITLE
Make the emptyDir medium configurable and set pubnet and testnet touching coresets to use disk.

### DIFF
--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
@@ -44,6 +44,7 @@ let historyPubnetParallelCatchup (context: MissionContext) =
 
     let opts =
         { PubnetCoreSetOptions context.image with
+              emptyDirType = MemoryBackedEmptyDir
               localHistory = false
               invariantChecks = AllInvariantsExceptBucketConsistencyChecks
               initialization = CoreSetInitialization.OnlyNewDb }

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -68,6 +68,10 @@ type DBType =
     | SqliteMemory
     | Postgres
 
+type EmptyDirType =
+    | MemoryBackedEmptyDir
+    | DiskBackedEmptyDir
+
 type CoreSetInitialization =
     { newDb: bool
       newHist: bool
@@ -135,6 +139,7 @@ type CoreSetOptions =
     { nodeCount: int
       nodeLocs: GeoLoc list option
       dbType: DBType
+      emptyDirType: EmptyDirType
       syncStartupDelay: int option
       quorumSet: QuorumSetSpec
       historyNodes: CoreSetName list option
@@ -164,6 +169,7 @@ type CoreSetOptions =
         { nodeCount = 3
           nodeLocs = None
           dbType = Sqlite
+          emptyDirType = MemoryBackedEmptyDir
           syncStartupDelay = Some(5)
           quorumSet = AllPeersQuorum
           historyNodes = None

--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -465,6 +465,7 @@ let PubnetPeers =
 
 let PubnetCoreSetOptions (image: string) =
     { CoreSetOptions.GetDefault image with
+          emptyDirType = DiskBackedEmptyDir
           quorumSet = ExplicitQuorum PubnetQuorum
           historyGetCommands = PubnetGetCommands
           peersDns = PubnetPeers
@@ -500,6 +501,7 @@ let TestnetPeers =
 
 let TestnetCoreSetOptions (image: string) =
     { CoreSetOptions.GetDefault image with
+          emptyDirType = DiskBackedEmptyDir
           quorumSet = ExplicitQuorum TestnetQuorum
           historyGetCommands = TestnetGetCommands
           peersDns = TestnetPeers


### PR DESCRIPTION
I think this should avoid bumping into memory limits quite as often.