### PR TITLE
Switch Ubuntu base image to 22.04 from 20.04

### DIFF
--- a/Dockerfile.netdelay
+++ b/Dockerfile.netdelay
@@ -6,5 +6,5 @@
 #
 # docker build -t stellar/sdf-netdelay:latest -f Dockerfile.netdelay .
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt-get -y -q update && DEBIAN_FRONTEND=noninteractive apt-get -y -q install iproute2 bind9-host


### PR DESCRIPTION

### What

Switch Ubuntu to 22.04 from 20.04
### Why

We are moving other images to 22.04, this change improves consistency across SDF docker images.
