### PR TITLE
Use MediumTestResources for pubnet performance mission

### DIFF
--- a/src/FSLibrary/MissionHistoryPubnetPerformance.fs
+++ b/src/FSLibrary/MissionHistoryPubnetPerformance.fs
@@ -20,6 +20,8 @@ let historyPubnetPerformance (context: MissionContext) =
               invariantChecks = AllInvariantsExceptBucketConsistencyChecks
               initialization = CoreSetInitialization.OnlyNewDb }
 
+    let context = { context with coreResources = MediumTestResources }
+
     context.ExecuteJobs
         (Some(opts))
         (Some(SDFMainNet))


### PR DESCRIPTION
We're hitting the memory limits with the default SmallTestResources.