### PR TITLE
Fix failures caused by client bump

### DIFF
--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -49,6 +49,8 @@ type StellarFormation with
                 match forbiddenEvent with
                 | Some (ev) -> ()
                 | None ->
+                    self.sleepUntilNextRateLimitedApiCallTime ()
+
                     let s =
                         self
                             .Kube


### PR DESCRIPTION
Encountered two different issues after https://github.com/stellar/supercluster/pull/126 was merged:
1. The change exposed a potential race condition in how we determine sts readiness. Previous implementation watched for new events from a stateful set to determine if sts is ready. The problem is that k8s only fires events for sts creation, not readiness. This means a situation where a creation event is consumed _before_ all pods became ready is possible, causing supercluster to get stuck and timeout. Relying on events is also quite error-prone, since by the time we attach an event watcher, it is possible we miss some events that already fired. Fix is to remove dependence on events altogether, and rely on a simple timer to check status instead. 
2. For some reason, tailing logs for all containers in large missions doesn't work. When running "Soroban Load Generation", it consistently gets stuck trying to tail logs for the `publicnode-1-network-delay` container. I'm not entirely sure what the root cause is (the client code doesn't provide any documentation or even a changelog), but reducing the number of containers to tail logs from helps. We don't really care about network-delay and history logs anyway, so I only kept logs from core. I also confirmed that the issue is not related to cluster rate limits or file descriptor limits. So it seems to be a bug in the client code.