### PR TITLE
Bump Kubernetes client

### DIFF
--- a/src/CSLibrary/CSLibrary.csproj
+++ b/src/CSLibrary/CSLibrary.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-   <PackageReference Include="KubernetesClient" Version="7.0.6" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    <PackageReference Include="KubernetesClient" Version="9.0.38" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="stellar-dotnet-sdk" Version="7.1.4" />

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -67,8 +67,9 @@
     <Compile Include="StellarMission.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="FSharp.Data" Version="4.1.1" />
-    <PackageReference Include="KubernetesClient" Version="7.0.6" />
+    <PackageReference Include="KubernetesClient" Version="9.0.38" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />


### PR DESCRIPTION
Bump client to version compatible with 1.25 - https://github.com/kubernetes-client/csharp?tab=readme-ov-file#version-compatibility/

7.0 is technically compatible with 1.23, 1.24, and 1.25 according to that link, but maybe this change will get rid of the intermittent api request errors we see in pubnet parallel catchup.