### PR TITLE
Reduce parallelism due to disk space usage

### DIFF
--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchup.fs
@@ -22,7 +22,7 @@ let historyPubnetParallelCatchup (context: MissionContext) =
     let latestLedgerNum = GetLatestPubnetLedgerNumber()
     let ledgersPerJob = checkpointsPerJob * ledgersPerCheckpoint
     let startingLedger = max context.pubnetParallelCatchupStartingLedger 0
-    let parallelism = 256
+    let parallelism = 220
     let overlapCheckpoints = 5
     let overlapLedgers = overlapCheckpoints * ledgersPerCheckpoint
 


### PR DESCRIPTION
The recent pubnet catchup ranges are using enough disk space where the workers are evicting pods due to disk pressure, so I'm temporarily reducing parallelism.