### PR TITLE
nginx-ingress migration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,8 @@ jobs:
       uses: debianmaster/actions-k3s@master
       with:
         version: 'v1.20.8-k3s1'
+    - name: Setup nginx-ingress
+      run: kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.5.1/deploy/static/provider/cloud/deploy.yaml
     - name: Setup .NET SDK 5
       uses: actions/setup-dotnet@v1
       with:
@@ -32,7 +34,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: Run BootAndSync mission
-      run: dotnet run --project src/App/App.fsproj --configuration Release -- mission BootAndSync --image stellar/stellar-core:stable --kubeconfig $KUBECONFIG --namespace default --ingress-class traefik --ingress-internal-domain local --ingress-external-host localhost --uneven-sched
+      run: dotnet run --project src/App/App.fsproj --configuration Release -- mission BootAndSync --image stellar/stellar-core:stable --kubeconfig $KUBECONFIG --namespace default --ingress-class nginx --ingress-internal-domain local --ingress-external-host localhost --uneven-sched
     - uses: actions/upload-artifact@v2
       with:
         name: destination

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -2,7 +2,7 @@
 
   - Find or make a Kubernetes cluster. The easiest approach currently is probably [k3s](k3s.md) on an ubuntu system, but it should work on a variety of other kubernetes distributions.
 
-  - Make sure you have enabled at least the `dns` and `ingress` components on the Kubernetes cluster, and that the `ingress` controller is [traefik](https://traefik.io). This is the default in k3s.
+  - Make sure you have enabled at least the `dns` and `ingress` components on the Kubernetes cluster, and that the `ingress` controller is [nginx-ingress](https://kubernetes.github.io/ingress-nginx/).
 
   - Download and install [dotnet 5.0 or later](https://dotnet.microsoft.com/download).
 

--- a/doc/k3s.md
+++ b/doc/k3s.md
@@ -6,7 +6,9 @@ Supercluster can run on k3s, and this is a relatively easy way to test it or run
 
 Follow these steps:
 
-- Install k3s: `curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.20.8+k3s1 sh -s - --write-kubeconfig-mode 644 --docker --kubelet-arg=cgroup-driver=systemd`
+- Install k3s: `curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.20.8+k3s1 sh -s - --write-kubeconfig-mode 644 --docker --kubelet-arg=cgroup-driver=systemd --no-deploy traefik`
+
+- Deploy nginx-ingress: `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.5.1/deploy/static/provider/cloud/deploy.yaml`
 
 - Raise the sysctl limits on your ARP cache. This is necessary to run larger supercluster
   missions. Put something like this in your `/etc/sysctl.conf` and then run `sysctl -p`
@@ -25,5 +27,5 @@ net.ipv6.neigh.default.gc_thresh3 = 100000
 
   - Build supercluster normally (see [getting-started.md](getting-started.md))
 
-  - Run supercluster with these additional arguments: `--kubeconfig $KUBECONFIG --namespace default --ingress-class traefik --ingress-internal-domain local --ingress-external-host localhost --uneven-sched`
+  - Run supercluster with these additional arguments: `--kubeconfig $KUBECONFIG --namespace default --ingress-class nginx --ingress-internal-domain local --ingress-external-host localhost --uneven-sched`
 

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -825,7 +825,7 @@ type NetworkCfg with
     // Returns an Ingress object with rules that map URLs http://$ingressHost/peer-N/foo
     // to the per-Pod Service within the current networkCfg named peer-N (which then, via
     // DNS mapping, goes to the Pod itself). Exposing this to external traffic
-    // requires that you enable the traefik Ingress controller on your k8s
+    // requires that you enable the nginx Ingress controller on your k8s
     // cluster.
     member self.ToIngress() : Extensionsv1beta1Ingress =
         let httpPortStr = IntstrIntOrString(value = CfgVal.httpPort.ToString())
@@ -838,11 +838,21 @@ type NetworkCfg with
 
         let corePath (coreSet: CoreSet) (i: int) : Extensionsv1beta1HTTPIngressPath =
             let pn = self.PodName coreSet i
-            Extensionsv1beta1HTTPIngressPath(path = sprintf "/%s/core/" pn.StringName, backend = coreBackend pn)
+
+            Extensionsv1beta1HTTPIngressPath(
+                path = sprintf "/%s/core(/|$)(.*)" pn.StringName,
+                pathType = "Prefix",
+                backend = coreBackend pn
+            )
 
         let historyPath (coreSet: CoreSet) (i: int) : Extensionsv1beta1HTTPIngressPath =
             let pn = self.PodName coreSet i
-            Extensionsv1beta1HTTPIngressPath(path = sprintf "/%s/history/" pn.StringName, backend = historyBackend pn)
+
+            Extensionsv1beta1HTTPIngressPath(
+                path = sprintf "/%s/history(/|$)(.*)" pn.StringName,
+                pathType = "Prefix",
+                backend = historyBackend pn
+            )
 
         let corePaths = self.MapAllPeers corePath
         let historyPaths = self.MapAllPeers historyPath
@@ -855,8 +865,8 @@ type NetworkCfg with
         let spec = Extensionsv1beta1IngressSpec(rules = rules)
 
         let annotation =
-            Map.ofArray [| ("traefik.ingress.kubernetes.io/rule-type", "PathPrefixStrip")
-                           ("kubernetes.io/ingress.class", self.missionContext.ingressClass) |]
+            Map.ofArray [| ("kubernetes.io/ingress.class", self.missionContext.ingressClass)
+                           ("nginx.ingress.kubernetes.io/rewrite-target", "/$2") |]
 
         let meta =
             V1ObjectMeta(name = self.IngressName, namespaceProperty = self.NamespaceProperty, annotations = annotation)


### PR DESCRIPTION
This PR adds support for `nginx-ingress` to supercluster. Now supercluster is compatible with both Traefik and Nginx ingresses. To use `nginx-ingress`, [the stellar fork](https://github.com/stellar/ingress-nginx) of Nginx must be deployed on the cluster. Currently, local k3s development does not support Nginx.

To enable `nginx-ingress`, use the flag `--ingress-class nginx-private`. 