### PR TITLE
Disable local archives for after-upgrade in DatabaseInplaceUpgrade

### DIFF
--- a/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
+++ b/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
@@ -36,6 +36,7 @@ let databaseInplaceUpgrade (context: MissionContext) =
             { CoreSetOptions.GetDefault newImage with
                   nodeCount = 1
                   quorumSet = quorumSet
+                  localHistory = false
                   initialization =
                       { newDb = false
                         newHist = false


### PR DESCRIPTION
~~We backup stellar.db and buckets, but we don't copy stellar-history.json, causing issues in coreSets that try to use the backed up data. Related to https://github.com/stellar/stellar-supercluster/issues/257.~~

Just disable local archives for after-upgrade.