### PR TITLE
Revert "Disable soroban loadgen on old images"

### DIFF
--- a/src/FSLibrary/MissionMixedImageLoadGeneration.fs
+++ b/src/FSLibrary/MissionMixedImageLoadGeneration.fs
@@ -58,9 +58,8 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
                   dumpDatabase = false
                   quorumSet = qSet }
 
-    // FIXME: Apply small loadgen options to context once the old image supports the new loadgen API
     let context =
-        { context with
+        { context.WithSmallLoadgenOptions with
               coreResources = MediumTestResources
               numAccounts = 20000
               numTxs = 50000
@@ -93,10 +92,8 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
                 let majorityPeer = formation.NetworkCfg.GetPeer loadgenCoreSet 0
 
                 if majorityPeer.GetLedgerProtocolVersion() >= 20 then
-                    formation.UpgradeSorobanLedgerLimitsWithMultiplier coreSets 100)
-// FIXME: Uncomment the `RunLoadgen` call below once the old
-// image supports the new loadgen API
-//                  formation.RunLoadgen loadgenCoreSet { context.GenerateSorobanUploadLoad with txrate = 1; txs = 200 })
+                    formation.UpgradeSorobanLedgerLimitsWithMultiplier coreSets 100
+                    formation.RunLoadgen loadgenCoreSet { context.GenerateSorobanUploadLoad with txrate = 1; txs = 200 })
 
 let mixedImageLoadGenerationWithOldImageMajority (context: MissionContext) = mixedImageLoadGeneration 2 context
 


### PR DESCRIPTION
Resolves #163

This change re-enables soroban loadgen on the mixed images load generation mission by reverting commit
7195b348d34a9fc7b4d2762005f8d09ed2c230a2.

I tested this by running the `MixedImageLoadGenerationWithOldImageMajority` and `MixedImageLoadGenerationWithNewImageMajority` missions locally.