### PR TITLE
fix default tx rate

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -173,7 +173,7 @@ type MissionOptions
     [<Option("tx-rate",
              HelpText = "Transaction rate for benchmarks and load generation tests",
              Required = false,
-             Default = 200)>]
+             Default = 20)>]
     member self.TxRate = txRate
 
     [<Option("max-tx-rate",


### PR DESCRIPTION
Looks like our default tx rate is too high: most missions are configured to "maxTxSetSize=100", so loadgen was submitting load too fast, causing some missions to fail. This change reduces the default to 20 tx/s. Note that missions that need realistic tx rate (SimulatePubnet, Tier1Perf) should configure desired tx rate manually. 