### PR TITLE
Improved soroban loadgen and added mixed load mission

### DIFF
--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -40,6 +40,7 @@
     <Compile Include="MissionHistoryGenerateAndCatchup.fs" />
     <Compile Include="MissionHistoryPubnetMinimumCatchup.fs" />
     <Compile Include="MissionSimulatePubnet.fs" />
+    <Compile Include="MissionSorobanClassicMixed.fs" />
     <Compile Include="MissionSimulatePubnetTier1Perf.fs" />
     <Compile Include="MissionHistoryPubnetRecentCatchup.fs" />
     <Compile Include="MissionHistoryPubnetParallelCatchup.fs" />

--- a/src/FSLibrary/MissionSimulatePubnetTier1Perf.fs
+++ b/src/FSLibrary/MissionSimulatePubnetTier1Perf.fs
@@ -97,7 +97,7 @@ let simulatePubnetTier1Perf (context: MissionContext) =
                                   maxfeerate = None
                                   skiplowfeetxs = false }
 
-                        formation.RunMultiLoadgen tier1 loadGen
+                        formation.RunMultiFractionalLoadgen tier1 loadGen
                         formation.CheckNoErrorsAndPairwiseConsistency()
                         formation.EnsureAllNodesInSync allNodes
 

--- a/src/FSLibrary/MissionSorobanClassicMixed.fs
+++ b/src/FSLibrary/MissionSorobanClassicMixed.fs
@@ -1,10 +1,11 @@
-// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 module MissionSorobanClassicMixed
 
 open StellarCoreSet
+open StellarCorePeer
 open StellarMissionContext
 open StellarFormation
 open StellarStatefulSets
@@ -17,89 +18,67 @@ let sorobanClassicMixed (context: MissionContext) =
     let context =
         { context with
               numAccounts = 2000
-              numTxs = 10000
-              coreResources = SimulatePubnetResources context.networkSizeLimit
-              installNetworkDelay = Some(context.installNetworkDelay |> Option.defaultValue true)
-
-              // This spike configuration was derived from some pubnet data.
-              // Most ledgers are expected to have roughly 60 * 5 = 300 ops,
-              // and 1 in 13 ledgers are expected to have roughly 60 * 5 + 700 = 1000 txs.
-              // We expect that a transaction contains 1.65 ops on average.
-              // * txRate = (60 op / s) / (1.65 op / tx) = 36 tx / s.
-              // * spikeSize = 700 op / (1.65 op / tx) = 424 tx.
-              txRate = 36
-              spikeSize = 424
-              spikeInterval = 65
+              numTxs = 2000
+              txRate = 20
               skipLowFeeTxs = true }
 
-    let fullCoreSet = FullPubnetCoreSets context true true
+    let sorobanCoreSet =
+        MakeLiveCoreSet
+            "soroban"
+            { CoreSetOptions.GetDefault context.image with
+                  quorumSet = CoreSetQuorum(CoreSetName "core")
+                  invariantChecks = AllInvariantsExceptBucketConsistencyChecks
+                  dumpDatabase = false }
 
-    let sdf =
-        List.find (fun (cs: CoreSet) -> cs.name.StringName = "stellar" || cs.name.StringName = "sdf") fullCoreSet
+    let classicCoreSet =
+        MakeLiveCoreSet
+            "classic"
+            { CoreSetOptions.GetDefault context.image with
+                  quorumSet = CoreSetQuorum(CoreSetName "core")
+                  invariantChecks = AllInvariantsExceptBucketConsistencyChecks
+                  dumpDatabase = false }
 
-    let tier1 = List.filter (fun (cs: CoreSet) -> cs.options.tier1 = Some true) fullCoreSet
+    let allNodes = [ sorobanCoreSet; classicCoreSet ]
 
     context.Execute
-        fullCoreSet
+        allNodes
         None
         (fun (formation: StellarFormation) ->
-            // Setup overlay connections first before manually closing
-            // ledger, which kick off consensus
-            formation.WaitUntilConnected fullCoreSet
-            formation.ManualClose tier1
-
             // Wait until the whole network is synced before proceeding,
             // to fail asap in case of a misconfiguration
-            formation.WaitUntilSynced fullCoreSet
-            formation.UpgradeProtocolToLatest tier1
-            formation.UpgradeMaxTxSetSize tier1 1000000
+            formation.WaitUntilSynced allNodes
+            formation.UpgradeProtocolToLatest allNodes
+            formation.UpgradeMaxTxSetSize allNodes 1000000
 
-            formation.RunLoadgen sdf { context.GenerateAccountCreationLoad with accounts = context.numAccounts * 2 }
+            formation.RunLoadgen
+                sorobanCoreSet
+                { context.GenerateAccountCreationLoad with accounts = context.numAccounts * 2 }
 
             // Upgrade to Phase 1 limits
-            formation.SetupUpgradeContract sdf
+            formation.SetupUpgradeContract sorobanCoreSet
 
-            formation.DeployUpgradeEntriesAndArm
-                sdf
-                fullCoreSet
-                (LoadGen.GetSorobanPhase1Upgrade())
-                (System.DateTime.UtcNow.AddSeconds(20.0))
+            let limits = LoadGen.GetSorobanPhase1Upgrade()
+            formation.DeployUpgradeEntriesAndArm allNodes limits (System.DateTime.UtcNow)
 
-            formation.RunLoadgenWithPeer
-                0
-                sdf
-                { context.SetupSorobanInvoke with
-                      instances = Some(100)
-                      txrate = 1
-                      spikesize = 0
-                      spikeinterval = 0 }
+            // Wait until upgrade has been applied
+            let peer = formation.NetworkCfg.GetPeer sorobanCoreSet 0
+            peer.WaitForMaxTxSize limits.txMaxSizeBytes.Value
+
+            formation.RunLoadgen sorobanCoreSet { context.SetupSorobanInvoke with instances = Some(10); txrate = 1 }
 
             let sorobanLoad =
-                async {
-                    formation.RunLoadgenWithPeer
-                        0
-                        sdf
-                        { context.GenerateSorobanInvokeLoad with
-                              // Assume 1-2 large TXs per ledger, so each tx can have up to 1/2 ledger limits
-                              dataEntriesHigh = Some(20 / 2)
-                              ioKiloBytesHigh = Some(64 / 2)
-                              txSizeBytesHigh = Some(71_680 / 2)
-                              instructionsHigh = Some(100_000_000L / 2L)
-                              instances = Some(100)
-                              offset = context.numAccounts
-                              // Soroban is expected to receive less traffic, scale everything down
-                              txrate = 6
-                              txs = 100
-                              spikesize = 50 }
+                { context.GenerateSorobanInvokeLoad with
+                      // Assume 1-2 large TXs per ledger, so each tx can have up to 1/2 ledger limits
+                      dataEntriesHigh = Some(limits.txMaxWriteLedgerEntries.Value / 2)
+                      ioKiloBytesHigh = Some((limits.txMaxWriteBytes.Value / 1024) / 2)
+                      txSizeBytesHigh = Some(limits.txMaxSizeBytes.Value / 2)
+                      instructionsHigh = Some(limits.txMaxInstructions.Value / 2L)
+                      instances = Some(10)
+                      offset = context.numAccounts
+                      // Soroban is expected to receive less traffic, scale everything down
+                      txrate = context.txRate / 10
+                      txs = context.numTxs / 10 }
 
-                }
 
-            let classicLoad = async { formation.RunLoadgenWithPeer 1 sdf context.GeneratePaymentLoad }
-
-            // Generate soroban load from peer 0 and classic load from peer 1 in parallel
-            [ sorobanLoad; classicLoad ]
-            |> Async.Parallel
-            |> Async.RunSynchronously
-            |> ignore
-
-            formation.EnsureAllNodesInSync fullCoreSet)
+            formation.RunMultiLoadgen allNodes [ sorobanLoad; context.GeneratePaymentLoad ]
+            formation.EnsureAllNodesInSync allNodes)

--- a/src/FSLibrary/MissionSorobanClassicMixed.fs
+++ b/src/FSLibrary/MissionSorobanClassicMixed.fs
@@ -9,48 +9,76 @@ open StellarMissionContext
 open StellarFormation
 open StellarStatefulSets
 open StellarSupercluster
+open StellarNetworkData
 open StellarCoreHTTP
 
 let sorobanClassicMixed (context: MissionContext) =
-    let coreSet =
-        MakeLiveCoreSet
-            "core"
-            { CoreSetOptions.GetDefault context.image with
-                  invariantChecks = AllInvariantsExceptBucketConsistencyChecks
-                  dumpDatabase = false }
 
     let context =
         { context with
               numAccounts = 2000
-              numTxs = 2000
-              txRate = 20
+              numTxs = 10000
+              coreResources = SimulatePubnetResources context.networkSizeLimit
+              installNetworkDelay = Some(context.installNetworkDelay |> Option.defaultValue true)
+
+              // This spike configuration was derived from some pubnet data.
+              // Most ledgers are expected to have roughly 60 * 5 = 300 ops,
+              // and 1 in 13 ledgers are expected to have roughly 60 * 5 + 700 = 1000 txs.
+              // We expect that a transaction contains 1.65 ops on average.
+              // * txRate = (60 op / s) / (1.65 op / tx) = 36 tx / s.
+              // * spikeSize = 700 op / (1.65 op / tx) = 424 tx.
+              txRate = 36
+              spikeSize = 424
+              spikeInterval = 65
               skipLowFeeTxs = true }
 
+    let fullCoreSet = FullPubnetCoreSets context true true
+
+    let sdf =
+        List.find (fun (cs: CoreSet) -> cs.name.StringName = "stellar" || cs.name.StringName = "sdf") fullCoreSet
+
+    let tier1 = List.filter (fun (cs: CoreSet) -> cs.options.tier1 = Some true) fullCoreSet
+
     context.Execute
-        [ coreSet ]
+        fullCoreSet
         None
         (fun (formation: StellarFormation) ->
-            formation.WaitUntilSynced [ coreSet ]
-            formation.UpgradeProtocolToLatest [ coreSet ]
-            formation.UpgradeMaxTxSetSize [ coreSet ] 100000
+            // Setup overlay connections first before manually closing
+            // ledger, which kick off consensus
+            formation.WaitUntilConnected fullCoreSet
+            formation.ManualClose tier1
 
-            formation.RunLoadgen coreSet { context.GenerateAccountCreationLoad with accounts = context.numAccounts * 2 }
+            // Wait until the whole network is synced before proceeding,
+            // to fail asap in case of a misconfiguration
+            formation.WaitUntilSynced fullCoreSet
+            formation.UpgradeProtocolToLatest tier1
+            formation.UpgradeMaxTxSetSize tier1 1000000
+
+            formation.RunLoadgen sdf { context.GenerateAccountCreationLoad with accounts = context.numAccounts * 2 }
 
             // Upgrade to Phase 1 limits
-            formation.SetupUpgradeContract coreSet
+            formation.SetupUpgradeContract sdf
 
             formation.DeployUpgradeEntriesAndArm
-                coreSet
+                sdf
+                fullCoreSet
                 (LoadGen.GetSorobanPhase1Upgrade())
                 (System.DateTime.UtcNow.AddSeconds(20.0))
 
-            formation.RunLoadgenWithPeer 0 coreSet { context.SetupSorobanInvoke with instances = Some(100) }
+            formation.RunLoadgenWithPeer
+                0
+                sdf
+                { context.SetupSorobanInvoke with
+                      instances = Some(100)
+                      txrate = 1
+                      spikesize = 0
+                      spikeinterval = 0 }
 
             let sorobanLoad =
                 async {
                     formation.RunLoadgenWithPeer
                         0
-                        coreSet
+                        sdf
                         { context.GenerateSorobanInvokeLoad with
                               // Assume 1-2 large TXs per ledger, so each tx can have up to 1/2 ledger limits
                               dataEntriesHigh = Some(20 / 2)
@@ -59,12 +87,14 @@ let sorobanClassicMixed (context: MissionContext) =
                               instructionsHigh = Some(100_000_000L / 2L)
                               instances = Some(100)
                               offset = context.numAccounts
-                              txrate = context.txRate / 4
-                              txs = context.numTxs / 4 // Our txrate is 1/4 of payment rate, so submit 1/4 of txs
-                        }
+                              // Soroban is expected to receive less traffic, scale everything down
+                              txrate = 6
+                              txs = 100
+                              spikesize = 50 }
+
                 }
 
-            let classicLoad = async { formation.RunLoadgenWithPeer 1 coreSet context.GeneratePaymentLoad }
+            let classicLoad = async { formation.RunLoadgenWithPeer 1 sdf context.GeneratePaymentLoad }
 
             // Generate soroban load from peer 0 and classic load from peer 1 in parallel
             [ sorobanLoad; classicLoad ]
@@ -72,4 +102,4 @@ let sorobanClassicMixed (context: MissionContext) =
             |> Async.RunSynchronously
             |> ignore
 
-            formation.EnsureAllNodesInSync [ coreSet ])
+            formation.EnsureAllNodesInSync fullCoreSet)

--- a/src/FSLibrary/MissionSorobanClassicMixed.fs
+++ b/src/FSLibrary/MissionSorobanClassicMixed.fs
@@ -1,0 +1,75 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+module MissionSorobanClassicMixed
+
+open StellarCoreSet
+open StellarMissionContext
+open StellarFormation
+open StellarStatefulSets
+open StellarSupercluster
+open StellarCoreHTTP
+
+let sorobanClassicMixed (context: MissionContext) =
+    let coreSet =
+        MakeLiveCoreSet
+            "core"
+            { CoreSetOptions.GetDefault context.image with
+                  invariantChecks = AllInvariantsExceptBucketConsistencyChecks
+                  dumpDatabase = false }
+
+    let context =
+        { context with
+              numAccounts = 2000
+              numTxs = 2000
+              txRate = 20
+              skipLowFeeTxs = true }
+
+    context.Execute
+        [ coreSet ]
+        None
+        (fun (formation: StellarFormation) ->
+            formation.WaitUntilSynced [ coreSet ]
+            formation.UpgradeProtocolToLatest [ coreSet ]
+            formation.UpgradeMaxTxSetSize [ coreSet ] 100000
+
+            formation.RunLoadgen coreSet { context.GenerateAccountCreationLoad with accounts = context.numAccounts * 2 }
+
+            // Upgrade to Phase 1 limits
+            formation.SetupUpgradeContract coreSet
+
+            formation.DeployUpgradeEntriesAndArm
+                coreSet
+                (LoadGen.GetSorobanPhase1Upgrade())
+                (System.DateTime.UtcNow.AddSeconds(20.0))
+
+            formation.RunLoadgenWithPeer 0 coreSet { context.SetupSorobanInvoke with instances = Some(100) }
+
+            let sorobanLoad =
+                async {
+                    formation.RunLoadgenWithPeer
+                        0
+                        coreSet
+                        { context.GenerateSorobanInvokeLoad with
+                              // Assume 1-2 large TXs per ledger, so each tx can have up to 1/2 ledger limits
+                              dataEntriesHigh = Some(20 / 2)
+                              ioKiloBytesHigh = Some(64 / 2)
+                              txSizeBytesHigh = Some(71_680 / 2)
+                              instructionsHigh = Some(100_000_000L / 2L)
+                              instances = Some(100)
+                              offset = context.numAccounts
+                              txrate = context.txRate / 4
+                              txs = context.numTxs / 4 // Our txrate is 1/4 of payment rate, so submit 1/4 of txs
+                        }
+                }
+
+            let classicLoad = async { formation.RunLoadgenWithPeer 1 coreSet context.GeneratePaymentLoad }
+
+            // Generate soroban load from peer 0 and classic load from peer 1 in parallel
+            [ sorobanLoad; classicLoad ]
+            |> Async.Parallel
+            |> Async.RunSynchronously
+            |> ignore
+
+            formation.EnsureAllNodesInSync [ coreSet ])

--- a/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
+++ b/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
@@ -22,9 +22,9 @@ let sorobanInvokeHostLoad (context: MissionContext) =
 
     let context =
         { context with
-              numAccounts = 100
-              numTxs = 100
-              txRate = 1
+              numAccounts = 1000
+              numTxs = 1000
+              txRate = 5
               coreResources = MediumTestResources }
 
     context.Execute

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -212,22 +212,30 @@ type LoadGen =
     static member GetSorobanPhase1Upgrade() =
         { LoadGen.GetDefault() with
               mode = CreateSorobanUpgrade
-              ledgerMaxTxCount = Some(30)
-              txMaxInstructions = Some(100_000_000L)
-              txMaxReadBytes = Some(133_120) // 130 KB
-              txMaxWriteBytes = Some(66_560) // 65 KB
-              txMaxReadLedgerEntries = Some(30)
-              txMaxWriteLedgerEntries = Some(20)
-              txMemoryLimit = Some(41_943_040L) // 40 MB
-              txMaxSizeBytes = Some(71_680) // 70 KB
-              txMaxContractEventsSizeBytes = Some(8192) // 8 KB
               maxContractSizeBytes = Some(65_536) // 64 KB
-              maxContractDataEntrySizeBytes = Some(65_536) // 64 KB
+
               ledgerMaxInstructions = Some(100_000_000L)
+              txMaxInstructions = Some(100_000_000L)
+              txMemoryLimit = Some(41_943_040) // 40 MB
+
+              ledgerMaxReadLedgerEntries = Some(40)
               ledgerMaxReadBytes = Some(133_120) // 130 KB
+              ledgerMaxWriteLedgerEntries = Some(25)
               ledgerMaxWriteBytes = Some(66_560) // 65 KB
-              ledgerMaxReadLedgerEntries = Some(30)
-              ledgerMaxWriteLedgerEntries = Some(20) }
+              txMaxReadLedgerEntries = Some(40)
+              txMaxReadBytes = Some(133_120) // 130 KB
+              txMaxWriteLedgerEntries = Some(25)
+              txMaxWriteBytes = Some(66_560) // 65 KB
+
+              txMaxContractEventsSizeBytes = Some(8192) // 8 KB
+
+              ledgerMaxTransactionsSizeBytes = Some(71_680) // 70 KB
+              txMaxSizeBytes = Some(71_680) // 70 KB
+
+              maxContractDataEntrySizeBytes = Some(65_536) // 64 KB
+              maxContractDataKeySizeBytes = Some(200)
+
+              ledgerMaxTxCount = Some(100) }
 
 type MissionContext with
 
@@ -429,6 +437,8 @@ type Peer with
     member self.GetLedgerReadEntries() : int = self.GetSorobanInfo().Ledger.MaxReadLedgerEntries
 
     member self.GetLedgerWriteEntries() : int = self.GetSorobanInfo().Ledger.MaxWriteLedgerEntries
+
+    member self.GetLedgerMaxTransactionCount() : int = self.GetSorobanInfo().Ledger.MaxTxCount
 
     member self.GetLedgerMaxTransactionsSizeBytes() : int = self.GetSorobanInfo().Ledger.MaxTxSizeBytes
 

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -77,8 +77,8 @@ type LoadGen =
       instances: int option
       dataEntriesLow: int option
       dataEntriesHigh: int option
-      kiloBytesPerDataEntryLow: int option
-      kiloBytesPerDataEntryHigh: int option
+      ioKiloBytesLow: int option
+      ioKiloBytesHigh: int option
       txSizeBytesLow: int option
       txSizeBytesHigh: int option
       instructionsLow: int64 option
@@ -129,8 +129,8 @@ type LoadGen =
               @ optionalParam "instances" self.instances
                 @ optionalParam "dataentrieslow" self.dataEntriesLow
                   @ optionalParam "dataentrieshigh" self.dataEntriesHigh
-                    @ optionalParam "kilobyteslow" self.kiloBytesPerDataEntryLow
-                      @ optionalParam "kilobyteshigh" self.kiloBytesPerDataEntryHigh
+                    @ optionalParam "kilobyteslow" self.ioKiloBytesLow
+                      @ optionalParam "kilobyteshigh" self.ioKiloBytesHigh
                         @ optionalParam "txsizelow" self.txSizeBytesLow
                           @ optionalParam "txsizehigh" self.txSizeBytesHigh
                             @ optionalParam "cpulow" self.instructionsLow
@@ -181,8 +181,8 @@ type LoadGen =
           instances = None
           dataEntriesLow = None
           dataEntriesHigh = None
-          kiloBytesPerDataEntryLow = None
-          kiloBytesPerDataEntryHigh = None
+          ioKiloBytesLow = None
+          ioKiloBytesHigh = None
           txSizeBytesLow = None
           txSizeBytesHigh = None
           instructionsLow = None
@@ -208,6 +208,26 @@ type LoadGen =
           bucketListSizeWindowSampleSize = None
           evictionScanSize = None
           startingEvictionScanLevel = None }
+
+    static member GetSorobanPhase1Upgrade() =
+        { LoadGen.GetDefault() with
+              mode = CreateSorobanUpgrade
+              ledgerMaxTxCount = Some(30)
+              txMaxInstructions = Some(100_000_000L)
+              txMaxReadBytes = Some(133_120) // 130 KB
+              txMaxWriteBytes = Some(66_560) // 65 KB
+              txMaxReadLedgerEntries = Some(30)
+              txMaxWriteLedgerEntries = Some(20)
+              txMemoryLimit = Some(41_943_040L) // 40 MB
+              txMaxSizeBytes = Some(71_680) // 70 KB
+              txMaxContractEventsSizeBytes = Some(8192) // 8 KB
+              maxContractSizeBytes = Some(65_536) // 64 KB
+              maxContractDataEntrySizeBytes = Some(65_536) // 64 KB
+              ledgerMaxInstructions = Some(100_000_000L)
+              ledgerMaxReadBytes = Some(133_120) // 130 KB
+              ledgerMaxWriteBytes = Some(66_560) // 65 KB
+              ledgerMaxReadLedgerEntries = Some(30)
+              ledgerMaxWriteLedgerEntries = Some(20) }
 
 type MissionContext with
 
@@ -275,8 +295,8 @@ type MissionContext with
               skiplowfeetxs = self.skipLowFeeTxs
               dataEntriesLow = Some(0)
               dataEntriesHigh = Some(10)
-              kiloBytesPerDataEntryLow = Some(1)
-              kiloBytesPerDataEntryHigh = Some(5)
+              ioKiloBytesLow = Some(1)
+              ioKiloBytesHigh = Some(5)
               txSizeBytesLow = Some(0)
               txSizeBytesHigh = Some(1000)
               instructionsLow = Some(0L)

--- a/src/FSLibrary/StellarMission.fs
+++ b/src/FSLibrary/StellarMission.fs
@@ -33,6 +33,7 @@ open MissionProtocolUpgradeWithLoad
 open MissionDatabaseInplaceUpgrade
 open MissionAcceptanceUnitTests
 open MissionSimulatePubnet
+open MissionSorobanClassicMixed
 open MissionSimulatePubnetTier1Perf
 open StellarMissionContext
 open MissionSorobanLoadGeneration
@@ -77,5 +78,6 @@ let allMissions : Map<string, Mission> =
                  ("SimulatePubnetTier1Perf", simulatePubnetTier1Perf)
                  ("SorobanLoadGeneration", sorobanLoadGeneration)
                  ("SorobanConfigUpgrades", sorobanConfigUpgrades)
+                 ("SorobanClassicMixed", sorobanClassicMixed)
                  ("SorobanInvokeHostLoad", sorobanInvokeHostLoad)
                  ("SorobanCatchupWithPrevAndCurr", sorobanCatchupWithPrevAndCurr) |]

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -269,6 +269,12 @@ type StellarFormation with
         LogInfo "Loadgen: %s" (peer.GenerateLoad loadGen)
         peer.WaitForLoadGenComplete loadGen
 
+    member self.RunLoadgenWithPeer (peer: int) (coreSet: CoreSet) (loadGen: LoadGen) =
+        let peer = self.NetworkCfg.GetPeer coreSet peer
+        LogInfo "Loadgen: %s" (peer.GenerateLoad loadGen)
+        peer.WaitForLoadGenComplete loadGen
+        if peer.IsLoadGenComplete() <> Success then failwith "Loadgen failed!"
+
     member self.SetupUpgradeContract(coreSet: CoreSet) =
         let loadgen = { LoadGen.GetDefault() with mode = SetupSorobanUpgrade }
         self.RunLoadgen coreSet loadgen


### PR DESCRIPTION
This change makes `SorobanInvokeHostLoad` significantly more stressful. It also adds the `SorobanClassicMixed` mission. This mission upgrades the network to the phase 1 soroban limits, then submits both classic payment TXs and soroban TXs in parallel. This is an initial mixed test. In the future, this mission should include more complicated classic traffic, such as DEX operations. Additionally, we should add soroban TXs to `SimulatePubnet` missions once we have soroban pubnet data.