### PR TITLE
Check for null items after ListNamespacedPod call

### DIFF
--- a/src/FSLibrary/StellarJobExec.fs
+++ b/src/FSLibrary/StellarJobExec.fs
@@ -196,7 +196,7 @@ type StellarFormation with
                 LogInfo "Checking for pod buildup"
                 let pods = self.Kube.ListNamespacedPod(namespaceParameter = ns)
 
-                if pods <> null then
+                if pods <> null && pods.Items <> null then
                     for pod in pods.Items do
                         let stillPending = (pod.Status.Phase = "Pending")
 


### PR DESCRIPTION
In response to this recent SSC exception -
```
2022-06-01 13:23:28.764 +00:00 [ERR] Exception thrown. Message = Object reference not set to an instance of an object. - StackTrace =   at StellarJobExec.checkPendingPodBuildup$cont@200(DateTime now, V1PodList pods, Unit unitVar) in /supercluster/src/FSLibrary/StellarJobExec.fs:line 200
   at StellarJobExec.checkPendingPodBuildup@190(StellarFormation self, FSharpRef`1 lastPodBuildupCheckTime, Unit unitVar0) in /supercluster/src/FSLibrary/StellarJobExec.fs:line 221
```