### PR TITLE
Increase parallel catchup parallelism

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -438,7 +438,7 @@ let main argv =
                          reraise ()
 
                  // Poll cluster every minute to make sure we don't have any issues
-                 let timer = new System.Threading.Timer(TimerCallback(heartbeatHandler), null, 1000, 60000)
+                 let timer = new System.Threading.Timer(TimerCallback(heartbeatHandler), null, 1000, 300000)
 
                  for m in mission.Missions do
                      LogInfo "-----------------------------------"

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
@@ -22,7 +22,7 @@ let historyPubnetParallelCatchup (context: MissionContext) =
     let latestLedgerNum = GetLatestPubnetLedgerNumber()
     let ledgersPerJob = checkpointsPerJob * ledgersPerCheckpoint
     let startingLedger = max context.pubnetParallelCatchupStartingLedger 0
-    let parallelism = 128
+    let parallelism = 256
     let overlapCheckpoints = 5
     let overlapLedgers = overlapCheckpoints * ledgersPerCheckpoint
 

--- a/src/FSLibrary/MissionHistoryTestnetParallelCatchup.fs
+++ b/src/FSLibrary/MissionHistoryTestnetParallelCatchup.fs
@@ -19,7 +19,7 @@ let historyTestnetParallelCatchup (context: MissionContext) =
     let ledgersPerCheckpoint = 64
     let ledgersPerJob = checkpointsPerJob * ledgersPerCheckpoint
     let totalLedgers = GetLatestTestnetLedgerNumber()
-    let parallelism = 128
+    let parallelism = 256
     let overlapCheckpoints = 5
     let overlapLedgers = overlapCheckpoints * ledgersPerCheckpoint
 


### PR DESCRIPTION
The ops team updated the dev cluster to machines with 16 vCPU and 64 GiB (https://github.com/stellar/ops/issues/1653), so we can increase our parallelization.