### PR TITLE
Add a special case for pod names (stellar.expert => expert)

### DIFF
--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -211,7 +211,11 @@ type Tests(output: ITestOutputHelper) =
              let nCfg = MakeNetworkCfg pubnetctx coreSets passOpt
              let sdfCoreSetName = CoreSetName "stellar"
              Assert.Contains(coreSets, (fun cs -> cs.name = sdfCoreSetName))
+             // Ensure that 'validator.stellar.expert' got a different name from
+             // 'www.stellar.org'.
+             Assert.Contains(coreSets, (fun cs -> cs.name = (CoreSetName "expert")))
              let sdfCoreSet = List.find (fun cs -> cs.name = sdfCoreSetName) coreSets
+             Assert.Equal(3, sdfCoreSet.options.nodeCount)
              let cfg = nCfg.StellarCoreCfg(sdfCoreSet, 0, MainCoreContainer)
              let toml = cfg.ToString()
              Assert.Contains("[QUORUM_SET.sub1]", toml)

--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -266,7 +266,14 @@ let FullPubnetCoreSets (context: MissionContext) (manualclose: bool) : CoreSet l
                 let domain = n.SbHomeDomain.Value
                 // We turn 'www.stellar.org' into 'stellar'
                 // and 'stellar.blockdaemon.com' into 'blockdaemon'
-                let cleanOrgName = if domain.Contains('.') then ((Array.rev (domain.Split('.'))).[1]) else domain
+                // 'validator.stellar.expert' is a special case
+                // since it would also turn into 'stellar'.
+                // As a slightly hacky fix, we will call it 'exert'.
+                let cleanOrgName =
+                    if domain = "validator.stellar.expert" then "expert"
+                    else if domain.Contains('.') then ((Array.rev (domain.Split('.'))).[1])
+                    else domain
+
                 let lowercase = cleanOrgName.ToLower()
                 HomeDomainName lowercase)
             orgNodes


### PR DESCRIPTION
Currently, both `stellar.org` and `stellar.expert` get the pod name `stellar-*` which is a bit confusing.
This PR adds a special case for `stellar.expert` and turn that into `expert`. This change is not very elegant, but it's unlikely that we have to deal with corner cases like that often, so I figured it's reasonable.

We can't use the full name due to label-length limits. See

https://github.com/stellar/supercluster/blob/d6771b84f52372170d3a5d98bd93f4a2f9babd8c/src/FSLibrary/StellarCoreSet.fs#L22-L31