### PR TITLE
Add new mission that runs a survey

### DIFF
--- a/doc/missions.md
+++ b/doc/missions.md
@@ -131,3 +131,7 @@ Test resource-intensive InvokeHostFunction operations on a small network of node
 ## MissionSorobanCatchupWithPrevAndCurr
 
 Test catchup to ledger state that spans multiple protocols supporting Soroban.
+
+## MissionMixedImageNetworkSurvey
+
+Run a network survey with mixed version images on a small network of nodes.

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="MissionHistoryTestnetParallelCatchup.fs" />
     <Compile Include="MissionHistoryTestnetPerformance.fs" />
     <Compile Include="MissionMixedImageLoadGeneration.fs" />
+    <Compile Include="MissionMixedImageNetworkSurvey.fs" />
     <Compile Include="MissionVersionMixConsensus.fs" />
     <Compile Include="MissionSorobanLoadGeneration.fs" />
     <Compile Include="MissionSorobanConfigUpgrades.fs" />

--- a/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
+++ b/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
@@ -1,0 +1,130 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+module MissionMixedImageNetworkSurvey
+
+// This test runs a survey with 1 old node and 2 new nodes. One of the new nodes
+// runs the survey. The test checks that no nodes crash. It does not check the
+// correctness of survey results (that is done in the tests built into
+// stellar-core).
+
+open stellar_dotnet_sdk
+
+open Logging
+open StellarCoreSet
+open StellarMissionContext
+open StellarFormation
+open StellarStatefulSets
+open StellarSupercluster
+open StellarCoreHTTP
+open StellarCorePeer
+
+let mixedImageNetworkSurvey (context: MissionContext) =
+    let oldNodeCount = 1
+    let newNodeCount = 2
+
+    // Set max survey phase durations to 3 minutes
+    let surveyPhaseDurationMinutes = 3
+
+    let newImage = context.image
+    let oldImage = GetOrDefault context.oldImage newImage
+
+    let oldName = "core-old"
+    let newName = "core-new"
+
+    // keypairs of old and new surveyed nodes
+    let oldSurveyedKeys = KeyPair.Random()
+    let newSurveyedKeys = KeyPair.Random()
+
+    // Allow 2/3 nodes consensus, so that one image version could fork the
+    // network in case of bugs.
+    let qSet =
+        CoreSetQuorumListWithThreshold(([ CoreSetName oldName; CoreSetName newName ], 51))
+
+    let oldCoreSet =
+        { name = CoreSetName oldName
+          keys = [| oldSurveyedKeys |]
+          live = true
+          options =
+              { CoreSetOptions.GetDefault oldImage with
+                    nodeCount = oldNodeCount
+                    accelerateTime = false
+                    surveyPhaseDuration = None
+                    quorumSet = qSet } }
+
+    let newCoreSet =
+        { name = CoreSetName newName
+          keys = [| KeyPair.Random(); newSurveyedKeys |]
+          live = true
+          options =
+              { CoreSetOptions.GetDefault newImage with
+                    nodeCount = newNodeCount
+                    accelerateTime = false
+                    surveyPhaseDuration = Some surveyPhaseDurationMinutes
+                    quorumSet = qSet } }
+
+    let coreSets = [ newCoreSet; oldCoreSet ]
+
+    context.Execute
+        coreSets
+        None
+        (fun (formation: StellarFormation) ->
+            formation.WaitUntilSynced coreSets
+
+            // Upgrade the network to the old protocol
+            let oldPeer = formation.NetworkCfg.GetPeer oldCoreSet 0
+            let oldVersion = oldPeer.GetSupportedProtocolVersion()
+            formation.UpgradeProtocol coreSets oldVersion
+
+            // Chose a new node to run the survey
+            let surveyor = formation.NetworkCfg.GetPeer newCoreSet 0
+
+            // Helper functions to run survey commands from `surveyor`
+            let startSurveyCollecting () =
+                let nonce = 42
+                LogInfo "startSurveyCollecting: %s" (surveyor.StartSurveyCollecting nonce)
+
+            let stopSurveyCollecting () = LogInfo "stopSurveyCollecting: %s" (surveyor.StopSurveyCollecting())
+
+            let surveyTimeSliceData (node: KeyPair) =
+                LogInfo "surveyTimeSliceData: %s" (surveyor.SurveyTimeSliceData node.AccountId 0 0)
+
+            let getSurveyResult () = LogInfo "getSurveyResult: %s" (surveyor.GetSurveyResult())
+
+            let waitSeconds (seconds: int) =
+                LogInfo "Waiting %i seconds" seconds
+                System.Threading.Thread.Sleep(seconds * 1000)
+
+            // Start survey collecting
+            startSurveyCollecting ()
+
+            // Let survey collect for a minute
+            waitSeconds 60
+
+            // Stop survey collecting
+            stopSurveyCollecting ()
+
+            // Give message time to propagate
+            waitSeconds 30
+
+            // Request results from peers
+            surveyTimeSliceData oldSurveyedKeys
+            surveyTimeSliceData newSurveyedKeys
+
+            // Give time to propagate and respond
+            waitSeconds 60
+
+            // Get results
+            getSurveyResult ()
+
+            // Let survey expire. At this point the survey has spent 1.5 minutes
+            // in the reporting phase, so knock a minute off of the wait time
+            // leaving 30 seconds of buffer to ensure survey is truly expired
+            waitSeconds ((surveyPhaseDurationMinutes - 1) * 60)
+
+            // Test collecting phase expiration by starting a new survey and
+            // letting it expire.  Add in a buffer to ensure the survey is truly
+            // expired
+            startSurveyCollecting ()
+            waitSeconds (surveyPhaseDurationMinutes * 60 + 30))

--- a/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
+++ b/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
@@ -37,11 +37,6 @@ let mixedImageNetworkSurvey (context: MissionContext) =
     let oldSurveyedKeys = KeyPair.Random()
     let newSurveyedKeys = KeyPair.Random()
 
-    // Allow 2/3 nodes consensus, so that one image version could fork the
-    // network in case of bugs.
-    let qSet =
-        CoreSetQuorumListWithThreshold(([ CoreSetName oldName; CoreSetName newName ], 51))
-
     let oldCoreSet =
         { name = CoreSetName oldName
           keys = [| oldSurveyedKeys |]
@@ -50,8 +45,7 @@ let mixedImageNetworkSurvey (context: MissionContext) =
               { CoreSetOptions.GetDefault oldImage with
                     nodeCount = oldNodeCount
                     accelerateTime = false
-                    surveyPhaseDuration = None
-                    quorumSet = qSet } }
+                    surveyPhaseDuration = None } }
 
     let newCoreSet =
         { name = CoreSetName newName
@@ -61,8 +55,7 @@ let mixedImageNetworkSurvey (context: MissionContext) =
               { CoreSetOptions.GetDefault newImage with
                     nodeCount = newNodeCount
                     accelerateTime = false
-                    surveyPhaseDuration = Some surveyPhaseDurationMinutes
-                    quorumSet = qSet } }
+                    surveyPhaseDuration = Some surveyPhaseDurationMinutes } }
 
     let coreSets = [ newCoreSet; oldCoreSet ]
 

--- a/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
+++ b/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
@@ -87,8 +87,8 @@ let mixedImageNetworkSurvey (context: MissionContext) =
 
             let stopSurveyCollecting () = LogInfo "stopSurveyCollecting: %s" (surveyor.StopSurveyCollecting())
 
-            let surveyTimeSliceData (node: KeyPair) =
-                LogInfo "surveyTimeSliceData: %s" (surveyor.SurveyTimeSliceData node.AccountId 0 0)
+            let surveyTopologyTimeSliced (node: KeyPair) =
+                LogInfo "surveyTopologyTimeSliced: %s" (surveyor.SurveyTopologyTimeSliced node.AccountId 0 0)
 
             let getSurveyResult () = LogInfo "getSurveyResult: %s" (surveyor.GetSurveyResult())
 
@@ -109,8 +109,8 @@ let mixedImageNetworkSurvey (context: MissionContext) =
             waitSeconds 30
 
             // Request results from peers
-            surveyTimeSliceData oldSurveyedKeys
-            surveyTimeSliceData newSurveyedKeys
+            surveyTopologyTimeSliced oldSurveyedKeys
+            surveyTopologyTimeSliced newSurveyedKeys
 
             // Give time to propagate and respond
             waitSeconds 60

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -163,6 +163,7 @@ type StellarCoreCfg =
       maxBatchWriteCount: int
       inMemoryMode: bool
       enableBucketListDB: bool
+      surveyPhaseDuration: int option
       containerType: CoreContainerType }
 
     member self.ToTOML() : TomlTable =
@@ -309,6 +310,10 @@ type StellarCoreCfg =
         t.Add("INVARIANT_CHECKS", invList) |> ignore
         t.Add("UNSAFE_QUORUM", self.unsafeQuorum) |> ignore
         t.Add("FAILURE_SAFETY", self.failureSafety) |> ignore
+
+        match self.surveyPhaseDuration with
+        | None -> ()
+        | Some duration -> t.Add("ARTIFICIALLY_SET_SURVEY_PHASE_DURATION_FOR_TESTING", duration) |> ignore
 
         // Add tables (and subtables, recursively) for qsets.
         let rec addQsetAt (label: string) (qs: QuorumSet) =
@@ -483,6 +488,7 @@ type NetworkCfg with
           maxBatchWriteCount = opts.maxBatchWriteCount
           inMemoryMode = opts.inMemoryMode
           enableBucketListDB = opts.enableBucketListDB
+          surveyPhaseDuration = opts.surveyPhaseDuration
           containerType = MainCoreContainer }
 
     member self.StellarCoreCfg(c: CoreSet, i: int, ctype: CoreContainerType) : StellarCoreCfg =
@@ -519,4 +525,5 @@ type NetworkCfg with
           maxBatchWriteCount = c.options.maxBatchWriteCount
           inMemoryMode = c.options.inMemoryMode
           enableBucketListDB = c.options.enableBucketListDB
+          surveyPhaseDuration = c.options.surveyPhaseDuration
           containerType = ctype }

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -667,13 +667,13 @@ type Peer with
             (fun _ ->
                 Http.RequestString(httpMethod = "GET", url = self.URL("stopsurveycollecting"), headers = self.Headers))
 
-    member self.SurveyTimeSliceData (node: string) (inboundPeersIndex: int) (outboundPeersIndex: int) =
+    member self.SurveyTopologyTimeSliced (node: string) (inboundPeersIndex: int) (outboundPeersIndex: int) =
         WebExceptionRetry
             DefaultRetry
             (fun _ ->
                 Http.RequestString(
                     httpMethod = "GET",
-                    url = self.URL("surveytimeslicedata"),
+                    url = self.URL("surveytopologytimesliced"),
                     headers = self.Headers,
                     query =
                         [ ("node", node)

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -650,6 +650,42 @@ type Peer with
 
         TestAcc.Parse(if s.Trim().StartsWith("null") then "{}" else s)
 
+    member self.StartSurveyCollecting(nonce: int) =
+        WebExceptionRetry
+            DefaultRetry
+            (fun _ ->
+                Http.RequestString(
+                    httpMethod = "GET",
+                    url = self.URL("startsurveycollecting"),
+                    headers = self.Headers,
+                    query = [ ("nonce", nonce.ToString()) ]
+                ))
+
+    member self.StopSurveyCollecting() =
+        WebExceptionRetry
+            DefaultRetry
+            (fun _ ->
+                Http.RequestString(httpMethod = "GET", url = self.URL("stopsurveycollecting"), headers = self.Headers))
+
+    member self.SurveyTimeSliceData (node: string) (inboundPeersIndex: int) (outboundPeersIndex: int) =
+        WebExceptionRetry
+            DefaultRetry
+            (fun _ ->
+                Http.RequestString(
+                    httpMethod = "GET",
+                    url = self.URL("surveytimeslicedata"),
+                    headers = self.Headers,
+                    query =
+                        [ ("node", node)
+                          ("inboundpeerindex", inboundPeersIndex.ToString())
+                          ("outboundpeerindex", outboundPeersIndex.ToString()) ]
+                ))
+
+    member self.GetSurveyResult() =
+        WebExceptionRetry
+            DefaultRetry
+            (fun _ -> Http.RequestString(httpMethod = "GET", url = self.URL("getsurveyresult"), headers = self.Headers))
+
     member self.GetTestAccBalance(accName: string) : int64 =
         RetryUntilSome
             (fun _ -> self.GetTestAcc(accName).Balance)

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -170,7 +170,8 @@ type CoreSetOptions =
       maxSlotsToRemember: int
       maxBatchWriteCount: int
       inMemoryMode: bool
-      enableBucketListDB: bool }
+      enableBucketListDB: bool
+      surveyPhaseDuration: int option }
 
     member self.WithWaitForConsensus(w: bool) =
         { self with initialization = { self.initialization with waitForConsensus = w } }
@@ -202,7 +203,8 @@ type CoreSetOptions =
           maxSlotsToRemember = 12
           maxBatchWriteCount = 1024
           inMemoryMode = false
-          enableBucketListDB = false }
+          enableBucketListDB = false
+          surveyPhaseDuration = None }
 
 type CoreSet =
     { name: CoreSetName

--- a/src/FSLibrary/StellarMission.fs
+++ b/src/FSLibrary/StellarMission.fs
@@ -39,6 +39,7 @@ open MissionSorobanLoadGeneration
 open MissionSorobanConfigUpgrades
 open MissionSorobanInvokeHostLoad
 open MissionSorobanCatchupWithPrevAndCurr
+open MissionMixedImageNetworkSurvey
 
 type Mission = (MissionContext -> unit)
 
@@ -78,4 +79,5 @@ let allMissions : Map<string, Mission> =
                  ("SorobanLoadGeneration", sorobanLoadGeneration)
                  ("SorobanConfigUpgrades", sorobanConfigUpgrades)
                  ("SorobanInvokeHostLoad", sorobanInvokeHostLoad)
-                 ("SorobanCatchupWithPrevAndCurr", sorobanCatchupWithPrevAndCurr) |]
+                 ("SorobanCatchupWithPrevAndCurr", sorobanCatchupWithPrevAndCurr)
+                 ("MixedImageNetworkSurvey", mixedImageNetworkSurvey) |]


### PR DESCRIPTION
This change adds a mission `MixedImageNetworkSurvey` that runs a survey with mixed version images on a small network of nodes. I tested this locally with `--image` set to a build with the new time sliced survey and `--old-image` set to a `20.4.0` build.

NOTE: This should only be merged after the time sliced network survey PR is merged as it relies on those new APIs.