### PR TITLE
Bump KubernetesClient to 7.0.5

### DIFF
--- a/src/CSLibrary/CSLibrary.csproj
+++ b/src/CSLibrary/CSLibrary.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-   <PackageReference Include="KubernetesClient" Version="6.0.1" />
+   <PackageReference Include="KubernetesClient" Version="7.0.6" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="stellar-dotnet-sdk" Version="7.1.4" />

--- a/src/CSLibrary/CSLibrary.csproj
+++ b/src/CSLibrary/CSLibrary.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-   <PackageReference Include="KubernetesClient" Version="4.0.13" />
+   <PackageReference Include="KubernetesClient" Version="6.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="stellar-dotnet-sdk" Version="7.1.4" />

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="4.1.1" />
-    <PackageReference Include="KubernetesClient" Version="4.0.13" />
+    <PackageReference Include="KubernetesClient" Version="6.0.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="4.1.1" />
-    <PackageReference Include="KubernetesClient" Version="6.0.1" />
+    <PackageReference Include="KubernetesClient" Version="7.0.6" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/FSLibrary/StellarNamespaceContent.fs
+++ b/src/FSLibrary/StellarNamespaceContent.fs
@@ -139,7 +139,7 @@ type NamespaceContent(kube: Kubernetes, apiRateLimit: int, namespaceProperty: st
         ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (apiRateLimit)
         ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (apiRateLimit)
 
-        for i in kube.ListNamespacedIngress1(namespaceParameter = namespaceProperty).Items do
+        for i in kube.ListNamespacedIngress(namespaceParameter = namespaceProperty).Items do
             self.Add(i)
 
         ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (apiRateLimit)

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -64,7 +64,7 @@ type StellarFormation with
 
                 self.Kube.WatchNamespacedStatefulSetAsync(
                     name = name,
-                    ``namespace`` = ns,
+                    namespaceParameter = ns,
                     onEvent = action,
                     onClosed = reinstall
                 )

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -60,14 +60,14 @@ type StellarFormation with
             let reinstall = System.Action(installHandler)
 
             if not event.IsSet then
-                self.sleepUntilNextRateLimitedApiCallTime ()
+                let fs = sprintf "metadata.name=%s" name
 
-                self.Kube.WatchNamespacedStatefulSetAsync(
-                    name = name,
-                    namespaceParameter = ns,
-                    onEvent = action,
-                    onClosed = reinstall
-                )
+                self
+                    .Kube
+                    .ListNamespacedStatefulSetWithHttpMessagesAsync(namespaceParameter = ns,
+                                                                    fieldSelector = fs,
+                                                                    watch = true)
+                    .Watch<V1StatefulSet, V1StatefulSetList>(onEvent = action, onClosed = reinstall)
                 |> ignore
 
         installHandler ()

--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -146,7 +146,7 @@ type Kubernetes with
                 let ing = nCfg.ToIngress()
                 LogInfo "Creating Ingress %s" ing.Metadata.Name
                 ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (rps)
-                let ingress = self.CreateNamespacedIngress1(namespaceParameter = nsStr, body = ing)
+                let ingress = self.CreateNamespacedIngress(namespaceParameter = nsStr, body = ing)
                 namespaceContent.Add(ingress)
 
             let formation =


### PR DESCRIPTION
Resolves https://github.com/stellar/supercluster/issues/95

Confirmed locally that `dotnet run clean` properly deletes orphaned ingresses. This change _may_ cause mission breakages, so we should try this new version in CI.