### PR TITLE
Use parallel catchup resources for testnet

### DIFF
--- a/src/FSLibrary/MissionHistoryTestnetParallelCatchup.fs
+++ b/src/FSLibrary/MissionHistoryTestnetParallelCatchup.fs
@@ -15,6 +15,8 @@ open StellarSupercluster
 open MissionCatchupHelpers
 
 let historyTestnetParallelCatchup (context: MissionContext) =
+    let context = { context with coreResources = ParallelCatchupResources }
+
     let checkpointsPerJob = 256
     let ledgersPerCheckpoint = 64
     let ledgersPerJob = checkpointsPerJob * ledgersPerCheckpoint


### PR DESCRIPTION
Small test has a  memory limit of 256kb, which isn't enough.