### PR TITLE
Rollback kubernetes client version

### DIFF
--- a/src/CSLibrary/CSLibrary.csproj
+++ b/src/CSLibrary/CSLibrary.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="6.0.26" />
+   <PackageReference Include="KubernetesClient" Version="4.0.13" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="stellar-dotnet-sdk" Version="7.1.4" />

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="4.1.1" />
-    <PackageReference Include="KubernetesClient" Version="6.0.26" />
+   <PackageReference Include="KubernetesClient" Version="4.0.13" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/FSLibrary/StellarNamespaceContent.fs
+++ b/src/FSLibrary/StellarNamespaceContent.fs
@@ -139,7 +139,7 @@ type NamespaceContent(kube: Kubernetes, apiRateLimit: int, namespaceProperty: st
         ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (apiRateLimit)
         ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (apiRateLimit)
 
-        for i in kube.ListNamespacedIngress(namespaceParameter = namespaceProperty).Items do
+        for i in kube.ListNamespacedIngress1(namespaceParameter = namespaceProperty).Items do
             self.Add(i)
 
         ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (apiRateLimit)

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -64,7 +64,7 @@ type StellarFormation with
 
                 self.Kube.WatchNamespacedStatefulSetAsync(
                     name = name,
-                    namespaceParameter = ns,
+                    ``namespace`` = ns,
                     onEvent = action,
                     onClosed = reinstall
                 )

--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -146,7 +146,7 @@ type Kubernetes with
                 let ing = nCfg.ToIngress()
                 LogInfo "Creating Ingress %s" ing.Metadata.Name
                 ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (rps)
-                let ingress = self.CreateNamespacedIngress(namespaceParameter = nsStr, body = ing)
+                let ingress = self.CreateNamespacedIngress1(namespaceParameter = nsStr, body = ing)
                 namespaceContent.Add(ingress)
 
             let formation =


### PR DESCRIPTION
With the recent migration to k8s 1.22, we also updated the C# Kubernetes Client from version 4 to version 6. This has caused issues with the `SimulatePubnet` test. This change rolls back the Kubernetes Client version with minor changes so that it is compatible with k8s 1.22. This is a band aid while we figure out the simulation issues.