### PR TITLE
Change pod creation within stateful set to sequential to avoid races

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -770,7 +770,7 @@ type NetworkCfg with
             V1StatefulSetSpec(
                 selector = V1LabelSelector(matchLabels = CfgVal.labels),
                 serviceName = self.ServiceName,
-                podManagementPolicy = "Parallel",
+                podManagementPolicy = "OrderedReady",
                 template = self.ToPodTemplateSpec coreSet,
                 replicas = System.Nullable<int>(coreSet.CurrentCount)
             )


### PR DESCRIPTION
it seems like starting pods in parallel occasionally causes races described in https://github.com/stellar/supercluster/issues/52. I think this is related to how we do auth in overlay: if both nodes send hello at the same time, they'll both drop each other as they consider that peer already connected. 

With this change, the startup will take a bit longer, but hopefully because the pods are started at different times, it'll be much easier for core to win the race.
