### PR TITLE
Add support for new loadgen API

### DIFF
--- a/doc/missions.md
+++ b/doc/missions.md
@@ -114,7 +114,7 @@ Simulate Public Network topology and throughput based on user-supplied distribut
 
 ## MissionSimulatePubnetTier1Perf
 
-Stress test a network of simulated Tier1 topology and report maximum achieved throughput.
+Stress test a network of simulated Tier1 topology with classic traffic and report maximum achieved throughput.
 
 ## MissionSorobanLoadGeneration
 

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -73,6 +73,20 @@ type MissionOptions
         flatQuorum: bool option,
         tier1Keys: string option,
         opCountDistribution: string option,
+        wasmBytesValues: seq<int>,
+        wasmBytesWeights: seq<int>,
+        dataEntriesValues: seq<int>,
+        dataEntriesWeights: seq<int>,
+        totalKiloBytesValues: seq<int>,
+        totalKilobytesWeights: seq<int>,
+        txSizeBytesValues: seq<int>,
+        txSizeBytesWeights: seq<int>,
+        instructionsValues: seq<int>,
+        instructionsWeights: seq<int>,
+        payWeight: int option,
+        sorobanUploadWeight: int option,
+        sorobanInvokeWeight: int option,
+        minSorobanPercentSuccess: int option,
         installNetworkDelay: bool option,
         flatNetworkDelay: int option,
         peerReadingCapacity: int option,
@@ -262,6 +276,76 @@ type MissionOptions
              Required = false)>]
     member self.OpCountDistribution = opCountDistribution
 
+    [<Option("wasm-bytes",
+             HelpText = "A space-separated list of sizes of wasm blobs for SOROBAN_UPLOAD and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_WASM_BYTES_FOR_TESTING)",
+             Required = false)>]
+    member self.WasmBytesValues = wasmBytesValues
+
+    [<Option("wasm-bytes-weights",
+             HelpText = "A space-separated indicating how often to select a certain size when generating wasms (See LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.WasmBytesWeights = wasmBytesWeights
+
+    [<Option("data-entries",
+             HelpText = "A space-separated list of number of data entries for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING)",
+             Required = false)>]
+    member self.DataEntriesValues = dataEntriesValues
+
+    [<Option("data-entries-weights",
+             HelpText = "A space-separated indicating how often to select a certain number of data entries when generating invoke transactions (See LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.DataEntriesWeights = dataEntriesWeights
+
+    [<Option("total-kilobytes",
+             HelpText = "A space-separated list of kilobytes of IO for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_IO_KILOBYTES_FOR_TESTING)",
+             Required = false)>]
+    member self.TotalKiloBytesValues = totalKiloBytesValues
+
+    [<Option("total-kilobytes-weights",
+             HelpText = "A space-separated indicating how often to select a certain number of kilobytes of IO when generating invoke transactions (See LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.TotalKiloBytesWeights = totalKilobytesWeights
+
+    [<Option("tx-size-bytes",
+             HelpText = "A space-separated list of transaction sizes for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_TX_SIZE_BYTES_FOR_TESTING)",
+             Required = false)>]
+    member self.TxSizeBytesValues = txSizeBytesValues
+
+    [<Option("tx-size-bytes-weights",
+             HelpText = "A space-separated indicating how often to select a certain transaction size when generating invoke transactions (See LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.TxSizeBytesWeights = txSizeBytesWeights
+
+    [<Option("instructions",
+             HelpText = "A space-separated list of instruction counts for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen modes (See LOADGEN_TX_SIZE_BYTES_FOR_TESTING)",
+             Required = false)>]
+    member self.InstructionsValues = instructionsValues
+
+    [<Option("instructions-weights",
+             HelpText = "A space-separated indicating how often to select a certain instruction count when generating invoke transactions (See LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING)",
+             Required = false)>]
+    member self.InstructionsWeights = instructionsWeights
+
+    [<Option("pay-weight",
+             HelpText = "Weight for classic transactions in MIX_CLASSIC_SOROBAN loadgen mode",
+             Required = false)>]
+    member self.PayWeight = payWeight
+
+    [<Option("soroban-upload-weight",
+             HelpText = "Weight for SOROBAN_UPLOAD transactions in MIX_CLASSIC_SOROBAN loadgen mode",
+             Required = false)>]
+    member self.SorobanUploadWeight = sorobanUploadWeight
+
+    [<Option("soroban-invoke-weight",
+             HelpText = "Weight for SOROBAN_INVOKE transactions in MIX_CLASSIC_SOROBAN loadgen mode",
+             Required = false)>]
+    member self.SorobanInvokeWeight = sorobanInvokeWeight
+
+    [<Option("min-soroban-percent-success",
+             HelpText = "Minimum percentage of soroban transactions that must succeed at apply time in loadgen",
+             Required = false)>]
+    member self.MinSorobanPercentSuccess = minSorobanPercentSuccess
+
     [<Option("install-network-delay",
              HelpText = "Installs network delay estimated from node locations",
              Required = false)>]
@@ -426,6 +510,15 @@ let main argv =
                   flatQuorum = None
                   tier1Keys = None
                   opCountDistribution = None
+                  wasmBytesDistribution = []
+                  dataEntriesDistribution = []
+                  totalKiloBytesDistribution = []
+                  txSizeBytesDistribution = []
+                  instructionsDistribution = []
+                  payWeight = None
+                  sorobanUploadWeight = None
+                  sorobanInvokeWeight = None
+                  minSorobanPercentSuccess = None
                   installNetworkDelay = None
                   flatNetworkDelay = None
                   simulateApplyDuration = None
@@ -537,6 +630,28 @@ let main argv =
                                flatQuorum = mission.FlatQuorum
                                tier1Keys = mission.Tier1Keys
                                opCountDistribution = mission.OpCountDistribution
+                               wasmBytesDistribution =
+                                   List.zip (List.ofSeq mission.WasmBytesValues) (List.ofSeq mission.WasmBytesWeights)
+                               dataEntriesDistribution =
+                                   List.zip
+                                       (List.ofSeq mission.DataEntriesValues)
+                                       (List.ofSeq mission.DataEntriesWeights)
+                               totalKiloBytesDistribution =
+                                   List.zip
+                                       (List.ofSeq mission.TotalKiloBytesValues)
+                                       (List.ofSeq mission.TotalKiloBytesWeights)
+                               txSizeBytesDistribution =
+                                   List.zip
+                                       (List.ofSeq mission.TxSizeBytesValues)
+                                       (List.ofSeq mission.TxSizeBytesWeights)
+                               instructionsDistribution =
+                                   List.zip
+                                       (List.ofSeq mission.InstructionsValues)
+                                       (List.ofSeq mission.InstructionsWeights)
+                               payWeight = mission.PayWeight
+                               sorobanUploadWeight = mission.SorobanUploadWeight
+                               sorobanInvokeWeight = mission.SorobanInvokeWeight
+                               minSorobanPercentSuccess = mission.MinSorobanPercentSuccess
                                installNetworkDelay = mission.InstallNetworkDelay
                                flatNetworkDelay = mission.FlatNetworkDelay
                                simulateApplyDuration = processInputSeq mission.SimulateApplyDuration

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -95,6 +95,15 @@ let ctx : MissionContext =
               __SOURCE_DIRECTORY__
               + "/../FSLibrary/csv-type-samples/sample-loadgen-op-count-distribution.csv"
           )
+      wasmBytesDistribution = []
+      dataEntriesDistribution = []
+      totalKiloBytesDistribution = []
+      txSizeBytesDistribution = []
+      instructionsDistribution = []
+      payWeight = None
+      sorobanUploadWeight = None
+      sorobanInvokeWeight = None
+      minSorobanPercentSuccess = None
       networkSizeLimit = 100
       tier1OrgsToAdd = 0
       nonTier1NodesToAdd = 0

--- a/src/FSLibrary/MissionHistoryGenerateAndCatchup.fs
+++ b/src/FSLibrary/MissionHistoryGenerateAndCatchup.fs
@@ -15,7 +15,7 @@ open StellarSupercluster
 let sorobanProtocolVersion = 20
 
 let historyGenerateAndCatchup (context: MissionContext) =
-    let context = context.WithNominalLoad
+    let context = context.WithNominalLoad.WithSmallLoadgenOptions
     let image = context.image
     let catchupOptions = { generatorImage = image; catchupImage = image; versionImage = image }
     let catchupSets = MakeRecentCatchupSet catchupOptions

--- a/src/FSLibrary/MissionInMemoryMode.fs
+++ b/src/FSLibrary/MissionInMemoryMode.fs
@@ -26,7 +26,11 @@ let runInMemoryMode (context: MissionContext) =
                   localHistory = false
                   quorumSet = CoreSetQuorum(CoreSetName "core") }
 
-    let context = { context with numAccounts = 100; numTxs = 100; txRate = 20 }
+    let context =
+        { context.WithSmallLoadgenOptions with
+              numAccounts = 100
+              numTxs = 100
+              txRate = 20 }
 
     context.Execute
         [ coreSet; coreSetWithCaptiveCore ]

--- a/src/FSLibrary/MissionLoadGenerationWithTxSetLimit.fs
+++ b/src/FSLibrary/MissionLoadGenerationWithTxSetLimit.fs
@@ -20,7 +20,7 @@ let loadGenerationWithTxSetLimit (context: MissionContext) =
                   dumpDatabase = false }
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               coreResources = MediumTestResources
               numAccounts = 20000
               numTxs = 50000

--- a/src/FSLibrary/MissionMixedImageLoadGeneration.fs
+++ b/src/FSLibrary/MissionMixedImageLoadGeneration.fs
@@ -59,7 +59,7 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
                   quorumSet = qSet }
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               coreResources = MediumTestResources
               numAccounts = 20000
               numTxs = 50000

--- a/src/FSLibrary/MissionProtocolUpgradeWithLoad.fs
+++ b/src/FSLibrary/MissionProtocolUpgradeWithLoad.fs
@@ -21,7 +21,7 @@ let protocolUpgradeWithLoad (context: MissionContext) =
                   dumpDatabase = false }
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               coreResources = UpgradeResources
               numAccounts = 20000
               numTxs = 50000

--- a/src/FSLibrary/MissionSorobanCatchupWithPrevAndCurr.fs
+++ b/src/FSLibrary/MissionSorobanCatchupWithPrevAndCurr.fs
@@ -33,7 +33,7 @@ let sorobanCatchupWithPrevAndCurr (context: MissionContext) =
                   catchupMode = CatchupComplete }
 
     let context =
-        { context with
+        { context.WithMediumLoadgenOptions with
               numAccounts = 100
               numTxs = 100
               txRate = 1

--- a/src/FSLibrary/MissionSorobanConfigUpgrades.fs
+++ b/src/FSLibrary/MissionSorobanConfigUpgrades.fs
@@ -29,7 +29,7 @@ let sorobanConfigUpgrades (context: MissionContext) =
                   nodeCount = 5 }
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               numAccounts = 100
               numTxs = 100
               txRate = 1

--- a/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
+++ b/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
@@ -10,7 +10,6 @@ open StellarFormation
 open StellarStatefulSets
 open StellarSupercluster
 open StellarCoreHTTP
-open StellarCorePeer
 
 let sorobanInvokeHostLoad (context: MissionContext) =
     let coreSet =
@@ -21,7 +20,7 @@ let sorobanInvokeHostLoad (context: MissionContext) =
                   emptyDirType = DiskBackedEmptyDir }
 
     let context =
-        { context with
+        { context.WithMediumLoadgenOptions with
               numAccounts = 100
               numTxs = 100
               txRate = 1

--- a/src/FSLibrary/MissionSorobanLoadGeneration.fs
+++ b/src/FSLibrary/MissionSorobanLoadGeneration.fs
@@ -17,7 +17,7 @@ let sorobanLoadGeneration (context: MissionContext) =
     let rate = 5
 
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               coreResources = SimulatePubnetTier1PerfResources
               installNetworkDelay = Some(context.installNetworkDelay |> Option.defaultValue true)
               txRate = rate

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -122,6 +122,17 @@ let cwd = __SOURCE_DIRECTORY__
 type Distribution =
     CsvProvider<"csv-type-samples/sample-loadgen-op-count-distribution.csv", HasHeaders=true, ResolutionFolder=cwd>
 
+// Add a loadgen distribution to a TOML table.
+let distributionToToml (d: (int * int) list) (name: string) (t: TomlTable) : unit =
+    match d with
+    | [] -> ()
+    | _ ->
+        let values = List.map fst d
+        let weights = List.map snd d
+
+        t.Add("LOADGEN_" + name + "_FOR_TESTING", values) |> ignore
+        t.Add("LOADGEN_" + name + "_DISTRIBUTION_FOR_TESTING", weights) |> ignore
+
 // Represents the contents of a stellar-core.cfg file, along with method to
 // write it out to TOML.
 type StellarCoreCfg =
@@ -274,6 +285,12 @@ type StellarCoreCfg =
 
             t.Add("LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING", distribution |> Seq.map snd)
             |> ignore
+
+        distributionToToml self.network.missionContext.wasmBytesDistribution "WASM_BYTES" t
+        distributionToToml self.network.missionContext.dataEntriesDistribution "NUM_DATA_ENTRIES" t
+        distributionToToml self.network.missionContext.totalKiloBytesDistribution "IO_KILOBYTES" t
+        distributionToToml self.network.missionContext.txSizeBytesDistribution "TX_SIZE_BYTES" t
+        distributionToToml self.network.missionContext.instructionsDistribution "INSTRUCTIONS" t
 
         t.Add("TARGET_PEER_CONNECTIONS", self.targetPeerConnections) |> ignore
 

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -63,6 +63,15 @@ type MissionContext =
       flatQuorum: bool option
       tier1Keys: string option
       opCountDistribution: string option
+      wasmBytesDistribution: ((int * int) list)
+      dataEntriesDistribution: ((int * int) list)
+      totalKiloBytesDistribution: ((int * int) list)
+      txSizeBytesDistribution: ((int * int) list)
+      instructionsDistribution: ((int * int) list)
+      payWeight: int option
+      sorobanUploadWeight: int option
+      sorobanInvokeWeight: int option
+      minSorobanPercentSuccess: int option
       installNetworkDelay: bool option
       flatNetworkDelay: int option
       simulateApplyDuration: seq<int> option


### PR DESCRIPTION
This PR adds support for the new distribution parameters added in https://github.com/stellar/stellar-core/pull/4248.  It is #155 with the mixed soroban/classic max TPS mission removed.

I tested these changes with the following missions using an image built from the linked stellar-core PR:
* `SorobanInvokeHostLoad`
* `SorobanConfigUpgrades`
* `SimplePayment`
* `LoadGeneration`
* `LoadGenerationWithTxSetLimit`
* `ProtocolUpgradeWithLoad`