### PR TITLE
Change pubnet archives to use aws east poc cache

### DIFF
--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -14,7 +14,7 @@ open Logging
 type HistoryArchiveState = JsonProvider<"json-type-samples/sample-stellar-history.json", ResolutionFolder=cwd>
 
 let PubnetLatestHistoryArchiveState =
-    "http://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json"
+    "http://history-cache-poc.stellar-ops.com:8080/prd/core-live/core_live_001/.well-known/stellar-history.json"
 
 let TestnetLatestHistoryArchiveState =
     "http://history.stellar.org/prd/core-testnet/core_testnet_001/.well-known/stellar-history.json"
@@ -569,9 +569,12 @@ let GetLatestTestnetLedgerNumber _ : int =
     has.CurrentLedger
 
 let PubnetGetCommands =
-    [ PeerShortName "core_live_001", "curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
-      PeerShortName "core_live_002", "curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
-      PeerShortName "core_live_003", "curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}" ]
+    [ PeerShortName "core_live_001",
+      "curl -sf http://history-cache-poc.stellar-ops.com:8080/prd/core-live/core_live_001/{0} -o {1}"
+      PeerShortName "core_live_002",
+      "curl -sf http://history-cache-poc.stellar-ops.com:8080/prd/core-live/core_live_002/{0} -o {1}"
+      PeerShortName "core_live_003",
+      "curl -sf http://history-cache-poc.stellar-ops.com:8080/prd/core-live/core_live_003/{0} -o {1}" ]
     |> Map.ofList
 
 let PubnetQuorum : QuorumSet =


### PR DESCRIPTION
This PR changes the archives used by pubnet parallel catchup from the AWS EU archives to the AWS US East-based POC archive cache. Ops has given the greenlight on enabling this for a few weeks to validate the performance of intra-region archive access. 
https://stellarfoundation.slack.com/archives/C0367MGFL/p1719476795975429?thread_ts=1718359425.776429&cid=C0367MGFL