### PR TITLE
Make `SimulatePubnet` stable for a large number of nodes

### DIFF
--- a/src/FSLibrary/MissionSimulatePubnet.fs
+++ b/src/FSLibrary/MissionSimulatePubnet.fs
@@ -19,7 +19,7 @@ open StellarCoreHTTP
 let simulatePubnet (context: MissionContext) =
     let context =
         { context with
-              coreResources = SimulatePubnetResources
+              coreResources = SimulatePubnetResources context.networkSizeLimit
               // When no value is given, use the default values derived from observing the pubnet.
               // 9/10, 88/100, 3/1000 denote 9% => 10 usec, 88% => 100 usec, 3% => 1000 usec.
               simulateApplyDuration =

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -17,7 +17,7 @@ type LogLevels = { LogDebugPartitions: string list; LogTracePartitions: string l
 type CoreResources =
     | SmallTestResources
     | AcceptanceTestResources
-    | SimulatePubnetResources
+    | SimulatePubnetResources of int
     | ParallelCatchupResources
     | NonParallelCatchupResources
     | UpgradeResources


### PR DESCRIPTION
Currently, `SimulatePubnet` is unstable when there's a lot of nodes (i.e., >= 200). After some investigation, it seems that two changes fix this:

- Remove nodes with <= 4 connections. They seem to go out of sync very easily. It seems that, in general, very few nodes have <= 4 connections, which is expected as `TARGET_PEER_CONNECTIONS` is by default 8.
- Increase the resource requirements.

With this change, I was able to run simulations with around 300 nodes and verify that all metrics (stellar core metrics, k8s metrics) are all reasonable. 