### PR TITLE
Add new max TPS mission with mixed classic/soroban traffic

### DIFF
--- a/doc/missions.md
+++ b/doc/missions.md
@@ -114,7 +114,7 @@ Simulate Public Network topology and throughput based on user-supplied distribut
 
 ## MissionSimulatePubnetTier1Perf
 
-Stress test a network of simulated Tier1 topology and report maximum achieved throughput.
+Stress test a network of simulated Tier1 topology with classic traffic and report maximum achieved throughput.
 
 ## MissionSorobanLoadGeneration
 
@@ -131,3 +131,7 @@ Test resource-intensive InvokeHostFunction operations on a small network of node
 ## MissionSorobanCatchupWithPrevAndCurr
 
 Test catchup to ledger state that spans multiple protocols supporting Soroban.
+
+## MissionMaxTPSMixed
+
+Stress test a network of simulated Tier1 topology with a mix of classic and soroban traffic and report maximum achieved throughput.

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -73,6 +73,20 @@ type MissionOptions
         flatQuorum: bool option,
         tier1Keys: string option,
         opCountDistribution: string option,
+        wasmBytesValues: seq<int>,
+        wasmBytesWeights: seq<int>,
+        dataEntriesValues: seq<int>,
+        dataEntriesWeights: seq<int>,
+        totalKiloBytesValues: seq<int>,
+        totalKilobytesWeights: seq<int>,
+        txSizeBytesValues: seq<int>,
+        txSizeBytesWeights: seq<int>,
+        instructionsValues: seq<int>,
+        instructionsWeights: seq<int>,
+        payWeight: int option,
+        sorobanUploadWeight: int option,
+        sorobanInvokeWeight: int option,
+        minSorobanPercentSuccess: int option,
         installNetworkDelay: bool option,
         flatNetworkDelay: int option,
         peerReadingCapacity: int option,
@@ -262,6 +276,70 @@ type MissionOptions
              Required = false)>]
     member self.OpCountDistribution = opCountDistribution
 
+    [<Option("wasm-bytes",
+             HelpText = "A space-separated list of sizes of wasm blobs for SOROBAN_UPLOAD and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_WASM_BYTES_FOR_TESTING)",
+             Required = false)>]
+    member self.WasmBytesValues = wasmBytesValues
+
+    [<Option("wasm-bytes-weights",
+             HelpText = "A space-separated indicating how often to select a certain size when generating wasms (See LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.WasmBytesWeights = wasmBytesWeights
+
+    [<Option("data-entries",
+             HelpText = "A space-separated list of number of data entries for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING)",
+             Required = false)>]
+    member self.DataEntriesValues = dataEntriesValues
+
+    [<Option("data-entries-weights",
+             HelpText = "A space-separated indicating how often to select a certain number of data entries when generating invoke transactions (See LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.DataEntriesWeights = dataEntriesWeights
+
+    [<Option("total-kilobytes",
+             HelpText = "A space-separated list of kilobytes of IO for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_IO_KILOBYTES_FOR_TESTING)",
+             Required = false)>]
+    member self.TotalKiloBytesValues = totalKiloBytesValues
+
+    [<Option("total-kilobytes-weights",
+             HelpText = "A space-separated indicating how often to select a certain number of kilobytes of IO when generating invoke transactions (See LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.TotalKiloBytesWeights = totalKilobytesWeights
+
+    [<Option("tx-size-bytes",
+             HelpText = "A space-separated list of transaction sizes for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_TX_SIZE_BYTES_FOR_TESTING)",
+             Required = false)>]
+    member self.TxSizeBytesValues = txSizeBytesValues
+
+    [<Option("tx-size-bytes-weights",
+             HelpText = "A space-separated indicating how often to select a certain transaction size when generating invoke transactions (See LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.TxSizeBytesWeights = txSizeBytesWeights
+
+    [<Option("instructions",
+             HelpText = "A space-separated list of instruction counts for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_TX_SIZE_BYTES_FOR_TESTING)",
+             Required = false)>]
+    member self.InstructionsValues = instructionsValues
+
+    [<Option("instructions-weights",
+             HelpText = "A space-separated indicating how often to select a certain instruction count when generating invoke transactions (See LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.InstructionsWeights = instructionsWeights
+
+    [<Option("pay-weight", HelpText = "Weight for classic transactions in MIX_CLASSIC_SOROBAN loadgen mode", Required = false)>]
+    member self.PayWeight = payWeight
+
+    [<Option("soroban-upload-weight", HelpText = "Weight for SOROBAN_UPLOAD transactions in MIX_CLASSIC_SOROBAN loadgen mode", Required = false)>]
+    member self.SorobanUploadWeight = sorobanUploadWeight
+
+    [<Option("soroban-invoke-weight", HelpText = "Weight for SOROBAN_INVOKE transactions in MIX_CLASSIC_SOROBAN loadgen mode", Required = false)>]
+    member self.SorobanInvokeWeight = sorobanInvokeWeight
+
+    [<Option("min-soroban-percent-success",
+             HelpText = "Minimum percentage of soroban transactions that must succeed at apply time in loadgen",
+             Required = false)>]
+    member self.MinSorobanPercentSuccess = minSorobanPercentSuccess
+
     [<Option("install-network-delay",
              HelpText = "Installs network delay estimated from node locations",
              Required = false)>]
@@ -426,6 +504,15 @@ let main argv =
                   flatQuorum = None
                   tier1Keys = None
                   opCountDistribution = None
+                  wasmBytesDistribution = []
+                  dataEntriesDistribution = []
+                  totalKiloBytesDistribution = []
+                  txSizeBytesDistribution = []
+                  instructionsDistribution = []
+                  payWeight = None
+                  sorobanUploadWeight = None
+                  sorobanInvokeWeight = None
+                  minSorobanPercentSuccess = None
                   installNetworkDelay = None
                   flatNetworkDelay = None
                   simulateApplyDuration = None
@@ -532,6 +619,15 @@ let main argv =
                                flatQuorum = mission.FlatQuorum
                                tier1Keys = mission.Tier1Keys
                                opCountDistribution = mission.OpCountDistribution
+                               wasmBytesDistribution = List.zip (List.ofSeq mission.WasmBytesValues) (List.ofSeq mission.WasmBytesWeights)
+                               dataEntriesDistribution = List.zip (List.ofSeq mission.DataEntriesValues) (List.ofSeq mission.DataEntriesWeights)
+                               totalKiloBytesDistribution = List.zip (List.ofSeq mission.TotalKiloBytesValues) (List.ofSeq mission.TotalKiloBytesWeights)
+                               txSizeBytesDistribution = List.zip (List.ofSeq mission.TxSizeBytesValues) (List.ofSeq mission.TxSizeBytesWeights)
+                               instructionsDistribution = List.zip (List.ofSeq mission.InstructionsValues) (List.ofSeq mission.InstructionsWeights)
+                               payWeight = mission.PayWeight
+                               sorobanUploadWeight = mission.SorobanUploadWeight
+                               sorobanInvokeWeight = mission.SorobanInvokeWeight
+                               minSorobanPercentSuccess = mission.MinSorobanPercentSuccess
                                installNetworkDelay = mission.InstallNetworkDelay
                                flatNetworkDelay = mission.FlatNetworkDelay
                                simulateApplyDuration = processInputSeq mission.SimulateApplyDuration

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -326,13 +326,19 @@ type MissionOptions
              Required = false)>]
     member self.InstructionsWeights = instructionsWeights
 
-    [<Option("pay-weight", HelpText = "Weight for classic transactions in MIX_CLASSIC_SOROBAN loadgen mode", Required = false)>]
+    [<Option("pay-weight",
+             HelpText = "Weight for classic transactions in MIX_CLASSIC_SOROBAN loadgen mode",
+             Required = false)>]
     member self.PayWeight = payWeight
 
-    [<Option("soroban-upload-weight", HelpText = "Weight for SOROBAN_UPLOAD transactions in MIX_CLASSIC_SOROBAN loadgen mode", Required = false)>]
+    [<Option("soroban-upload-weight",
+             HelpText = "Weight for SOROBAN_UPLOAD transactions in MIX_CLASSIC_SOROBAN loadgen mode",
+             Required = false)>]
     member self.SorobanUploadWeight = sorobanUploadWeight
 
-    [<Option("soroban-invoke-weight", HelpText = "Weight for SOROBAN_INVOKE transactions in MIX_CLASSIC_SOROBAN loadgen mode", Required = false)>]
+    [<Option("soroban-invoke-weight",
+             HelpText = "Weight for SOROBAN_INVOKE transactions in MIX_CLASSIC_SOROBAN loadgen mode",
+             Required = false)>]
     member self.SorobanInvokeWeight = sorobanInvokeWeight
 
     [<Option("min-soroban-percent-success",
@@ -619,11 +625,24 @@ let main argv =
                                flatQuorum = mission.FlatQuorum
                                tier1Keys = mission.Tier1Keys
                                opCountDistribution = mission.OpCountDistribution
-                               wasmBytesDistribution = List.zip (List.ofSeq mission.WasmBytesValues) (List.ofSeq mission.WasmBytesWeights)
-                               dataEntriesDistribution = List.zip (List.ofSeq mission.DataEntriesValues) (List.ofSeq mission.DataEntriesWeights)
-                               totalKiloBytesDistribution = List.zip (List.ofSeq mission.TotalKiloBytesValues) (List.ofSeq mission.TotalKiloBytesWeights)
-                               txSizeBytesDistribution = List.zip (List.ofSeq mission.TxSizeBytesValues) (List.ofSeq mission.TxSizeBytesWeights)
-                               instructionsDistribution = List.zip (List.ofSeq mission.InstructionsValues) (List.ofSeq mission.InstructionsWeights)
+                               wasmBytesDistribution =
+                                   List.zip (List.ofSeq mission.WasmBytesValues) (List.ofSeq mission.WasmBytesWeights)
+                               dataEntriesDistribution =
+                                   List.zip
+                                       (List.ofSeq mission.DataEntriesValues)
+                                       (List.ofSeq mission.DataEntriesWeights)
+                               totalKiloBytesDistribution =
+                                   List.zip
+                                       (List.ofSeq mission.TotalKiloBytesValues)
+                                       (List.ofSeq mission.TotalKiloBytesWeights)
+                               txSizeBytesDistribution =
+                                   List.zip
+                                       (List.ofSeq mission.TxSizeBytesValues)
+                                       (List.ofSeq mission.TxSizeBytesWeights)
+                               instructionsDistribution =
+                                   List.zip
+                                       (List.ofSeq mission.InstructionsValues)
+                                       (List.ofSeq mission.InstructionsWeights)
                                payWeight = mission.PayWeight
                                sorobanUploadWeight = mission.SorobanUploadWeight
                                sorobanInvokeWeight = mission.SorobanInvokeWeight

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -95,6 +95,15 @@ let ctx : MissionContext =
               __SOURCE_DIRECTORY__
               + "/../FSLibrary/csv-type-samples/sample-loadgen-op-count-distribution.csv"
           )
+      wasmBytesDistribution = []
+      dataEntriesDistribution = []
+      totalKiloBytesDistribution = []
+      txSizeBytesDistribution = []
+      instructionsDistribution = []
+      payWeight = None
+      sorobanUploadWeight = None
+      sorobanInvokeWeight = None
+      minSorobanPercentSuccess = None
       networkSizeLimit = 100
       tier1OrgsToAdd = 0
       nonTier1NodesToAdd = 0

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="StellarStatefulSets.fs" />
     <Compile Include="StellarJobExec.fs" />
     <Compile Include="StellarSupercluster.fs" />
+    <Compile Include="MaxTPSTest.fs" />
     <Compile Include="MissionCatchupHelpers.fs" />
     <Compile Include="MissionBootAndSync.fs" />
     <Compile Include="MissionSimplePayment.fs" />
@@ -64,6 +65,7 @@
     <Compile Include="MissionProtocolUpgradeWithLoad.fs" />
     <Compile Include="MissionDatabaseInplaceUpgrade.fs" />
     <Compile Include="MissionAcceptanceUnitTests.fs" />
+    <Compile Include="MissionMaxTPSMixed.fs" />
     <Compile Include="StellarMission.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FSLibrary/MaxTPSTest.fs
+++ b/src/FSLibrary/MaxTPSTest.fs
@@ -1,0 +1,139 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+module MaxTPSTest
+
+// This module provides a configurable max TPS test to use in missions
+
+open Logging
+open StellarCoreHTTP
+open StellarCoreSet
+open StellarFormation
+open StellarMissionContext
+open StellarNetworkData
+open StellarStatefulSets
+open StellarSupercluster
+
+let maxTPSTest (context: MissionContext)
+               (baseLoadGen: LoadGen)
+               (setupCfg: LoadGen option)
+               (increaseSorobanLimits: bool) =
+    let allNodes =
+        if context.pubnetData.IsSome then
+            FullPubnetCoreSets context true false
+        else
+            StableApproximateTier1CoreSets
+                context.image
+                (if context.flatQuorum.IsSome then context.flatQuorum.Value else false)
+
+    let sdf =
+        List.find (fun (cs: CoreSet) -> cs.name.StringName = "stellar" || cs.name.StringName = "sdf") allNodes
+
+    let tier1 = List.filter (fun (cs: CoreSet) -> cs.options.tier1 = Some true) allNodes
+
+    context.ExecuteWithOptionalConsistencyCheck
+        allNodes
+        None
+        false
+        (fun (formation: StellarFormation) ->
+
+            let numAccounts = 30000
+
+            let upgradeMaxTxSetSize (coreSets: CoreSet list) (rate: int) =
+                // Set max tx size to 10x the rate -- at 5x we overflow the transaction queue too often.
+                formation.UpgradeMaxTxSetSize coreSets (10 * rate)
+
+            // Setup overlay connections first before manually closing
+            // ledger, which kick off consensus
+            formation.WaitUntilConnected allNodes
+            formation.ManualClose allNodes
+
+            // Wait until the whole network is synced before proceeding,
+            // to fail asap in case of a misconfiguration
+            formation.WaitUntilSynced allNodes
+            formation.UpgradeProtocolToLatest allNodes
+            upgradeMaxTxSetSize allNodes 10000
+            formation.RunLoadgen sdf { context.GenerateAccountCreationLoad with accounts = numAccounts }
+
+            // Upgrade limits (if requested)
+            if increaseSorobanLimits then
+                formation.UpgradeSorobanLedgerLimitsWithMultiplier allNodes 1000
+                formation.UpgradeSorobanTxLimitsWithMultiplier allNodes 100
+
+            // Perform setup (if requested)
+            match setupCfg with
+            | Some cfg -> formation.RunLoadgen sdf cfg
+            | None -> ()
+
+            let wait () = System.Threading.Thread.Sleep(30 * 1000)
+
+            let getMiddle (low: int) (high: int) = low + (high - low) / 2
+
+            let binarySearchWithThreshold (low: int) (high: int) (threshold: int) =
+
+                let mutable lowerBound = low
+                let mutable upperBound = high
+                let mutable shouldWait = false
+                let mutable finalTxRate = None
+
+                while upperBound - lowerBound > threshold do
+                    let middle = getMiddle lowerBound upperBound
+
+                    if shouldWait then wait ()
+
+                    formation.clearMetrics allNodes
+                    upgradeMaxTxSetSize allNodes middle
+
+                    try
+                        LogInfo "Run started at tx rate %i" middle
+
+                        let loadGen =
+                            { baseLoadGen with
+                                  accounts = numAccounts
+                                  // Roughly 15 min of load
+                                  txs = middle * 1000
+                                  txrate = middle
+                            }
+
+                        formation.RunMultiLoadgen tier1 loadGen
+                        formation.CheckNoErrorsAndPairwiseConsistency()
+                        formation.EnsureAllNodesInSync allNodes
+
+                        // Increase the tx rate
+                        lowerBound <- middle
+                        finalTxRate <- Some middle
+                        LogInfo "Run succeeded at tx rate %i" middle
+                        shouldWait <- false
+
+                    with _ ->
+                        LogInfo "Run failed at tx rate %i" middle
+                        upperBound <- middle
+                        shouldWait <- true
+
+                if finalTxRate.IsSome then
+                    LogInfo "Found max tx rate %i" finalTxRate.Value
+
+                    if context.maxTxRate - finalTxRate.Value <= threshold then
+                        LogInfo "Tx rate reached the upper bound, increase max-tx-rate for more accurate results"
+                else
+                    failwith (sprintf "No successful runs at tx rate %i or higher" lowerBound)
+
+                finalTxRate.Value
+
+            let mutable results = []
+            // As the runs take a while, set a threshold of 10, so we get a reasonable approximation
+            let threshold = 10
+            let numRuns = (if context.numRuns.IsSome then context.numRuns.Value else 3)
+
+            for run in 1 .. numRuns do
+                LogInfo "Starting max TPS run %i out of %i" run numRuns
+                let resultRate = binarySearchWithThreshold context.txRate context.maxTxRate threshold
+                results <- List.append results [ resultRate ]
+                if run < numRuns then wait ()
+
+            LogInfo
+                "Final tx rate averaged to %i over %i runs for image %s"
+                (results |> List.map float |> List.average |> int)
+                numRuns
+                context.image)

--- a/src/FSLibrary/MaxTPSTest.fs
+++ b/src/FSLibrary/MaxTPSTest.fs
@@ -15,10 +15,12 @@ open StellarNetworkData
 open StellarStatefulSets
 open StellarSupercluster
 
-let maxTPSTest (context: MissionContext)
-               (baseLoadGen: LoadGen)
-               (setupCfg: LoadGen option)
-               (increaseSorobanLimits: bool) =
+let maxTPSTest
+    (context: MissionContext)
+    (baseLoadGen: LoadGen)
+    (setupCfg: LoadGen option)
+    (increaseSorobanLimits: bool)
+    =
     let allNodes =
         if context.pubnetData.IsSome then
             FullPubnetCoreSets context true false
@@ -93,8 +95,7 @@ let maxTPSTest (context: MissionContext)
                                   accounts = numAccounts
                                   // Roughly 15 min of load
                                   txs = middle * 1000
-                                  txrate = middle
-                            }
+                                  txrate = middle }
 
                         formation.RunMultiLoadgen tier1 loadGen
                         formation.CheckNoErrorsAndPairwiseConsistency()

--- a/src/FSLibrary/MissionHistoryGenerateAndCatchup.fs
+++ b/src/FSLibrary/MissionHistoryGenerateAndCatchup.fs
@@ -15,7 +15,7 @@ open StellarSupercluster
 let sorobanProtocolVersion = 20
 
 let historyGenerateAndCatchup (context: MissionContext) =
-    let context = context.WithNominalLoad
+    let context = context.WithNominalLoad.WithSmallLoadgenOptions
     let image = context.image
     let catchupOptions = { generatorImage = image; catchupImage = image; versionImage = image }
     let catchupSets = MakeRecentCatchupSet catchupOptions

--- a/src/FSLibrary/MissionInMemoryMode.fs
+++ b/src/FSLibrary/MissionInMemoryMode.fs
@@ -26,7 +26,11 @@ let runInMemoryMode (context: MissionContext) =
                   localHistory = false
                   quorumSet = CoreSetQuorum(CoreSetName "core") }
 
-    let context = { context.WithSmallLoadgenOptions with numAccounts = 100; numTxs = 100; txRate = 20 }
+    let context =
+        { context.WithSmallLoadgenOptions with
+              numAccounts = 100
+              numTxs = 100
+              txRate = 20 }
 
     context.Execute
         [ coreSet; coreSetWithCaptiveCore ]

--- a/src/FSLibrary/MissionInMemoryMode.fs
+++ b/src/FSLibrary/MissionInMemoryMode.fs
@@ -26,7 +26,7 @@ let runInMemoryMode (context: MissionContext) =
                   localHistory = false
                   quorumSet = CoreSetQuorum(CoreSetName "core") }
 
-    let context = { context with numAccounts = 100; numTxs = 100; txRate = 20 }
+    let context = { context.WithSmallLoadgenOptions with numAccounts = 100; numTxs = 100; txRate = 20 }
 
     context.Execute
         [ coreSet; coreSetWithCaptiveCore ]

--- a/src/FSLibrary/MissionLoadGenerationWithTxSetLimit.fs
+++ b/src/FSLibrary/MissionLoadGenerationWithTxSetLimit.fs
@@ -20,7 +20,7 @@ let loadGenerationWithTxSetLimit (context: MissionContext) =
                   dumpDatabase = false }
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               coreResources = MediumTestResources
               numAccounts = 20000
               numTxs = 50000

--- a/src/FSLibrary/MissionMaxTPSMixed.fs
+++ b/src/FSLibrary/MissionMaxTPSMixed.fs
@@ -1,0 +1,53 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+module MissionMaxTPSMixed
+
+// This module provides a max TPS test with a blend of classic and Soroban load.
+// It uses the MaxTPSTest module to perform a binary search for the max TPS.
+
+open MaxTPSTest
+open StellarMissionContext
+open StellarCoreHTTP
+
+let maxTPSMixed (baseContext: MissionContext) =
+    let context =
+        { baseContext with
+              coreResources = SimulatePubnetTier1PerfResources
+              installNetworkDelay = Some(baseContext.installNetworkDelay |> Option.defaultValue true)
+              // No additional DB overhead unless specified (this will measure the in-memory SQLite DB only)
+              simulateApplyDuration = Some(baseContext.simulateApplyDuration |> Option.defaultValue (seq { 0 }))
+              simulateApplyWeight = Some(baseContext.simulateApplyWeight |> Option.defaultValue (seq { 100 }))
+              enableTailLogging = false
+              // Setup distributions based on testnet data
+              wasmBytesDistribution = [(8*1024, 132); (24*1024, 68); (40*1024, 92); (56*1024, 141)]
+              dataEntriesDistribution = [(3, 380); (9, 42); (15, 5); (21, 2)]
+              totalKiloBytesDistribution = [(1, 409); (3, 18); (5, 2)]
+              txSizeBytesDistribution = [(200, 37); (400, 6); (600, 1); (800, 4); (1000, 1)]
+              instructionsDistribution = [(12500000, 201); (37500000, 183); (62500000, 34); (87500000, 11)]
+        }
+
+    let baseLoadGen =
+        { LoadGen.GetDefault() with
+                mode = MixedClassicSoroban
+                spikesize = context.spikeSize
+                spikeinterval = context.spikeInterval
+                offset = 0
+                maxfeerate = None
+                skiplowfeetxs = false
+
+                wasms = context.numWasms
+                instances = context.numInstances
+
+                // Blend settings. 50% classic, 5% upload, 45% invoke by default
+                payWeight = Some (baseContext.payWeight |> Option.defaultValue 50)
+                sorobanUploadWeight = Some (baseContext.sorobanUploadWeight |> Option.defaultValue 5)
+                sorobanInvokeWeight = Some (baseContext.sorobanInvokeWeight |> Option.defaultValue 45)
+
+                // Require 80% of Soroban transactions to successfully apply by
+                // default
+                minSorobanPercentSuccess = Some (baseContext.minSorobanPercentSuccess |> Option.defaultValue 80)
+        }
+
+    maxTPSTest context baseLoadGen (Some context.SetupSorobanInvoke) true

--- a/src/FSLibrary/MissionMaxTPSMixed.fs
+++ b/src/FSLibrary/MissionMaxTPSMixed.fs
@@ -21,33 +21,31 @@ let maxTPSMixed (baseContext: MissionContext) =
               simulateApplyWeight = Some(baseContext.simulateApplyWeight |> Option.defaultValue (seq { 100 }))
               enableTailLogging = false
               // Setup distributions based on testnet data
-              wasmBytesDistribution = [(8*1024, 132); (24*1024, 68); (40*1024, 92); (56*1024, 141)]
-              dataEntriesDistribution = [(3, 380); (9, 42); (15, 5); (21, 2)]
-              totalKiloBytesDistribution = [(1, 409); (3, 18); (5, 2)]
-              txSizeBytesDistribution = [(200, 37); (400, 6); (600, 1); (800, 4); (1000, 1)]
-              instructionsDistribution = [(12500000, 201); (37500000, 183); (62500000, 34); (87500000, 11)]
-        }
+              wasmBytesDistribution = [ (8 * 1024, 132); (24 * 1024, 68); (40 * 1024, 92); (56 * 1024, 141) ]
+              dataEntriesDistribution = [ (3, 380); (9, 42); (15, 5); (21, 2) ]
+              totalKiloBytesDistribution = [ (1, 409); (3, 18); (5, 2) ]
+              txSizeBytesDistribution = [ (200, 37); (400, 6); (600, 1); (800, 4); (1000, 1) ]
+              instructionsDistribution = [ (12500000, 201); (37500000, 183); (62500000, 34); (87500000, 11) ] }
 
     let baseLoadGen =
         { LoadGen.GetDefault() with
-                mode = MixedClassicSoroban
-                spikesize = context.spikeSize
-                spikeinterval = context.spikeInterval
-                offset = 0
-                maxfeerate = None
-                skiplowfeetxs = false
+              mode = MixedClassicSoroban
+              spikesize = context.spikeSize
+              spikeinterval = context.spikeInterval
+              offset = 0
+              maxfeerate = None
+              skiplowfeetxs = false
 
-                wasms = context.numWasms
-                instances = context.numInstances
+              wasms = context.numWasms
+              instances = context.numInstances
 
-                // Blend settings. 50% classic, 5% upload, 45% invoke by default
-                payWeight = Some (baseContext.payWeight |> Option.defaultValue 50)
-                sorobanUploadWeight = Some (baseContext.sorobanUploadWeight |> Option.defaultValue 5)
-                sorobanInvokeWeight = Some (baseContext.sorobanInvokeWeight |> Option.defaultValue 45)
+              // Blend settings. 50% classic, 5% upload, 45% invoke by default
+              payWeight = Some(baseContext.payWeight |> Option.defaultValue 50)
+              sorobanUploadWeight = Some(baseContext.sorobanUploadWeight |> Option.defaultValue 5)
+              sorobanInvokeWeight = Some(baseContext.sorobanInvokeWeight |> Option.defaultValue 45)
 
-                // Require 80% of Soroban transactions to successfully apply by
-                // default
-                minSorobanPercentSuccess = Some (baseContext.minSorobanPercentSuccess |> Option.defaultValue 80)
-        }
+              // Require 80% of Soroban transactions to successfully apply by
+              // default
+              minSorobanPercentSuccess = Some(baseContext.minSorobanPercentSuccess |> Option.defaultValue 80) }
 
     maxTPSTest context baseLoadGen (Some context.SetupSorobanInvoke) true

--- a/src/FSLibrary/MissionMixedImageLoadGeneration.fs
+++ b/src/FSLibrary/MissionMixedImageLoadGeneration.fs
@@ -59,7 +59,7 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
                   quorumSet = qSet }
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               coreResources = MediumTestResources
               numAccounts = 20000
               numTxs = 50000

--- a/src/FSLibrary/MissionProtocolUpgradeWithLoad.fs
+++ b/src/FSLibrary/MissionProtocolUpgradeWithLoad.fs
@@ -21,7 +21,7 @@ let protocolUpgradeWithLoad (context: MissionContext) =
                   dumpDatabase = false }
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               coreResources = UpgradeResources
               numAccounts = 20000
               numTxs = 50000

--- a/src/FSLibrary/MissionSimulatePubnetTier1Perf.fs
+++ b/src/FSLibrary/MissionSimulatePubnetTier1Perf.fs
@@ -23,11 +23,11 @@ let simulatePubnetTier1Perf (context: MissionContext) =
 
     let baseLoadGen =
         { LoadGen.GetDefault() with
-                mode = GeneratePaymentLoad
-                spikesize = context.spikeSize
-                spikeinterval = context.spikeInterval
-                offset = 0
-                maxfeerate = None
-                skiplowfeetxs = false }
+              mode = GeneratePaymentLoad
+              spikesize = context.spikeSize
+              spikeinterval = context.spikeInterval
+              offset = 0
+              maxfeerate = None
+              skiplowfeetxs = false }
 
     maxTPSTest context baseLoadGen None false

--- a/src/FSLibrary/MissionSimulatePubnetTier1Perf.fs
+++ b/src/FSLibrary/MissionSimulatePubnetTier1Perf.fs
@@ -7,14 +7,9 @@ module MissionSimulatePubnetTier1Perf
 // The point of this mission is to simulate the tier1 group of pubnet
 // for purposes of repeatable / comparable performance evaluation.
 
-open StellarCoreSet
+open MaxTPSTest
 open StellarMissionContext
-open StellarFormation
-open StellarStatefulSets
-open StellarNetworkData
-open StellarSupercluster
 open StellarCoreHTTP
-open Logging
 
 let simulatePubnetTier1Perf (context: MissionContext) =
     let context =
@@ -26,116 +21,13 @@ let simulatePubnetTier1Perf (context: MissionContext) =
               simulateApplyWeight = Some(context.simulateApplyWeight |> Option.defaultValue (seq { 100 }))
               enableTailLogging = false }
 
-    let allNodes =
-        if context.pubnetData.IsSome then
-            FullPubnetCoreSets context true false
-        else
-            StableApproximateTier1CoreSets
-                context.image
-                (if context.flatQuorum.IsSome then context.flatQuorum.Value else false)
+    let baseLoadGen =
+        { LoadGen.GetDefault() with
+                mode = GeneratePaymentLoad
+                spikesize = context.spikeSize
+                spikeinterval = context.spikeInterval
+                offset = 0
+                maxfeerate = None
+                skiplowfeetxs = false }
 
-    let sdf =
-        List.find (fun (cs: CoreSet) -> cs.name.StringName = "stellar" || cs.name.StringName = "sdf") allNodes
-
-    let tier1 = List.filter (fun (cs: CoreSet) -> cs.options.tier1 = Some true) allNodes
-
-    context.ExecuteWithOptionalConsistencyCheck
-        allNodes
-        None
-        false
-        (fun (formation: StellarFormation) ->
-
-            let numAccounts = 30000
-
-            let upgradeMaxTxSetSize (coreSets: CoreSet list) (rate: int) =
-                // Set max tx size to 10x the rate -- at 5x we overflow the transaction queue too often.
-                formation.UpgradeMaxTxSetSize coreSets (10 * rate)
-
-            // Setup overlay connections first before manually closing
-            // ledger, which kick off consensus
-            formation.WaitUntilConnected allNodes
-            formation.ManualClose allNodes
-
-            // Wait until the whole network is synced before proceeding,
-            // to fail asap in case of a misconfiguration
-            formation.WaitUntilSynced allNodes
-            formation.UpgradeProtocolToLatest allNodes
-            upgradeMaxTxSetSize allNodes 10000
-            formation.RunLoadgen sdf { context.GenerateAccountCreationLoad with accounts = numAccounts }
-
-            let wait () = System.Threading.Thread.Sleep(5 * 60 * 1000)
-
-            let getMiddle (low: int) (high: int) = low + (high - low) / 2
-
-            let binarySearchWithThreshold (low: int) (high: int) (threshold: int) =
-
-                let mutable lowerBound = low
-                let mutable upperBound = high
-                let mutable shouldWait = false
-                let mutable finalTxRate = None
-
-                while upperBound - lowerBound > threshold do
-                    let middle = getMiddle lowerBound upperBound
-
-                    if shouldWait then wait ()
-
-                    formation.clearMetrics allNodes
-                    upgradeMaxTxSetSize allNodes middle
-
-                    try
-                        LogInfo "Run started at tx rate %i" middle
-
-                        let loadGen =
-                            { LoadGen.GetDefault() with
-                                  mode = GeneratePaymentLoad
-                                  accounts = numAccounts
-                                  // Roughly 15 min of load
-                                  txs = middle * 1000
-                                  spikesize = context.spikeSize
-                                  spikeinterval = context.spikeInterval
-                                  txrate = middle
-                                  offset = 0
-                                  maxfeerate = None
-                                  skiplowfeetxs = false }
-
-                        formation.RunMultiLoadgen tier1 loadGen
-                        formation.CheckNoErrorsAndPairwiseConsistency()
-                        formation.EnsureAllNodesInSync allNodes
-
-                        // Increase the tx rate
-                        lowerBound <- middle
-                        finalTxRate <- Some middle
-                        LogInfo "Run succeeded at tx rate %i" middle
-                        shouldWait <- false
-
-                    with _ ->
-                        LogInfo "Run failed at tx rate %i" middle
-                        upperBound <- middle
-                        shouldWait <- true
-
-                if finalTxRate.IsSome then
-                    LogInfo "Found max tx rate %i" finalTxRate.Value
-
-                    if context.maxTxRate - finalTxRate.Value <= threshold then
-                        LogInfo "Tx rate reached the upper bound, increase max-tx-rate for more accurate results"
-                else
-                    failwith (sprintf "No successful runs at tx rate %i or higher" lowerBound)
-
-                finalTxRate.Value
-
-            let mutable results = []
-            // As the runs take a while, set a threshold of 10, so we get a reasonbale approximation
-            let threshold = 10
-            let numRuns = (if context.numRuns.IsSome then context.numRuns.Value else 3)
-
-            for run in 1 .. numRuns do
-                LogInfo "Starting max TPS run %i out of %i" run numRuns
-                let resultRate = binarySearchWithThreshold context.txRate context.maxTxRate threshold
-                results <- List.append results [ resultRate ]
-                if run < numRuns then wait ()
-
-            LogInfo
-                "Final tx rate averaged to %i over %i runs for image %s"
-                (results |> List.map float |> List.average |> int)
-                numRuns
-                context.image)
+    maxTPSTest context baseLoadGen None false

--- a/src/FSLibrary/MissionSorobanCatchupWithPrevAndCurr.fs
+++ b/src/FSLibrary/MissionSorobanCatchupWithPrevAndCurr.fs
@@ -33,7 +33,7 @@ let sorobanCatchupWithPrevAndCurr (context: MissionContext) =
                   catchupMode = CatchupComplete }
 
     let context =
-        { context with
+        { context.WithMediumLoadgenOptions with
               numAccounts = 100
               numTxs = 100
               txRate = 1

--- a/src/FSLibrary/MissionSorobanConfigUpgrades.fs
+++ b/src/FSLibrary/MissionSorobanConfigUpgrades.fs
@@ -29,7 +29,7 @@ let sorobanConfigUpgrades (context: MissionContext) =
                   nodeCount = 5 }
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               numAccounts = 100
               numTxs = 100
               txRate = 1

--- a/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
+++ b/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
@@ -10,7 +10,6 @@ open StellarFormation
 open StellarStatefulSets
 open StellarSupercluster
 open StellarCoreHTTP
-open StellarCorePeer
 
 let sorobanInvokeHostLoad (context: MissionContext) =
     let coreSet =
@@ -21,7 +20,7 @@ let sorobanInvokeHostLoad (context: MissionContext) =
                   emptyDirType = DiskBackedEmptyDir }
 
     let context =
-        { context with
+        { context.WithMediumLoadgenOptions with
               numAccounts = 100
               numTxs = 100
               txRate = 1

--- a/src/FSLibrary/MissionSorobanLoadGeneration.fs
+++ b/src/FSLibrary/MissionSorobanLoadGeneration.fs
@@ -17,7 +17,7 @@ let sorobanLoadGeneration (context: MissionContext) =
     let rate = 5
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               coreResources = SimulatePubnetTier1PerfResources
               installNetworkDelay = Some(context.installNetworkDelay |> Option.defaultValue true)
               txRate = rate

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -123,12 +123,12 @@ type Distribution =
     CsvProvider<"csv-type-samples/sample-loadgen-op-count-distribution.csv", HasHeaders=true, ResolutionFolder=cwd>
 
 // Add a loadgen distribution to a TOML table.
-let distributionToToml (d : (int * int) list) (name : string) (t : TomlTable) : unit =
+let distributionToToml (d: (int * int) list) (name: string) (t: TomlTable) : unit =
     match d with
     | [] -> ()
     | _ ->
         let values = List.map fst d
-        let weights= List.map snd d
+        let weights = List.map snd d
 
         t.Add("LOADGEN_" + name + "_FOR_TESTING", values) |> ignore
         t.Add("LOADGEN_" + name + "_DISTRIBUTION_FOR_TESTING", weights) |> ignore

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -122,6 +122,17 @@ let cwd = __SOURCE_DIRECTORY__
 type Distribution =
     CsvProvider<"csv-type-samples/sample-loadgen-op-count-distribution.csv", HasHeaders=true, ResolutionFolder=cwd>
 
+// Add a loadgen distribution to a TOML table.
+let distributionToToml (d : (int * int) list) (name : string) (t : TomlTable) : unit =
+    match d with
+    | [] -> ()
+    | _ ->
+        let values = List.map fst d
+        let weights= List.map snd d
+
+        t.Add("LOADGEN_" + name + "_FOR_TESTING", values) |> ignore
+        t.Add("LOADGEN_" + name + "_DISTRIBUTION_FOR_TESTING", weights) |> ignore
+
 // Represents the contents of a stellar-core.cfg file, along with method to
 // write it out to TOML.
 type StellarCoreCfg =
@@ -274,6 +285,12 @@ type StellarCoreCfg =
 
             t.Add("LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING", distribution |> Seq.map snd)
             |> ignore
+
+        distributionToToml self.network.missionContext.wasmBytesDistribution "WASM_BYTES" t
+        distributionToToml self.network.missionContext.dataEntriesDistribution "NUM_DATA_ENTRIES" t
+        distributionToToml self.network.missionContext.totalKiloBytesDistribution "IO_KILOBYTES" t
+        distributionToToml self.network.missionContext.txSizeBytesDistribution "TX_SIZE_BYTES" t
+        distributionToToml self.network.missionContext.instructionsDistribution "INSTRUCTIONS" t
 
         t.Add("TARGET_PEER_CONNECTIONS", self.targetPeerConnections) |> ignore
 

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -105,8 +105,7 @@ type LoadGen =
       // Fields for BLEND_CLASSIC_SOROBAN mode
       payWeight: int option
       sorobanUploadWeight: int option
-      sorobanInvokeWeight: int option
-      }
+      sorobanInvokeWeight: int option }
 
     member self.ToQuery : (string * string) list =
         let mandatoryParams =
@@ -126,33 +125,37 @@ type LoadGen =
 
         let optionalParams =
             optionalParam "maxfeerate" self.maxfeerate
-          @ optionalParam "wasms" self.wasms
-          @ optionalParam "instances" self.instances
-          @ optionalParam "minpercentsuccess" self.minSorobanPercentSuccess
-          @ optionalParam "mxcntrctsz" self.maxContractSizeBytes
-          @ optionalParam "mxcntrctkeysz" self.maxContractDataKeySizeBytes
-          @ optionalParam "mxcntrctdatasz" self.maxContractDataEntrySizeBytes
-          @ optionalParam "ldgrmxinstrc" self.ledgerMaxInstructions
-          @ optionalParam "txmxinstrc" self.txMaxInstructions
-          @ optionalParam "txmemlim" self.txMemoryLimit
-          @ optionalParam "ldgrmxrdntry" self.ledgerMaxReadLedgerEntries
-          @ optionalParam "ldgrmxrdbyt" self.ledgerMaxReadBytes
-          @ optionalParam "ldgrmxwrntry" self.ledgerMaxWriteLedgerEntries
-          @ optionalParam "ldgrmxwrbyt" self.ledgerMaxWriteBytes
-          @ optionalParam "ldgrmxtxcnt" self.ledgerMaxTxCount
-          @ optionalParam "txmxrdntry" self.txMaxReadLedgerEntries
-          @ optionalParam "txmxrdbyt" self.txMaxReadBytes
-          @ optionalParam "txmxwrntry" self.txMaxWriteLedgerEntries
-          @ optionalParam "txmxwrbyt" self.txMaxWriteBytes
-          @ optionalParam "txmxevntsz" self.txMaxContractEventsSizeBytes
-          @ optionalParam "ldgrmxtxsz" self.ledgerMaxTransactionsSizeBytes
-          @ optionalParam "txmxsz" self.txMaxSizeBytes
-          @ optionalParam "wndowsz" self.bucketListSizeWindowSampleSize
-          @ optionalParam "evctsz" self.evictionScanSize
-          @ optionalParam "evctlvl" self.startingEvictionScanLevel
-          @ optionalParam "payweight" self.payWeight
-          @ optionalParam "sorobanuploadweight" self.sorobanUploadWeight
-          @ optionalParam "sorobaninvokeweight" self.sorobanInvokeWeight
+            @ optionalParam "wasms" self.wasms
+              @ optionalParam "instances" self.instances
+                @ optionalParam "minpercentsuccess" self.minSorobanPercentSuccess
+                  @ optionalParam "mxcntrctsz" self.maxContractSizeBytes
+                    @ optionalParam "mxcntrctkeysz" self.maxContractDataKeySizeBytes
+                      @ optionalParam "mxcntrctdatasz" self.maxContractDataEntrySizeBytes
+                        @ optionalParam "ldgrmxinstrc" self.ledgerMaxInstructions
+                          @ optionalParam "txmxinstrc" self.txMaxInstructions
+                            @ optionalParam "txmemlim" self.txMemoryLimit
+                              @ optionalParam "ldgrmxrdntry" self.ledgerMaxReadLedgerEntries
+                                @ optionalParam "ldgrmxrdbyt" self.ledgerMaxReadBytes
+                                  @ optionalParam "ldgrmxwrntry" self.ledgerMaxWriteLedgerEntries
+                                    @ optionalParam "ldgrmxwrbyt" self.ledgerMaxWriteBytes
+                                      @ optionalParam "ldgrmxtxcnt" self.ledgerMaxTxCount
+                                        @ optionalParam "txmxrdntry" self.txMaxReadLedgerEntries
+                                          @ optionalParam "txmxrdbyt" self.txMaxReadBytes
+                                            @ optionalParam "txmxwrntry" self.txMaxWriteLedgerEntries
+                                              @ optionalParam "txmxwrbyt" self.txMaxWriteBytes
+                                                @ optionalParam "txmxevntsz" self.txMaxContractEventsSizeBytes
+                                                  @ optionalParam "ldgrmxtxsz" self.ledgerMaxTransactionsSizeBytes
+                                                    @ optionalParam "txmxsz" self.txMaxSizeBytes
+                                                      @ optionalParam "wndowsz" self.bucketListSizeWindowSampleSize
+                                                        @ optionalParam "evctsz" self.evictionScanSize
+                                                          @ optionalParam "evctlvl" self.startingEvictionScanLevel
+                                                            @ optionalParam "payweight" self.payWeight
+                                                              @ optionalParam
+                                                                  "sorobanuploadweight"
+                                                                  self.sorobanUploadWeight
+                                                                @ optionalParam
+                                                                    "sorobaninvokeweight"
+                                                                    self.sorobanInvokeWeight
 
         mandatoryParams @ optionalParams
 
@@ -192,12 +195,11 @@ type LoadGen =
           startingEvictionScanLevel = None
           payWeight = None
           sorobanUploadWeight = None
-          sorobanInvokeWeight = None
-        }
+          sorobanInvokeWeight = None }
 
 // Takes a default value `v` and a list `l` and returns `v` if `l` is empty,
 // otherwise `l`.
-let defaultList (v : 'a list) (l : 'a list) =
+let defaultList (v: 'a list) (l: 'a list) =
     match l with
     | [] -> v
     | _ -> l
@@ -209,23 +211,21 @@ type MissionContext with
     // For loadgen missions that increase soroban ledger and transaction limits.
     member self.WithMediumLoadgenOptions : MissionContext =
         { self with
-              wasmBytesDistribution = [(30000, 1)]
-              dataEntriesDistribution = [(5, 1)]
-              totalKiloBytesDistribution = [(3, 1)]
-              txSizeBytesDistribution = [(512, 1)]
-              instructionsDistribution = [(25000000, 1)]
-        }
+              wasmBytesDistribution = [ (30000, 1) ]
+              dataEntriesDistribution = [ (5, 1) ]
+              totalKiloBytesDistribution = [ (3, 1) ]
+              txSizeBytesDistribution = [ (512, 1) ]
+              instructionsDistribution = [ (25000000, 1) ] }
 
     // For loadgen missions that do not increase both soroban ledger and
     // transaction limits. These are intended to fit within the default limits.
     member self.WithSmallLoadgenOptions : MissionContext =
         { self with
-              wasmBytesDistribution = [(1024, 1)]
-              dataEntriesDistribution = [(1, 1)]
-              totalKiloBytesDistribution = [(1, 1)]
-              txSizeBytesDistribution = [(64, 1)]
-              instructionsDistribution = [(1000000, 1)]
-        }
+              wasmBytesDistribution = [ (1024, 1) ]
+              dataEntriesDistribution = [ (1, 1) ]
+              totalKiloBytesDistribution = [ (1, 1) ]
+              txSizeBytesDistribution = [ (64, 1) ]
+              instructionsDistribution = [ (1000000, 1) ] }
 
     member self.GenerateAccountCreationLoad : LoadGen =
         { LoadGen.GetDefault() with

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -49,6 +49,7 @@ type LoadGenMode =
     | CreateSorobanUpgrade
     | SorobanInvokeSetup
     | SorobanInvoke
+    | MixedClassicSoroban
 
     override self.ToString() =
         match self with
@@ -60,6 +61,7 @@ type LoadGenMode =
         | CreateSorobanUpgrade -> "create_upgrade"
         | SorobanInvokeSetup -> "soroban_invoke_setup"
         | SorobanInvoke -> "soroban_invoke"
+        | MixedClassicSoroban -> "mixed_classic_soroban"
 
 type LoadGen =
     { mode: LoadGenMode
@@ -71,18 +73,11 @@ type LoadGen =
       offset: int
       maxfeerate: int option
       skiplowfeetxs: bool
+      minSorobanPercentSuccess: int option
 
       // New fields for SOROBAN_INVOKE mode
       wasms: int option
       instances: int option
-      dataEntriesLow: int option
-      dataEntriesHigh: int option
-      kiloBytesPerDataEntryLow: int option
-      kiloBytesPerDataEntryHigh: int option
-      txSizeBytesLow: int option
-      txSizeBytesHigh: int option
-      instructionsLow: int64 option
-      instructionsHigh: int64 option
 
       // Fields for SOROBAN_CREATE_UPGRADE parameters
       maxContractSizeBytes: int option
@@ -105,7 +100,13 @@ type LoadGen =
       txMaxSizeBytes: int option
       bucketListSizeWindowSampleSize: int option
       evictionScanSize: int64 option
-      startingEvictionScanLevel: int option }
+      startingEvictionScanLevel: int option
+
+      // Fields for BLEND_CLASSIC_SOROBAN mode
+      payWeight: int option
+      sorobanUploadWeight: int option
+      sorobanInvokeWeight: int option
+      }
 
     member self.ToQuery : (string * string) list =
         let mandatoryParams =
@@ -125,45 +126,33 @@ type LoadGen =
 
         let optionalParams =
             optionalParam "maxfeerate" self.maxfeerate
-            @ optionalParam "wasms" self.wasms
-              @ optionalParam "instances" self.instances
-                @ optionalParam "dataentrieslow" self.dataEntriesLow
-                  @ optionalParam "dataentrieshigh" self.dataEntriesHigh
-                    @ optionalParam "kilobyteslow" self.kiloBytesPerDataEntryLow
-                      @ optionalParam "kilobyteshigh" self.kiloBytesPerDataEntryHigh
-                        @ optionalParam "txsizelow" self.txSizeBytesLow
-                          @ optionalParam "txsizehigh" self.txSizeBytesHigh
-                            @ optionalParam "cpulow" self.instructionsLow
-                              @ optionalParam "cpuhigh" self.instructionsHigh
-                                @ optionalParam "mxcntrctsz" self.maxContractSizeBytes
-                                  @ optionalParam "mxcntrctkeysz" self.maxContractDataKeySizeBytes
-                                    @ optionalParam "mxcntrctdatasz" self.maxContractDataEntrySizeBytes
-                                      @ optionalParam "ldgrmxinstrc" self.ledgerMaxInstructions
-                                        @ optionalParam "txmxinstrc" self.txMaxInstructions
-                                          @ optionalParam "txmemlim" self.txMemoryLimit
-                                            @ optionalParam "ldgrmxrdntry" self.ledgerMaxReadLedgerEntries
-                                              @ optionalParam "ldgrmxrdbyt" self.ledgerMaxReadBytes
-                                                @ optionalParam "ldgrmxwrntry" self.ledgerMaxWriteLedgerEntries
-                                                  @ optionalParam "ldgrmxwrbyt" self.ledgerMaxWriteBytes
-                                                    @ optionalParam "ldgrmxtxcnt" self.ledgerMaxTxCount
-                                                      @ optionalParam "txmxrdntry" self.txMaxReadLedgerEntries
-                                                        @ optionalParam "txmxrdbyt" self.txMaxReadBytes
-                                                          @ optionalParam "txmxwrntry" self.txMaxWriteLedgerEntries
-                                                            @ optionalParam "txmxwrbyt" self.txMaxWriteBytes
-                                                              @ optionalParam
-                                                                  "txmxevntsz"
-                                                                  self.txMaxContractEventsSizeBytes
-                                                                @ optionalParam
-                                                                    "ldgrmxtxsz"
-                                                                    self.ledgerMaxTransactionsSizeBytes
-                                                                  @ optionalParam "txmxsz" self.txMaxSizeBytes
-                                                                    @ optionalParam
-                                                                        "wndowsz"
-                                                                        self.bucketListSizeWindowSampleSize
-                                                                      @ optionalParam "evctsz" self.evictionScanSize
-                                                                        @ optionalParam
-                                                                            "evctlvl"
-                                                                            self.startingEvictionScanLevel
+          @ optionalParam "wasms" self.wasms
+          @ optionalParam "instances" self.instances
+          @ optionalParam "minpercentsuccess" self.minSorobanPercentSuccess
+          @ optionalParam "mxcntrctsz" self.maxContractSizeBytes
+          @ optionalParam "mxcntrctkeysz" self.maxContractDataKeySizeBytes
+          @ optionalParam "mxcntrctdatasz" self.maxContractDataEntrySizeBytes
+          @ optionalParam "ldgrmxinstrc" self.ledgerMaxInstructions
+          @ optionalParam "txmxinstrc" self.txMaxInstructions
+          @ optionalParam "txmemlim" self.txMemoryLimit
+          @ optionalParam "ldgrmxrdntry" self.ledgerMaxReadLedgerEntries
+          @ optionalParam "ldgrmxrdbyt" self.ledgerMaxReadBytes
+          @ optionalParam "ldgrmxwrntry" self.ledgerMaxWriteLedgerEntries
+          @ optionalParam "ldgrmxwrbyt" self.ledgerMaxWriteBytes
+          @ optionalParam "ldgrmxtxcnt" self.ledgerMaxTxCount
+          @ optionalParam "txmxrdntry" self.txMaxReadLedgerEntries
+          @ optionalParam "txmxrdbyt" self.txMaxReadBytes
+          @ optionalParam "txmxwrntry" self.txMaxWriteLedgerEntries
+          @ optionalParam "txmxwrbyt" self.txMaxWriteBytes
+          @ optionalParam "txmxevntsz" self.txMaxContractEventsSizeBytes
+          @ optionalParam "ldgrmxtxsz" self.ledgerMaxTransactionsSizeBytes
+          @ optionalParam "txmxsz" self.txMaxSizeBytes
+          @ optionalParam "wndowsz" self.bucketListSizeWindowSampleSize
+          @ optionalParam "evctsz" self.evictionScanSize
+          @ optionalParam "evctlvl" self.startingEvictionScanLevel
+          @ optionalParam "payweight" self.payWeight
+          @ optionalParam "sorobanuploadweight" self.sorobanUploadWeight
+          @ optionalParam "sorobaninvokeweight" self.sorobanInvokeWeight
 
         mandatoryParams @ optionalParams
 
@@ -179,14 +168,7 @@ type LoadGen =
           skiplowfeetxs = false
           wasms = None
           instances = None
-          dataEntriesLow = None
-          dataEntriesHigh = None
-          kiloBytesPerDataEntryLow = None
-          kiloBytesPerDataEntryHigh = None
-          txSizeBytesLow = None
-          txSizeBytesHigh = None
-          instructionsLow = None
-          instructionsHigh = None
+          minSorobanPercentSuccess = None
           maxContractSizeBytes = None
           maxContractDataKeySizeBytes = None
           maxContractDataEntrySizeBytes = None
@@ -207,11 +189,43 @@ type LoadGen =
           txMaxSizeBytes = None
           bucketListSizeWindowSampleSize = None
           evictionScanSize = None
-          startingEvictionScanLevel = None }
+          startingEvictionScanLevel = None
+          payWeight = None
+          sorobanUploadWeight = None
+          sorobanInvokeWeight = None
+        }
+
+// Takes a default value `v` and a list `l` and returns `v` if `l` is empty,
+// otherwise `l`.
+let defaultList (v : 'a list) (l : 'a list) =
+    match l with
+    | [] -> v
+    | _ -> l
 
 type MissionContext with
 
     member self.WithNominalLoad : MissionContext = { self with numTxs = 100; numAccounts = 100 }
+
+    // For loadgen missions that increase soroban ledger and transaction limits.
+    member self.WithMediumLoadgenOptions : MissionContext =
+        { self with
+              wasmBytesDistribution = [(30000, 1)]
+              dataEntriesDistribution = [(5, 1)]
+              totalKiloBytesDistribution = [(3, 1)]
+              txSizeBytesDistribution = [(512, 1)]
+              instructionsDistribution = [(25000000, 1)]
+        }
+
+    // For loadgen missions that do not increase both soroban ledger and
+    // transaction limits. These are intended to fit within the default limits.
+    member self.WithSmallLoadgenOptions : MissionContext =
+        { self with
+              wasmBytesDistribution = [(1024, 1)]
+              dataEntriesDistribution = [(1, 1)]
+              totalKiloBytesDistribution = [(1, 1)]
+              txSizeBytesDistribution = [(64, 1)]
+              instructionsDistribution = [(1000000, 1)]
+        }
 
     member self.GenerateAccountCreationLoad : LoadGen =
         { LoadGen.GetDefault() with
@@ -272,15 +286,7 @@ type MissionContext with
               spikeinterval = self.spikeInterval
               offset = 0
               maxfeerate = self.maxFeeRate
-              skiplowfeetxs = self.skipLowFeeTxs
-              dataEntriesLow = Some(0)
-              dataEntriesHigh = Some(10)
-              kiloBytesPerDataEntryLow = Some(1)
-              kiloBytesPerDataEntryHigh = Some(5)
-              txSizeBytesLow = Some(0)
-              txSizeBytesHigh = Some(1000)
-              instructionsLow = Some(0L)
-              instructionsHigh = Some(5000000L) }
+              skiplowfeetxs = self.skipLowFeeTxs }
 
     member self.SetupSorobanInvoke : LoadGen =
         { LoadGen.GetDefault() with

--- a/src/FSLibrary/StellarMission.fs
+++ b/src/FSLibrary/StellarMission.fs
@@ -39,6 +39,7 @@ open MissionSorobanLoadGeneration
 open MissionSorobanConfigUpgrades
 open MissionSorobanInvokeHostLoad
 open MissionSorobanCatchupWithPrevAndCurr
+open MissionMaxTPSMixed
 
 type Mission = (MissionContext -> unit)
 
@@ -78,4 +79,5 @@ let allMissions : Map<string, Mission> =
                  ("SorobanLoadGeneration", sorobanLoadGeneration)
                  ("SorobanConfigUpgrades", sorobanConfigUpgrades)
                  ("SorobanInvokeHostLoad", sorobanInvokeHostLoad)
-                 ("SorobanCatchupWithPrevAndCurr", sorobanCatchupWithPrevAndCurr) |]
+                 ("SorobanCatchupWithPrevAndCurr", sorobanCatchupWithPrevAndCurr)
+                 ("MaxTPSMixed", maxTPSMixed) |]

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -63,6 +63,15 @@ type MissionContext =
       flatQuorum: bool option
       tier1Keys: string option
       opCountDistribution: string option
+      wasmBytesDistribution: ((int * int) list)
+      dataEntriesDistribution: ((int * int) list)
+      totalKiloBytesDistribution: ((int * int) list)
+      txSizeBytesDistribution: ((int * int) list)
+      instructionsDistribution: ((int * int) list)
+      payWeight: int option
+      sorobanUploadWeight: int option
+      sorobanInvokeWeight: int option
+      minSorobanPercentSuccess: int option
       installNetworkDelay: bool option
       flatNetworkDelay: int option
       simulateApplyDuration: seq<int> option


### PR DESCRIPTION
Closes #142

This change adds a new mission `MaxTPSMixed` that performs a binary search to determine the max TPS under a mix of classic and soroban traffic. It also adds support for the distributions added in https://github.com/stellar/stellar-core/pull/4248