### PR TITLE
Revert "Revert "Upgrade to kubernetes 1.22""

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup k3s
       uses: debianmaster/actions-k3s@master
       with:
-        version: 'v1.20.8-k3s1'
+        version: 'v1.22.16-k3s1'
     - name: Setup nginx-ingress
       run: kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.5.1/deploy/static/provider/cloud/deploy.yaml
     - name: Setup .NET SDK 5

--- a/doc/k3s.md
+++ b/doc/k3s.md
@@ -6,7 +6,7 @@ Supercluster can run on k3s, and this is a relatively easy way to test it or run
 
 Follow these steps:
 
-- Install k3s: `curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.20.8+k3s1 sh -s - --write-kubeconfig-mode 644 --docker --kubelet-arg=cgroup-driver=systemd --no-deploy traefik`
+- Install k3s: `curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.22.16+k3s1 sh -s - --write-kubeconfig-mode 644 --docker --kubelet-arg=cgroup-driver=systemd --no-deploy traefik`
 
 - Deploy nginx-ingress: `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.5.1/deploy/static/provider/cloud/deploy.yaml`
 

--- a/src/CSLibrary/CSLibrary.csproj
+++ b/src/CSLibrary/CSLibrary.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="4.0.13" />
+    <PackageReference Include="KubernetesClient" Version="6.0.26" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="stellar-dotnet-sdk" Version="7.1.4" />

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="4.1.1" />
-    <PackageReference Include="KubernetesClient" Version="4.0.13" />
+    <PackageReference Include="KubernetesClient" Version="6.0.26" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -859,42 +859,41 @@ type NetworkCfg with
     // DNS mapping, goes to the Pod itself). Exposing this to external traffic
     // requires that you enable the nginx Ingress controller on your k8s
     // cluster.
-    member self.ToIngress() : Extensionsv1beta1Ingress =
-        let httpPortStr = IntstrIntOrString(value = CfgVal.httpPort.ToString())
+    member self.ToIngress() : V1Ingress =
+        let coreBackend (pn: PodName) : V1IngressBackend =
+            let port = V1ServiceBackendPort(number = CfgVal.httpPort)
+            let service = V1IngressServiceBackend(pn.StringName, port = port)
+            V1IngressBackend(service = service)
 
-        let coreBackend (pn: PodName) =
-            Extensionsv1beta1IngressBackend(serviceName = pn.StringName, servicePort = httpPortStr)
+        let historyBackend (pn: PodName) : V1IngressBackend =
+            let port = V1ServiceBackendPort(number = 80)
+            let service = V1IngressServiceBackend(pn.StringName, port = port)
+            V1IngressBackend(service = service)
 
-        let historyBackend (pn: PodName) : Extensionsv1beta1IngressBackend =
-            Extensionsv1beta1IngressBackend(serviceName = pn.StringName, servicePort = IntstrIntOrString(value = "80"))
-
-        let corePath (coreSet: CoreSet) (i: int) : Extensionsv1beta1HTTPIngressPath =
+        let corePath (coreSet: CoreSet) (i: int) : V1HTTPIngressPath =
             let pn = self.PodName coreSet i
+            let ingressPath = V1HTTPIngressPath()
+            ingressPath.Backend <- coreBackend pn
+            ingressPath.Path <- sprintf "/%s/core(/|$)(.*)" pn.StringName
+            ingressPath.PathType <- "Prefix"
+            ingressPath
 
-            Extensionsv1beta1HTTPIngressPath(
-                path = sprintf "/%s/core(/|$)(.*)" pn.StringName,
-                pathType = "Prefix",
-                backend = coreBackend pn
-            )
-
-        let historyPath (coreSet: CoreSet) (i: int) : Extensionsv1beta1HTTPIngressPath =
+        let historyPath (coreSet: CoreSet) (i: int) : V1HTTPIngressPath =
             let pn = self.PodName coreSet i
-
-            Extensionsv1beta1HTTPIngressPath(
-                path = sprintf "/%s/history(/|$)(.*)" pn.StringName,
-                pathType = "Prefix",
-                backend = historyBackend pn
-            )
+            let ingressPath = V1HTTPIngressPath()
+            ingressPath.Backend <- historyBackend pn
+            ingressPath.Path <- sprintf "/%s/history(/|$)(.*)" pn.StringName
+            ingressPath.PathType <- "Prefix"
+            ingressPath
 
         let corePaths = self.MapAllPeers corePath
         let historyPaths = self.MapAllPeers historyPath
 
-        let rule =
-            Extensionsv1beta1HTTPIngressRuleValue(paths = Array.concat [ corePaths; historyPaths ])
+        let rule = V1HTTPIngressRuleValue(paths = Array.concat [ corePaths; historyPaths ])
 
         let host = self.IngressInternalHostName
-        let rules = [| Extensionsv1beta1IngressRule(host = host, http = rule) |]
-        let spec = Extensionsv1beta1IngressSpec(rules = rules)
+        let rules = [| V1IngressRule(host = host, http = rule) |]
+        let spec = V1IngressSpec(rules = rules)
 
         let annotation =
             Map.ofArray [| ("kubernetes.io/ingress.class", self.missionContext.ingressClass)
@@ -903,4 +902,4 @@ type NetworkCfg with
         let meta =
             V1ObjectMeta(name = self.IngressName, namespaceProperty = self.NamespaceProperty, annotations = annotation)
 
-        Extensionsv1beta1Ingress(spec = spec, metadata = meta)
+        V1Ingress(spec = spec, metadata = meta)

--- a/src/FSLibrary/StellarNamespaceContent.fs
+++ b/src/FSLibrary/StellarNamespaceContent.fs
@@ -106,7 +106,7 @@ type NamespaceContent(kube: Kubernetes, apiRateLimit: int, namespaceProperty: st
 
     member self.Add(statefulSet: V1StatefulSet) = addOne statefulSets statefulSet.Metadata.Name
 
-    member self.Add(ingress: Extensionsv1beta1Ingress) = addOne ingresses ingress.Metadata.Name
+    member self.Add(ingress: V1Ingress) = addOne ingresses ingress.Metadata.Name
 
     member self.Add(job: V1Job) = addOne jobs job.Metadata.Name
 
@@ -116,7 +116,7 @@ type NamespaceContent(kube: Kubernetes, apiRateLimit: int, namespaceProperty: st
 
     member self.Del(statefulSet: V1StatefulSet) = delOne delStatefulSet statefulSets statefulSet.Metadata.Name
 
-    member self.Del(ingress: Extensionsv1beta1Ingress) = delOne delIngress ingresses ingress.Metadata.Name
+    member self.Del(ingress: V1Ingress) = delOne delIngress ingresses ingress.Metadata.Name
 
     member self.Del(job: V1Job) = delOne delJob jobs job.Metadata.Name
 

--- a/src/FSLibrary/StellarNetworkCfg.fs
+++ b/src/FSLibrary/StellarNetworkCfg.fs
@@ -31,7 +31,7 @@ type NetworkNonce =
 let MakeNetworkNonce (tag: string option) : NetworkNonce =
     let utcTime = System.DateTime.UtcNow
     let bytes : byte array = Array.zeroCreate 3
-    let rng = System.Security.Cryptography.RNGCryptoServiceProvider.Create()
+    let rng = System.Security.Cryptography.RandomNumberGenerator.Create()
 
     match tag with
     | Some s when (not (System.Text.RegularExpressions.Regex("^[a-z0-9-]+$").IsMatch(s))) ->

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -64,7 +64,7 @@ type StellarFormation with
 
                 self.Kube.WatchNamespacedStatefulSetAsync(
                     name = name,
-                    ``namespace`` = ns,
+                    namespaceParameter = ns,
                     onEvent = action,
                     onClosed = reinstall
                 )


### PR DESCRIPTION
Reverts stellar/supercluster#87

After testing locally, it looks like these changes break `SimulatePubnet` in k8s 1.21, but everything works fine in k8s 1.22. Because of this, we should hold off on merging this PR until ops has upgraded to 1.22