### PR TITLE
Properly scale ledger and transaction limits in InvokeHostLoad mission

### DIFF
--- a/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
+++ b/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
@@ -36,5 +36,7 @@ let sorobanInvokeHostLoad (context: MissionContext) =
             formation.UpgradeMaxTxSetSize [ coreSet ] 100000
 
             formation.RunLoadgen coreSet context.GenerateAccountCreationLoad
+            formation.UpgradeSorobanLedgerLimitsWithMultiplier [ coreSet ] 1000
+            formation.UpgradeSorobanTxLimitsWithMultiplier [ coreSet ] 100
             formation.RunLoadgen coreSet context.SetupSorobanInvoke
             formation.RunLoadgen coreSet context.GenerateSorobanInvokeLoad)

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -90,7 +90,7 @@ type LoadGen =
       maxContractDataEntrySizeBytes: int option
       ledgerMaxInstructions: int64 option
       txMaxInstructions: int64 option
-      txMemoryLimit: int64 option
+      txMemoryLimit: int option
       ledgerMaxReadLedgerEntries: int option
       ledgerMaxReadBytes: int option
       ledgerMaxWriteLedgerEntries: int option
@@ -412,7 +412,27 @@ type Peer with
 
     member self.GetLedgerMaxTransactionsSizeBytes() : int = self.GetSorobanInfo().Ledger.MaxTxSizeBytes
 
+    member self.GetTxMaxInstructions() : int64 = self.GetSorobanInfo().Tx.MaxInstructions
+
+    member self.GetTxReadBytes() : int = self.GetSorobanInfo().Tx.MaxReadBytes
+
+    member self.GetTxWriteBytes() : int = self.GetSorobanInfo().Tx.MaxWriteBytes
+
+    member self.GetTxReadEntries() : int = self.GetSorobanInfo().Tx.MaxReadLedgerEntries
+
+    member self.GetTxWriteEntries() : int = self.GetSorobanInfo().Tx.MaxWriteLedgerEntries
+
+    member self.GetTxMemoryLimit() : int = self.GetSorobanInfo().Tx.MemoryLimit
+
     member self.GetMaxTxSize() : int = self.GetSorobanInfo().Tx.MaxSizeBytes
+
+    member self.GetMaxContractSize() : int = self.GetSorobanInfo().MaxContractSize
+
+    member self.GetMaxContractDataKeySize() : int = self.GetSorobanInfo().MaxContractDataKeySize
+
+    member self.GetMaxContractDataEntrySize() : int = self.GetSorobanInfo().MaxContractDataEntrySize
+
+    member self.GetTxMaxContractEventsSize() : int = self.GetSorobanInfo().Tx.MaxContractEventsSizeBytes
 
     member self.GetLedgerProtocolVersion() : int = self.GetInfo().Ledger.Version
 
@@ -505,6 +525,11 @@ type Peer with
         RetryUntilTrue
             (fun _ -> self.GetLedgerMaxInstructions() = n)
             (fun _ -> LogInfo "Waiting for LedgerMaxInstructions=%d on %s" n self.ShortName.StringName)
+
+    member self.WaitForTxMaxInstructions(n: int64) =
+        RetryUntilTrue
+            (fun _ -> self.GetTxMaxInstructions() = n)
+            (fun _ -> LogInfo "Waiting for TxMaxInstructions=%d on %s" n self.ShortName.StringName)
 
     member self.WaitForMaxTxSize(n: int) =
         RetryUntilTrue


### PR DESCRIPTION
Bigger network limits are needed to accommodate load produced by loadgen