### PR TITLE
Situational awareness

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -77,7 +77,8 @@ type MissionOptions
         tier1OrgsToAdd: int,
         nonTier1NodesToAdd: int,
         randomSeed: int,
-        pubnetParallelCatchupStartingLedger: int
+        pubnetParallelCatchupStartingLedger: int,
+        tag: string option
     ) =
 
     [<Option('k', "kubeconfig", HelpText = "Kubernetes config file", Required = false, Default = "~/.kube/config")>]
@@ -278,6 +279,9 @@ type MissionOptions
              Default = 0)>]
     member self.PubnetParallelCatchupStartingLedger = pubnetParallelCatchupStartingLedger
 
+    [<Option("tag", HelpText = "optional name to tag the run with", Required = false)>]
+    member self.Tag = tag
+
 
 let splitLabel (lab: string) : (string * string option) =
     match lab.Split ':' with
@@ -361,7 +365,8 @@ let main argv =
                   nonTier1NodesToAdd = 0
                   randomSeed = 0
                   networkSizeLimit = 0
-                  pubnetParallelCatchupStartingLedger = 0 }
+                  pubnetParallelCatchupStartingLedger = 0
+                  tag = None }
 
             let nCfg = MakeNetworkCfg ctx [] None
             use formation = kube.MakeEmptyFormation nCfg
@@ -449,7 +454,8 @@ let main argv =
                                nonTier1NodesToAdd = mission.NonTier1NodesToAdd
                                networkSizeLimit = mission.NetworkSizeLimit
                                randomSeed = mission.RandomSeed
-                               pubnetParallelCatchupStartingLedger = mission.PubnetParallelCatchupStartingLedger }
+                               pubnetParallelCatchupStartingLedger = mission.PubnetParallelCatchupStartingLedger
+                               tag = mission.Tag }
 
                          allMissions.[m] missionContext
 

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -388,6 +388,8 @@ let main argv =
                  1)
             | None ->
                 (LogInfo "-----------------------------------"
+                 LogInfo "Supercluster command line: %s" (System.String.Join(" ", argv))
+                 LogInfo "-----------------------------------"
                  LogInfo "Connecting to Kubernetes cluster"
                  LogInfo "-----------------------------------"
 

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -18,9 +18,9 @@ open Xunit.Abstractions
 
 [<Fact>]
 let ``Network nonce looks reasonable`` () =
-    let nonce = MakeNetworkNonce()
+    let nonce = MakeNetworkNonce None
     let nstr = nonce.ToString()
-    Assert.Matches(Regex("^ssc-[a-f0-9]+$"), nstr)
+    Assert.Matches(Regex("^ssc-[a-z0-9-]+$"), nstr)
 
 let coreSetOptions =
     { CoreSetOptions.GetDefault "stellar/stellar-core" with
@@ -86,7 +86,8 @@ let ctx : MissionContext =
       tier1OrgsToAdd = 0
       nonTier1NodesToAdd = 0
       randomSeed = 0
-      pubnetParallelCatchupStartingLedger = 0 }
+      pubnetParallelCatchupStartingLedger = 0
+      tag = None }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2021-01-05.json"
 let pubkeys = __SOURCE_DIRECTORY__ + "/../../../data/tier1keys.json"
@@ -203,20 +204,20 @@ type Tests(output: ITestOutputHelper) =
         if System.IO.File.Exists(netdata) && System.IO.File.Exists(pubkeys) then
             (let coreSets = FullPubnetCoreSets pubnetctx false
              let nCfg = MakeNetworkCfg pubnetctx coreSets passOpt
-             let sdfCoreSetName = CoreSetName "www-stellar-org"
+             let sdfCoreSetName = CoreSetName "stellar"
              Assert.Contains(coreSets, (fun cs -> cs.name = sdfCoreSetName))
              let sdfCoreSet = List.find (fun cs -> cs.name = sdfCoreSetName) coreSets
              let cfg = nCfg.StellarCoreCfg(sdfCoreSet, 0, MainCoreContainer)
              let toml = cfg.ToString()
              Assert.Contains("[QUORUM_SET.sub1]", toml)
              Assert.Contains("[HISTORY.local]", toml)
-             Assert.Matches(Regex("VALIDATORS.*stellar-blockdaemon-com-0"), toml)
-             Assert.Matches(Regex("VALIDATORS.*www-stellar-org-0"), toml)
-             Assert.Matches(Regex("VALIDATORS.*keybase-io-0"), toml)
-             Assert.Matches(Regex("VALIDATORS.*wirexapp-com-0"), toml)
-             Assert.Matches(Regex("VALIDATORS.*coinqvest-com-0"), toml)
-             Assert.Matches(Regex("VALIDATORS.*satoshipay-io-0"), toml)
-             Assert.Matches(Regex("VALIDATORS.*lobstr-co-0"), toml))
+             Assert.Matches(Regex("VALIDATORS.*blockdaemon-0"), toml)
+             Assert.Matches(Regex("VALIDATORS.*stellar-0"), toml)
+             Assert.Matches(Regex("VALIDATORS.*keybase-0"), toml)
+             Assert.Matches(Regex("VALIDATORS.*wirexapp-0"), toml)
+             Assert.Matches(Regex("VALIDATORS.*coinqvest-0"), toml)
+             Assert.Matches(Regex("VALIDATORS.*satoshipay-0"), toml)
+             Assert.Matches(Regex("VALIDATORS.*lobstr-0"), toml))
 
     [<Fact>]
     member __.``Geographic calculations are reasonable``() =
@@ -383,8 +384,7 @@ type Tests(output: ITestOutputHelper) =
             (let allCoreSets = FullPubnetCoreSets pubnetctx true
              let fullNetCfg = MakeNetworkCfg pubnetctx allCoreSets passOpt
 
-             let sdf =
-                 List.find (fun (cs: CoreSet) -> cs.name.StringName = "www-stellar-org") allCoreSets
+             let sdf = List.find (fun (cs: CoreSet) -> cs.name.StringName = "stellar") allCoreSets
 
              let delayCmd = fullNetCfg.NetworkDelayScript sdf 0
              let str = delayCmd.ToString()

--- a/src/FSLibrary/MissionSimulatePubnet.fs
+++ b/src/FSLibrary/MissionSimulatePubnet.fs
@@ -56,8 +56,7 @@ let simulatePubnet (context: MissionContext) =
 
     let fullCoreSet = FullPubnetCoreSets context true
 
-    let sdf =
-        List.find (fun (cs: CoreSet) -> cs.name.StringName = "www-stellar-org") fullCoreSet
+    let sdf = List.find (fun (cs: CoreSet) -> cs.name.StringName = "stellar") fullCoreSet
 
     let tier1 = List.filter (fun (cs: CoreSet) -> cs.options.tier1 = Some true) fullCoreSet
 

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -62,5 +62,6 @@ type MissionContext =
       tier1OrgsToAdd: int
       nonTier1NodesToAdd: int
       randomSeed: int
+      tag: string option
       networkSizeLimit: int
       pubnetParallelCatchupStartingLedger: int }

--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -255,7 +255,10 @@ let FullPubnetCoreSets (context: MissionContext) (manualclose: bool) : CoreSet l
     let groupedOrgNodes : (HomeDomainName * PubnetNode.Root array) array =
         Array.groupBy
             (fun (n: PubnetNode.Root) ->
-                let cleanOrgName = n.SbHomeDomain.Value.Replace('.', '-')
+                let domain = n.SbHomeDomain.Value
+                // We turn 'www.stellar.org' into 'stellar'
+                // and 'stellar.blockdaemon.com' into 'blockdaemon'
+                let cleanOrgName = if domain.Contains('.') then ((Array.rev (domain.Split('.'))).[1]) else domain
                 let lowercase = cleanOrgName.ToLower()
                 HomeDomainName lowercase)
             orgNodes


### PR DESCRIPTION
A small pair of changes to make it easier to keep track of supercluster runs:

  - The first changes the random 12-hex-digit (48 bit) nonce used to differentiate runs to be a readable hours-and-minutes timestamp, a 6-hex-digit (24 bit) nonce, and an optional user-provided `--tag` string in the middle. This makes it easier to tell at a glance when a run is from and also to mark runs with specific experiment/branch names. This change also attempts to shrink the amount of label-space chewed up by long homedomains in the pubnet data set (such as `stellar.blockdaemon.com`) by shortening them to just the middle domain-name component (i.e. `blockdaemon`). This is to make room for the user labels, as there is a strict 63-but-actually-52-character-because-k8s-adds-its-own-nonce limit imposed by DNS label rules.
  - The second adds a logging line at startup that includes the full command-line passed to supercluster, so that you can always reproduce a log and/or tell what command a given log came from.