### PR TITLE
Update label master to control-plane

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -428,7 +428,7 @@ type NetworkCfg with
         if self.missionContext.unevenSched then
             affinity both
         else
-            let nonMaster = avoidNodeLabel ("node-role.kubernetes.io/master", None)
+            let nonMaster = avoidNodeLabel ("node-role.kubernetes.io/control-plane", None)
             affinity (nonMaster :: both)
 
     member self.TopologyConstraints() : V1TopologySpreadConstraint array =


### PR DESCRIPTION
k8s 1.24 changed label to `control-plane` from `master`.