### PR TITLE
Increase retries from 5 to 20

### DIFF
--- a/src/FSLibrary/StellarJobExec.fs
+++ b/src/FSLibrary/StellarJobExec.fs
@@ -182,7 +182,7 @@ type StellarFormation with
 
         // We have seen sporadic http exceptions being thrown in the while loop below,
         // so this is an attempt to see if we can just ignore the exceptions.
-        let mutable numOfHttpRetriesAllowed = 5
+        let mutable numOfHttpRetriesAllowed = 20
 
         // We check to see if there are pods that have been in "Pending"
         // state for more than 120 minutes. This typically means the cluster


### PR DESCRIPTION
This retry mechanism has helped and we haven't hit https://github.com/stellar/stellar-supercluster/issues/280 since adding it. This PR is just preemptively increasing the retry limit because I've seen 1-2 exceptions caught on some runs.