### PR TITLE
Enable console logging for Jobs

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -264,11 +264,13 @@ let CoreContainerForCommand
 
     let cfgWords = cfgFileArgs configOpt MainCoreContainer
     let containerName = CfgVal.stellarCoreContainerName (Array.get command 0)
+    let consoleLogging = [| ShWord.OfStr "--console" |]
 
     let cmdWords =
         Array.concat [ [| ShWord.OfStr CfgVal.stellarCoreBinPath |]
                        Array.map ShWord.OfStr command
-                       cfgWords ]
+                       cfgWords
+                       consoleLogging ]
 
     let toShPieces word = ShPieces [| word |]
     let statusName = ShName "CORE_EXIT_STATUS"
@@ -704,8 +706,6 @@ type NetworkCfg with
                 Array.append runCmd [| "--in-memory" |]
             else
                 runCmd
-
-        let runCmd = Array.append runCmd [| "--console" |]
 
         let usePostgres = (coreSet.options.dbType = Postgres)
         let exportToPrometheus = self.missionContext.exportToPrometheus


### PR DESCRIPTION
We are currently missing logs for SSC missions that use jobs like parallel catchup because console logging is now disabled by default - Ex. https://buildmeister-v3.stellar-ops.com/job/Core/job/stellar-supercluster/216/artifact/run/HistoryPubnetParallelCatchup/ssc-1422z-c9e428-stellar-core-job-1006-v5w5p-stellar-core-catchup.log.

This PR enables the `--console` flag everywhere.