### PR TITLE
100 mbit class => 10git class (network delay)

### DIFF
--- a/src/FSLibrary/StellarNetworkDelays.fs
+++ b/src/FSLibrary/StellarNetworkDelays.fs
@@ -132,7 +132,7 @@ let getNetworkDelayCommands (loc1: GeoLoc) (locsAndNames: (GeoLoc * PeerDnsName)
                         sprintf "1:%d" n
                         "htb"
                         "rate"
-                        "100mbit" |]
+                        "10gbit" |]
 
     let peerVar (n: int) : string = sprintf "PEER%d" n
 


### PR DESCRIPTION
Updating this as 100mbit is an unnecessary limit, the production machines are much faster