### PR TITLE
Turn on `install-network-delays` by default for `SimulatePubnet`

### DIFF
--- a/src/FSLibrary/MissionSimulatePubnet.fs
+++ b/src/FSLibrary/MissionSimulatePubnet.fs
@@ -44,6 +44,12 @@ let simulatePubnet (context: MissionContext) =
                           }
                       )
                   )
+              // As the goal of `SimulatePubnet` is to simulate a pubnet,
+              // network delays are, in general, indispensable.
+              // Therefore, unless explicitly told otherwise, we will use
+              // network delays.
+              installNetworkDelay = Some(context.installNetworkDelay |> Option.defaultValue true)
+
               // This spike configuration was derived from some pubnet data.
               // Most ledgers are expected to have roughly 60 * 5 = 300 ops,
               // and 1 in 13 ledgers are expected to have roughly 60 * 5 + 700 = 1000 txs.


### PR DESCRIPTION
- This installs network delays by default for `SimulatePubnet`
- In case we can't install network delays because there's no geo location info, we will throw an error. (The current code just keeps going, so it's unlikely that we'll notice that we didn't install network delays.)
- This PR still lets a user run `SimulatePubnet` without network delays if they pass `install-network-delays=false`.