### PR TITLE
Increase parallel catchup memory burst limit for incoming BucketsDB optimization

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -147,8 +147,8 @@ let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
 
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
-    // 1200MB RAM, 0.25 vCPUs, and 35 GB of disk bursting to 2vCPU, 1500MB and 40 GB
-    makeResourceRequirementsWithStorageLimit 250 1200 2000 1500 35 40
+    // 1200MB RAM, 0.25 vCPUs, and 35 GB of disk bursting to 2vCPU, 4500MB and 40 GB
+    makeResourceRequirementsWithStorageLimit 250 1200 2000 4500 35 40
 
 let NonParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing non-parallel catchup, we give each container


### PR DESCRIPTION
From the testing I did, it looked like pods were using around 3.8 GB. Will be required once https://github.com/stellar/stellar-core/pull/4114 is merged.