### PR TITLE
Reduce load on mixed image mission for stability

### DIFF
--- a/src/FSLibrary/MissionMixedImageLoadGeneration.fs
+++ b/src/FSLibrary/MissionMixedImageLoadGeneration.fs
@@ -44,6 +44,7 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
             { CoreSetOptions.GetDefault oldImage with
                   nodeCount = oldNodeCount
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecks
+                  accelerateTime = false
                   dumpDatabase = false
                   quorumSet = qSet }
 
@@ -53,6 +54,7 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
             { CoreSetOptions.GetDefault newImage with
                   nodeCount = newNodeCount
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecks
+                  accelerateTime = false
                   dumpDatabase = false
                   quorumSet = qSet }
 
@@ -61,7 +63,7 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
               coreResources = MediumTestResources
               numAccounts = 20000
               numTxs = 50000
-              txRate = 1000
+              txRate = 250
               skipLowFeeTxs = true }
 
     // Put the version with majority of nodes in front of the set to let it generate
@@ -84,7 +86,7 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
                 formation.UpgradeMaxTxSetSize coreSets 1000
 
                 let loadgenCoreSet = coreSets.[0]
-                formation.RunLoadgen loadgenCoreSet context.GenerateAccountCreationLoad
+                formation.RunLoadgen loadgenCoreSet { context.GenerateAccountCreationLoad with txrate = 1 }
                 formation.RunLoadgen loadgenCoreSet context.GeneratePaymentLoad
 
                 let majorityPeer = formation.NetworkCfg.GetPeer loadgenCoreSet 0


### PR DESCRIPTION
Resolves #133 

The mission was failing because it was trying to submit too much load, and failing due to randomized fee being too low (we got a bit unfortunate). This change reduces the tx rate, but still ensures that we hit surge pricing mode every ledger (the purpose of this test).