### PR TITLE
Use a more recent range where buckets would be aware of init vs live

### DIFF
--- a/src/FSLibrary/MissionHistoryPubnetPerformance.fs
+++ b/src/FSLibrary/MissionHistoryPubnetPerformance.fs
@@ -27,14 +27,14 @@ let historyPubnetPerformance (context: MissionContext) =
 
             (formation.RunSingleJobWithTimeout
                 (Some(TimeSpan.FromMinutes(10.0)))
-                [| "catchup"; "20000000/0" |]
+                [| "catchup"; "33000000/0" |]
                 context.image
                 true)
             |> formation.CheckAllJobsSucceeded
 
             (formation.RunSingleJobWithTimeout
                 (Some(TimeSpan.FromHours(4.0)))
-                [| "catchup"; "20050000/50000" |]
+                [| "catchup"; "33030000/30000" |]
                 context.image
                 true)
             |> formation.CheckAllJobsSucceeded)


### PR DESCRIPTION
Older buckets (before protocol V11) take longer to apply now due to https://github.com/stellar/stellar-core/commit/5e36bab66ac834fd19ec852b1728ee71d4688a37, so we update the test here to use a more recent range.