### PR TITLE
Wait until nginx is ready in CI build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,9 +16,11 @@ jobs:
     - name: Setup k3s
       uses: debianmaster/actions-k3s@master
       with:
-        version: 'v1.22.16-k3s1'
+        version: 'v1.23.17-k3s1'
     - name: Setup nginx-ingress
-      run: kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.5.1/deploy/static/provider/cloud/deploy.yaml
+      run: |
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.5.1/deploy/static/provider/cloud/deploy.yaml
+        kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=120s
     - name: Setup .NET SDK 5
       uses: actions/setup-dotnet@v1
       with:

--- a/doc/k3s.md
+++ b/doc/k3s.md
@@ -6,9 +6,14 @@ Supercluster can run on k3s, and this is a relatively easy way to test it or run
 
 Follow these steps:
 
-- Install k3s: `curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.22.16+k3s1 sh -s - --write-kubeconfig-mode 644 --docker --kubelet-arg=cgroup-driver=systemd --no-deploy traefik`
+- Install k3s: `curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.23.17+k3s1 sh -s - --write-kubeconfig-mode 644 --docker --kubelet-arg=cgroup-driver=systemd --no-deploy traefik`
 
-- Deploy nginx-ingress: `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.5.1/deploy/static/provider/cloud/deploy.yaml`
+- Deploy nginx-ingress:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.5.1/deploy/static/provider/cloud/deploy.yaml \
+&& kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=120s
+```
 
 - Raise the sysctl limits on your ARP cache. This is necessary to run larger supercluster
   missions. Put something like this in your `/etc/sysctl.conf` and then run `sysctl -p`


### PR DESCRIPTION
When installing nginx-ingress, wait until nginx pods are ready before continuing. This fixes a race condition where the `BootAndSync` mission would sometimes run before nginx-ingress was done setting itself up. Additionally, the CI k3s version was behind the production k8s version and outside the supported range of nginx-ingress which may also lead to inconsistent behavior. This change also bumps k3s version to match supercluster k8s and fall within nginx-ingress supported range. 