### PR TITLE
Parallel catchup V2

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,10 +21,10 @@ jobs:
       run: |
         kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.5.1/deploy/static/provider/cloud/deploy.yaml
         kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=120s
-    - name: Setup .NET SDK 5
+    - name: Setup .NET SDK 8
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '8.0.x'
     - name: Install dependencies
       run: dotnet restore
     - name: Install tool dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /src/**/bin
 
 # run artifacts
-/destination
+**/destination
 
 
 .fake

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -5,8 +5,10 @@
 
   - Make sure you have enabled at least the `dns` and `ingress` components on the Kubernetes cluster, and that the `ingress` controller is [nginx-ingress](https://kubernetes.github.io/ingress-nginx/).
 
-  - Download and install the **x86** version of [dotnet 5.0 or later](https://dotnet.microsoft.com/download).
+  - Download and install the **x86** version of [dotnet 8.0 or later](https://dotnet.microsoft.com/download).
 
-  - Build with `dotnet build`. You might need to run `dotnet restore` first to install package dependencies. If you installed a version of dotnet newer that 5.x, then you may be asked to install the [dotnet 5.x runtime](https://dotnet.microsoft.com/en-us/download/dotnet/5.0).
+  - Build with `dotnet build`. You might need to run `dotnet restore` first to install package dependencies. If you installed a version of dotnet newer that 8.x, then you may be asked to install the [dotnet 8.x runtime](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
+
+  - To run new parallel catchup mission `MissionHistoryPubnetParallelCatchupV2`, it requires [Helm](https://helm.sh/docs/intro/install/) to be installed on the machine.
 
   - Run with `dotnet run --project src/App/App.fsproj --configuration Release -- mission SimplePayment --image=<stellar-core-docker-image>`

--- a/doc/missions.md
+++ b/doc/missions.md
@@ -52,6 +52,9 @@ Perform full catchup to Public Network, but in parallel to improve performance. 
 
 Perform full parallel catchup to Public Network, but with increased parallelism.
 
+## MissionHistoryPubnetParallelCatchupV2
+Perform full catchup to Public Network in parallel, leverging Kubernetes for improved performance and robustness.
+
 ## MissionHistoryPubnetPerformance
 
 Perform recent catchup to a fixed ledger and time bucket application and ledger replay portions of catchup.

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
@@ -19,7 +19,7 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="stellar-dotnet-sdk" Version="7.1.4" />
+    <PackageReference Include="stellar-dotnet-sdk" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -103,6 +103,7 @@ type MissionOptions
         nonTier1NodesToAdd: int,
         randomSeed: int,
         pubnetParallelCatchupStartingLedger: int,
+        pubnetParallelCatchupNumWorkers: int,
         tag: string option,
         numRuns: int option
     ) =
@@ -422,6 +423,12 @@ type MissionOptions
              Default = 0)>]
     member self.PubnetParallelCatchupStartingLedger = pubnetParallelCatchupStartingLedger
 
+    [<Option("pubnet-parallel-catchup-num-workers",
+             HelpText = "number of workers to run parallel catchup with (only supported for V2)",
+             Required = false,
+             Default = 128)>]
+    member self.PubnetParallelCatchupNumWorkers = pubnetParallelCatchupNumWorkers
+
     [<Option("tag", HelpText = "optional name to tag the run with", Required = false)>]
     member self.Tag = tag
 
@@ -535,6 +542,7 @@ let main argv =
                   randomSeed = 0
                   networkSizeLimit = 0
                   pubnetParallelCatchupStartingLedger = 0
+                  pubnetParallelCatchupNumWorkers = 128
                   tag = None
                   numRuns = None
                   enableTailLogging = true }
@@ -668,6 +676,7 @@ let main argv =
                                networkSizeLimit = mission.NetworkSizeLimit
                                randomSeed = mission.RandomSeed
                                pubnetParallelCatchupStartingLedger = mission.PubnetParallelCatchupStartingLedger
+                               pubnetParallelCatchupNumWorkers = mission.PubnetParallelCatchupNumWorkers
                                tag = mission.Tag
                                numRuns = mission.NumRuns
                                enableTailLogging = true }

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -580,7 +580,7 @@ let main argv =
                          LogError "Connection issue!"
                          reraise ()
 
-                 // Poll cluster every minute to make sure we don't have any issues
+                 // Poll cluster every 5 minutes to make sure we don't have any issues
                  let timer = new System.Threading.Timer(TimerCallback(heartbeatHandler), null, 1000, 300000)
 
                  for m in mission.Missions do

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -561,7 +561,7 @@ let main argv =
                 (LogInfo "-----------------------------------"
                  LogInfo "Supercluster command line: %s" (System.String.Join(" ", argv))
                  LogInfo "-----------------------------------"
-                 LogInfo "Connecting to Kubernetes cluster"
+                 LogInfo "Connecting to Kubernetes cluster: %s" mission.Destination
                  LogInfo "-----------------------------------"
 
                  let (kube, ns) = ConnectToCluster mission.KubeConfig mission.NamespaceProperty

--- a/src/CSLibrary/CSLibrary.csproj
+++ b/src/CSLibrary/CSLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
     <PackageReference Include="KubernetesClient" Version="9.0.38" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="stellar-dotnet-sdk" Version="7.1.4" />
+    <PackageReference Include="stellar-dotnet-sdk" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CSLibrary/CSLibrary.csproj
+++ b/src/CSLibrary/CSLibrary.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
-    <PackageReference Include="KubernetesClient" Version="9.0.38" />
+    <PackageReference Include="KubernetesClient" Version="14.0.2" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="stellar-dotnet-sdk" Version="10.0.0" />

--- a/src/FSLibrary.Tests/FSLibrary.Tests.fsproj
+++ b/src/FSLibrary.Tests/FSLibrary.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="stellar-dotnet-sdk" Version="7.1.4" />
+    <PackageReference Include="stellar-dotnet-sdk" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -109,6 +109,7 @@ let ctx : MissionContext =
       nonTier1NodesToAdd = 0
       randomSeed = 0
       pubnetParallelCatchupStartingLedger = 0
+      pubnetParallelCatchupNumWorkers = 128
       tag = None
       numRuns = None
       enableTailLogging = true }

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -74,7 +74,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="FSharp.Data" Version="4.1.1" />
-    <PackageReference Include="KubernetesClient" Version="9.0.38" />
+    <PackageReference Include="KubernetesClient" Version="14.0.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -47,6 +47,7 @@
     <Compile Include="MissionHistoryPubnetParallelCatchup.fs" />
     <Compile Include="MissionHistoryPubnetCompleteCatchup.fs" />
     <Compile Include="MissionHistoryPubnetParallelCatchupExtrawide.fs" />
+    <Compile Include="MissionHistoryPubnetParallelCatchupV2.fs" />
     <Compile Include="MissionHistoryPubnetPerformance.fs" />
     <Compile Include="MissionHistoryTestnetCompleteCatchup.fs" />
     <Compile Include="MissionHistoryTestnetRecentCatchup.fs" />

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -79,7 +79,7 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="stellar-dotnet-sdk" Version="7.1.4" />
+    <PackageReference Include="stellar-dotnet-sdk" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CSLibrary\CSLibrary.csproj" />

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -80,6 +80,8 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="stellar-dotnet-sdk" Version="10.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="YamlDotNet" Version="15.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CSLibrary\CSLibrary.csproj" />

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -24,11 +24,10 @@ open System.Threading
 let helmReleaseName = "parallel-catchup"
 let helmChartPath = "../MissionParallelCatchup/parallel_catchup_helm"
 let valuesFilePath = helmChartPath + "/values.yaml"
-let workerReplicas = 10
 
 let mutable cleanupCalled = false
 
-let runCommand (command: string[]) =
+let runCommand (command: string []) =
     try
         let psi = ProcessStartInfo()
         psi.FileName <- command.[0]
@@ -37,7 +36,7 @@ let runCommand (command: string[]) =
         psi.RedirectStandardError <- true
         psi.UseShellExecute <- false
         psi.CreateNoWindow <- true
-        
+
         use ps = Process.Start(psi)
         ps.WaitForExit()
 
@@ -49,51 +48,62 @@ let runCommand (command: string[]) =
             None
         else
             Some(output)
-    with
-    | ex -> 
+    with ex ->
         LogError "Command execution failed: %s" ex.Message
         None
 
-let installProject (image: string) =
+let installProject (image: string, workerReplicas: int) =
     LogInfo "Installing Helm chart..."
-    
-    let deserializer = DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build()
+
+    let deserializer =
+        DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build()
+
     let values =
         use reader = new StreamReader(valuesFilePath)
         deserializer.Deserialize<obj>(reader)
-
-    let updateWorkerDict (workerDict: Dictionary<string, obj>) =
-        workerDict.Add("stellar_core_image", (box image))
-        workerDict.Add("replicas", (box workerReplicas))
 
     // Update the replicas value
     let updatedValues =
         match values with
         | :? Dictionary<obj, obj> as dict ->
             let mutable workerObj = null
+
             if dict.TryGetValue(box "worker", &workerObj) then
                 match workerObj with
                 | :? Dictionary<obj, obj> as workerDict ->
                     workerDict.[(box "stellar_core_image")] <- (box image)
                     workerDict.[(box "replicas")] <- (box workerReplicas)
                     dict.[(box "worker")] <- box workerDict
-                | _ ->
-                    failwith "Unexpected YAML structure"                
+                | _ -> failwith "Unexpected YAML structure"
             else
                 failwith "Unexpected YAML structure"
+
             dict
         | _ ->
             LogError "%s" (values.ToString())
             failwith "Unexpected YAML structure"
 
     // Serialize the updated values to a temporary file
-    let serializer = SerializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build()
+    let serializer =
+        SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build()
+
     let tempFile = Path.GetTempFileName()
     use writer = new StreamWriter(tempFile)
     serializer.Serialize(writer, updatedValues)
     writer.Flush()
     // install the project, then delete the temporary helm values file
-    runCommand [| "helm"; "install"; helmReleaseName; helmChartPath; "--values"; tempFile |] |> ignore
+    runCommand [| "helm"
+                  "install"
+                  helmReleaseName
+                  helmChartPath
+                  "--values"
+                  tempFile |]
+    |> ignore
+
     File.Delete(tempFile)
 
 // Cleanup on exit
@@ -101,45 +111,60 @@ let cleanup () =
     if not cleanupCalled then
         cleanupCalled <- true
         LogInfo "Cleaning up resources..."
-        runCommand [| "helm"; "uninstall"; helmReleaseName |] |> ignore
+
+        runCommand [| "helm"
+                      "uninstall"
+                      helmReleaseName |]
+        |> ignore
 
 System.AppDomain.CurrentDomain.ProcessExit.Add(fun _ -> cleanup ())
-Console.CancelKeyPress.Add(fun _ -> cleanup (); Environment.Exit(0))
+
+Console.CancelKeyPress.Add
+    (fun _ ->
+        cleanup ()
+        Environment.Exit(0))
 
 let getJobMonitorStatus () =
     try
         use client = new HttpClient()
-        let response = client.GetStringAsync("http://ssc-job-monitor.services.stellar-ops.com/status").Result
+
+        let response =
+            client
+                .GetStringAsync(
+                    "http://ssc-job-monitor.services.stellar-ops.com/status"
+                )
+                .Result
+
         let json = JObject.Parse(response)
         Some(json)
-    with
-    | ex ->
+    with ex ->
         LogError "Error querying job monitor: %s" ex.Message
         None
 
 let historyPubnetParallelCatchupV2 (context: MissionContext) =
-    LogInfo
-        "Running parallel catchup v2 ..."
+    LogInfo "Running parallel catchup v2 ..."
 
-    installProject(context.image)
+    installProject (context.image, context.pubnetParallelCatchupNumWorkers)
 
     let mutable jobFinished = false
+
     while not jobFinished do
         Thread.Sleep 10000
-        let statusOpt = getJobMonitorStatus()
+        let statusOpt = getJobMonitorStatus ()
+
         match statusOpt with
         | Some status ->
             LogInfo "status: %s" (status.ToString())
             let remainSize = status.Value<int>("jobs_remain")
             let progressSize = status.Value<int>("jobs_in_progress")
-            let allWorkersDown = 
+
+            let allWorkersDown =
                 let workers = status.["workers"] :?> JArray
-                workers
-                |> Seq.forall (fun w -> (w :?> JObject).["status"].ToString() = "down")
+                workers |> Seq.forall (fun w -> (w :?> JObject).["status"].ToString() = "down")
+
             if allWorkersDown && remainSize = 0 && progressSize = 0 then
                 LogInfo "No job left and all workers are down."
                 jobFinished <- true
-        | None ->
-            LogError "no status"
-            
-    cleanup()
+        | None -> LogError "no status"
+
+    cleanup ()

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -87,8 +87,16 @@ let installProject (context: MissionContext) =
             if dict.TryGetValue(box "range_generator", &rangeObj) then
                 match rangeObj with
                 | :? Dictionary<obj, obj> as rangeDict ->
-                    rangeDict.[(box "starting_ledger")] <- (box context.pubnetParallelCatchupStartingLedger)
-                    rangeDict.[(box "latest_ledger_num")] <- (box (GetLatestPubnetLedgerNumber()))
+                    let mutable dictObj = null
+
+                    if rangeDict.TryGetValue(box "params", &dictObj) then
+                        match dictObj with
+                        | :? Dictionary<obj, obj> as paramsDict ->
+                            paramsDict.[(box "starting_ledger")] <- (box context.pubnetParallelCatchupStartingLedger)
+                            paramsDict.[(box "latest_ledger_num")] <- (box (GetLatestPubnetLedgerNumber()))
+                            rangeDict.[(box "params")] <- box paramsDict
+                        | _ -> failwith "Unexpected YAML structure"
+
                     dict.[(box "range_generator")] <- box rangeDict
                 | _ -> failwith "Unexpected YAML structure"
 

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -66,6 +66,7 @@ let installProject (context: MissionContext) =
     setOptions.Add(sprintf "range_generator.params.starting_ledger=%d" context.pubnetParallelCatchupStartingLedger)
     setOptions.Add(sprintf "range_generator.params.latest_ledger_num=%d" (GetLatestPubnetLedgerNumber()))
     setOptions.Add(sprintf "monitor.hostname=%s" jobMonitorHostName)
+
     runCommand [| "helm"
                   "install"
                   helmReleaseName
@@ -76,7 +77,10 @@ let installProject (context: MissionContext) =
                   String.Join(",", setOptions) |]
     |> ignore
 
-    match runCommand [| "helm"; "get";  "values"; helmReleaseName|] with
+    match runCommand [| "helm"
+                        "get"
+                        "values"
+                        helmReleaseName |] with
     | Some valuesOutput -> LogInfo "%s" valuesOutput
     | _ -> ()
 
@@ -105,7 +109,7 @@ let getJobMonitorStatus () =
         let response =
             client
                 .GetStringAsync(
-                     "http://" + jobMonitorHostName + jobMonitorEndPoint
+                    "http://" + jobMonitorHostName + jobMonitorEndPoint
                 )
                 .Result
 

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -64,7 +64,7 @@ let installProject (context: MissionContext) =
     setOptions.Add(sprintf "worker.stellar_core_image=%s" context.image)
     setOptions.Add(sprintf "worker.replicas=%d" context.pubnetParallelCatchupNumWorkers)
     setOptions.Add(sprintf "range_generator.params.starting_ledger=%d" context.pubnetParallelCatchupStartingLedger)
-    setOptions.Add(sprintf "range_generator.params.latest_ledger_num=%d" (GetLatestPubnetLedgerNumber()))    
+    setOptions.Add(sprintf "range_generator.params.latest_ledger_num=%d" (GetLatestPubnetLedgerNumber()))
     setOptions.Add(sprintf "monitor.hostname=%s" jobMonitorHostName)
     runCommand [| "helm"
                   "install"

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -7,6 +7,139 @@ module MissionHistoryPubnetParallelCatchupV2
 open Logging
 open StellarMissionContext
 
+open System
+open System.Diagnostics
+open System.IO
+open System.Net.Http
+open System.Text
+open System.Collections.Generic
+
+open Newtonsoft.Json.Linq
+open YamlDotNet.Serialization
+open YamlDotNet.Serialization.NamingConventions
+open Microsoft.FSharp.Control
+open System.Threading
+
+// Constants
+let helmReleaseName = "parallel-catchup"
+let helmChartPath = "../MissionParallelCatchup/parallel_catchup_helm"
+let valuesFilePath = helmChartPath + "/values.yaml"
+let workerReplicas = 10
+
+let mutable cleanupCalled = false
+
+let runCommand (command: string[]) =
+    try
+        let psi = ProcessStartInfo()
+        psi.FileName <- command.[0]
+        psi.Arguments <- String.Join(" ", command.[1..])
+        psi.RedirectStandardOutput <- true
+        psi.RedirectStandardError <- true
+        psi.UseShellExecute <- false
+        psi.CreateNoWindow <- true
+        
+        use ps = Process.Start(psi)
+        ps.WaitForExit()
+
+        let output = ps.StandardOutput.ReadToEnd()
+        let error = ps.StandardError.ReadToEnd()
+
+        if ps.ExitCode <> 0 then
+            LogError "Command '%s' failed with error: %s" (String.Join(" ", command)) error
+            None
+        else
+            Some(output)
+    with
+    | ex -> 
+        LogError "Command execution failed: %s" ex.Message
+        None
+
+let installProject (image: string) =
+    LogInfo "Installing Helm chart..."
+    
+    let deserializer = DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build()
+    let values =
+        use reader = new StreamReader(valuesFilePath)
+        deserializer.Deserialize<obj>(reader)
+
+    let updateWorkerDict (workerDict: Dictionary<string, obj>) =
+        workerDict.Add("stellar_core_image", (box image))
+        workerDict.Add("replicas", (box workerReplicas))
+
+    // Update the replicas value
+    let updatedValues =
+        match values with
+        | :? Dictionary<obj, obj> as dict ->
+            let mutable workerObj = null
+            if dict.TryGetValue(box "worker", &workerObj) then
+                match workerObj with
+                | :? Dictionary<obj, obj> as workerDict ->
+                    workerDict.[(box "stellar_core_image")] <- (box image)
+                    workerDict.[(box "replicas")] <- (box workerReplicas)
+                    dict.[(box "worker")] <- box workerDict
+                | _ ->
+                    failwith "Unexpected YAML structure"                
+            else
+                failwith "Unexpected YAML structure"
+            dict
+        | _ ->
+            LogError "%s" (values.ToString())
+            failwith "Unexpected YAML structure"
+
+    // Serialize the updated values to a temporary file
+    let serializer = SerializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build()
+    let tempFile = Path.GetTempFileName()
+    use writer = new StreamWriter(tempFile)
+    serializer.Serialize(writer, updatedValues)
+    writer.Flush()
+    // install the project, then delete the temporary helm values file
+    runCommand [| "helm"; "install"; helmReleaseName; helmChartPath; "--values"; tempFile |] |> ignore
+    File.Delete(tempFile)
+
+// Cleanup on exit
+let cleanup () =
+    if not cleanupCalled then
+        cleanupCalled <- true
+        LogInfo "Cleaning up resources..."
+        runCommand [| "helm"; "uninstall"; helmReleaseName |] |> ignore
+
+System.AppDomain.CurrentDomain.ProcessExit.Add(fun _ -> cleanup ())
+Console.CancelKeyPress.Add(fun _ -> cleanup (); Environment.Exit(0))
+
+let getJobMonitorStatus () =
+    try
+        use client = new HttpClient()
+        let response = client.GetStringAsync("http://ssc-job-monitor.services.stellar-ops.com/status").Result
+        let json = JObject.Parse(response)
+        Some(json)
+    with
+    | ex ->
+        LogError "Error querying job monitor: %s" ex.Message
+        None
+
 let historyPubnetParallelCatchupV2 (context: MissionContext) =
     LogInfo
         "Running parallel catchup v2 ..."
+
+    installProject(context.image)
+
+    let mutable jobFinished = false
+    while not jobFinished do
+        Thread.Sleep 10000
+        let statusOpt = getJobMonitorStatus()
+        match statusOpt with
+        | Some status ->
+            LogInfo "status: %s" (status.ToString())
+            let remainSize = status.Value<int>("jobs_remain")
+            let progressSize = status.Value<int>("jobs_in_progress")
+            let allWorkersDown = 
+                let workers = status.["workers"] :?> JArray
+                workers
+                |> Seq.forall (fun w -> (w :?> JObject).["status"].ToString() = "down")
+            if allWorkersDown && remainSize = 0 && progressSize = 0 then
+                LogInfo "No job left and all workers are down."
+                jobFinished <- true
+        | None ->
+            LogError "no status"
+            
+    cleanup()

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -1,0 +1,12 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+module MissionHistoryPubnetParallelCatchupV2
+
+open Logging
+open StellarMissionContext
+
+let historyPubnetParallelCatchupV2 (context: MissionContext) =
+    LogInfo
+        "Running parallel catchup v2 ..."

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -25,6 +25,8 @@ open System.Threading
 let helmReleaseName = "parallel-catchup"
 let helmChartPath = "../MissionParallelCatchup/parallel_catchup_helm"
 let valuesFilePath = helmChartPath + "/values.yaml"
+let jobMonitorHostName = "ssc-job-monitor.services.stellar-ops.com"
+let jobMonitorEndPoint = "/status"
 let jobMonitorStatusCheckIntervalSecs = 30
 let jobMonitorStatusCheckTimeOutSecs = 300
 let mutable toPerformCleanup = true
@@ -63,6 +65,7 @@ let installProject (context: MissionContext) =
     setOptions.Add(sprintf "worker.replicas=%d" context.pubnetParallelCatchupNumWorkers)
     setOptions.Add(sprintf "range_generator.params.starting_ledger=%d" context.pubnetParallelCatchupStartingLedger)
     setOptions.Add(sprintf "range_generator.params.latest_ledger_num=%d" (GetLatestPubnetLedgerNumber()))    
+    setOptions.Add(sprintf "monitor.hostname=%s" jobMonitorHostName)
     runCommand [| "helm"
                   "install"
                   helmReleaseName
@@ -102,7 +105,7 @@ let getJobMonitorStatus () =
         let response =
             client
                 .GetStringAsync(
-                    "http://ssc-job-monitor.services.stellar-ops.com/status"
+                     "http://" + jobMonitorHostName + jobMonitorEndPoint
                 )
                 .Result
 

--- a/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
+++ b/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
@@ -10,8 +10,6 @@ module MissionMixedImageNetworkSurvey
 // the content of those responses for correctness (for example, it does not
 // check the contents of the JSON response to the `getsurveyresult` command).
 
-open stellar_dotnet_sdk
-
 open Logging
 open StellarCoreSet
 open StellarMissionContext
@@ -20,6 +18,7 @@ open StellarStatefulSets
 open StellarSupercluster
 open StellarCoreHTTP
 open StellarCorePeer
+open StellarDotnetSdk.Accounts
 
 let mixedImageNetworkSurvey (context: MissionContext) =
     let oldNodeCount = 1

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -5,12 +5,12 @@
 module StellarCoreCfg
 
 open FSharp.Data
-open stellar_dotnet_sdk
 open Nett
 open System.Text.RegularExpressions
 open StellarCoreSet
 open StellarNetworkCfg
 open StellarShellCmd
+open StellarDotnetSdk.Accounts
 
 // Submodule of short fixed (or lightly parametrized) config values: names,
 // paths, labels, etc.

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -5,7 +5,6 @@
 module StellarCoreHTTP
 
 open FSharp.Data
-open stellar_dotnet_sdk
 open StellarCoreSet
 open PollRetry
 open Logging
@@ -13,7 +12,8 @@ open StellarMissionContext
 open StellarNetworkCfg
 open StellarCorePeer
 open System.Threading
-
+open StellarDotnetSdk.Transactions
+open StellarDotnetSdk.Responses.Results
 
 // Note to curious reader: these are "type providers" whereby the compiler's
 // type definition facility is extended by plugins that are themselves
@@ -751,7 +751,7 @@ type Peer with
             match res.Error with
             | None -> ()
             | Some (r) ->
-                let txr = responses.TransactionResult.FromXdr(r)
+                let txr = TransactionResult.FromXdrBase64(r)
                 LogError "Result details: %O" txr
 
             raise (TransactionRejectedException tx)

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -4,7 +4,7 @@
 
 module StellarCoreSet
 
-open stellar_dotnet_sdk
+open StellarDotnetSdk.Accounts
 
 // A PodName followed by the (nonce-qualified) service DNS suffix for a
 // given network, such as

--- a/src/FSLibrary/StellarMission.fs
+++ b/src/FSLibrary/StellarMission.fs
@@ -18,6 +18,7 @@ open MissionHistoryPubnetRecentCatchup
 open MissionHistoryPubnetCompleteCatchup
 open MissionHistoryPubnetParallelCatchup
 open MissionHistoryPubnetParallelCatchupExtrawide
+open MissionHistoryPubnetParallelCatchupV2
 open MissionHistoryPubnetPerformance
 open MissionHistoryTestnetMinimumCatchup
 open MissionHistoryTestnetRecentCatchup
@@ -62,6 +63,7 @@ let allMissions : Map<string, Mission> =
                  ("HistoryPubnetCompleteCatchup", historyPubnetCompleteCatchup)
                  ("HistoryPubnetParallelCatchup", historyPubnetParallelCatchup)
                  ("HistoryPubnetParallelCatchupExtrawide", historyPubnetParallelCatchupExtrawide)
+                 ("HistoryPubnetParallelCatchupV2", historyPubnetParallelCatchupV2)
                  ("HistoryPubnetPerformance", historyPubnetPerformance)
                  ("HistoryTestnetMinimumCatchup", historyTestnetMinimumCatchup)
                  ("HistoryTestnetRecentCatchup", historyTestnetRecentCatchup)

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -90,6 +90,7 @@ type MissionContext =
       numRuns: int option
       networkSizeLimit: int
       pubnetParallelCatchupStartingLedger: int
+      pubnetParallelCatchupNumWorkers: int
 
       // Tail logging can cause the pubnet simulation missions like SorobanLoadGeneration
       // and SimulatePubnet to fail on the heartbeat handler due to what looks like a

--- a/src/FSLibrary/StellarNetworkCfg.fs
+++ b/src/FSLibrary/StellarNetworkCfg.fs
@@ -4,9 +4,9 @@
 
 module StellarNetworkCfg
 
-open stellar_dotnet_sdk
 open StellarMissionContext
 open StellarCoreSet
+open StellarDotnetSdk
 
 // We identify SSC runs using a "nonce" composed from an hours-and-minutes
 // timestamp, a random 24-bit value, and an optional user-provided tag.

--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -5,11 +5,11 @@
 module StellarNetworkData
 
 open FSharp.Data
-open stellar_dotnet_sdk
 open StellarCoreSet
 open StellarCoreCfg
 open StellarMissionContext
 open Logging
+open StellarDotnetSdk.Accounts
 
 type HistoryArchiveState = JsonProvider<"json-type-samples/sample-stellar-history.json", ResolutionFolder=cwd>
 

--- a/src/FSLibrary/StellarTransaction.fs
+++ b/src/FSLibrary/StellarTransaction.fs
@@ -1,10 +1,13 @@
 module StellarTransaction
 
-open stellar_dotnet_sdk
-
 open StellarNetworkCfg
 open StellarCorePeer
 open StellarCoreHTTP
+open StellarDotnetSdk.Accounts
+open StellarDotnetSdk
+open StellarDotnetSdk.Transactions
+open StellarDotnetSdk.Assets
+open StellarDotnetSdk.Operations
 
 type Username =
 
@@ -82,7 +85,7 @@ type Peer with
     member self.TxCreateAccount(u: Username) : Transaction =
         let root = self.RootAccount
         let newKey = self.GetKeypair u
-        let trb = Transaction.Builder(root)
+        let trb = TransactionBuilder(root);
         let tx = trb.AddOperation(CreateAccountOperation(newKey, "10000")).Build()
         tx.Sign(signer = self.RootKeypair, network = self.GetNetwork())
         tx
@@ -92,14 +95,11 @@ type Peer with
         let recv = self.GetKeypair recipient
         let asset = AssetTypeNative()
         let amount = "100"
-        let trb = Transaction.Builder(send)
+        let trb = TransactionBuilder(send)
 
         let tx =
             trb
-                .AddOperation(PaymentOperation
-                    .Builder(recv, asset, amount)
-                    .SetSourceAccount(send.KeyPair)
-                    .Build())
+                .AddOperation(PaymentOperation(recv, asset, amount, send.KeyPair))
                 .Build()
 
         tx.Sign(signer = (self.GetKeypair sender), network = self.GetNetwork())

--- a/src/FSLibrary/StellarTransaction.fs
+++ b/src/FSLibrary/StellarTransaction.fs
@@ -85,7 +85,7 @@ type Peer with
     member self.TxCreateAccount(u: Username) : Transaction =
         let root = self.RootAccount
         let newKey = self.GetKeypair u
-        let trb = TransactionBuilder(root);
+        let trb = TransactionBuilder(root)
         let tx = trb.AddOperation(CreateAccountOperation(newKey, "10000")).Build()
         tx.Sign(signer = self.RootKeypair, network = self.GetNetwork())
         tx
@@ -97,10 +97,7 @@ type Peer with
         let amount = "100"
         let trb = TransactionBuilder(send)
 
-        let tx =
-            trb
-                .AddOperation(PaymentOperation(recv, asset, amount, send.KeyPair))
-                .Build()
+        let tx = trb.AddOperation(PaymentOperation(recv, asset, amount, send.KeyPair)).Build()
 
         tx.Sign(signer = (self.GetKeypair sender), network = self.GetNetwork())
         tx

--- a/src/MissionParallelCatchup/Dockerfile.jobmonitor
+++ b/src/MissionParallelCatchup/Dockerfile.jobmonitor
@@ -1,0 +1,20 @@
+# Use an official Python runtime as a parent image
+FROM --platform=linux/amd64 python:3.12-slim as build
+
+VOLUME /data
+
+# Set the working directory
+WORKDIR /app
+COPY ./job_monitor.py /app
+
+# Install optional tools for troubleshooting
+RUN apt-get update && apt-get install -y dnsutils net-tools iputils-ping
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir redis requests
+
+# Make port 8080 available to the world outside this container
+EXPOSE 8080
+
+# Run job_monitor.py when the container launches
+CMD ["python", "job_monitor.py"]

--- a/src/MissionParallelCatchup/Dockerfile.jobmonitor
+++ b/src/MissionParallelCatchup/Dockerfile.jobmonitor
@@ -1,20 +1,21 @@
-# Use an official Python runtime as a parent image
-FROM --platform=linux/amd64 python:3.12-slim as build
+FROM --platform=linux/amd64 ubuntu:22.04
 
 VOLUME /data
 
-# Set the working directory
 WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y \
+    python3 \
+    python3-pip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY ./job_monitor.py /app
 
-# Install optional tools for troubleshooting
-RUN apt-get update && apt-get install -y dnsutils net-tools iputils-ping
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --no-cache-dir redis requests
 
-# Install any needed packages specified in requirements.txt
-RUN pip install --no-cache-dir redis requests
-
-# Make port 8080 available to the world outside this container
 EXPOSE 8080
 
-# Run job_monitor.py when the container launches
-CMD ["python", "job_monitor.py"]
+CMD ["/usr/bin/python3", "job_monitor.py"]

--- a/src/MissionParallelCatchup/job_monitor.py
+++ b/src/MissionParallelCatchup/job_monitor.py
@@ -21,13 +21,27 @@ NAMESPACE = os.getenv('NAMESPACE', 'default')
 WORKER_COUNT = int(os.getenv('WORKER_COUNT', 3))
 LOGGING_INTERVAL_SECONDS = int(os.getenv('LOGGING_INTERVAL_SECONDS', 10))
 
+def get_logging_level():
+    name_to_level = {
+        'CRITICAL': logging.CRITICAL,
+        'ERROR': logging.ERROR,
+        'WARNING': logging.WARNING,
+        'INFO': logging.INFO,
+        'DEBUG': logging.DEBUG,
+    }
+    result = name_to_level.get(os.getenv('LOGGING_LEVEL', 'INFO'))
+    if result is not None:
+        return result
+    else:
+        return logging.INFO
+
 # Initialize Redis client
 redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 
 # Configure logging
 log_file_name = f"job_monitor_{datetime.now(timezone.utc).strftime('%Y-%m-%d_%H-%M-%S')}.log"
 log_file_path = os.path.join('/data', log_file_name)
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', handlers=[
+logging.basicConfig(level=get_logging_level(), format='%(asctime)s - %(levelname)s - %(message)s', handlers=[
     logging.StreamHandler(sys.stdout),
     logging.FileHandler(log_file_path),
 ])
@@ -35,10 +49,10 @@ logger = logging.getLogger()
 
 # In-memory status data structure and threading lock
 status = {
-    'jobs_remain': 1, # initialize the job remaining to non-zero to indicate something is running, just the status hasn't been updated yet
-    'jobs_succeeded': 0,
-    'jobs_failed': 0,
-    'jobs_in_progress': 0,
+    'num_remain': 1, # initialize the job remaining to non-zero to indicate something is running, just the status hasn't been updated yet
+    'num_succeeded': 0,
+    'jobs_failed': [],
+    'jobs_in_progress': [],
     'workers': []
 }
 status_lock = threading.Lock()
@@ -71,8 +85,8 @@ def update_status():
                 worker_name = f"{WORKER_PREFIX}-{i}.{WORKER_PREFIX}.{NAMESPACE}.svc.cluster.local"
                 try:
                     response = requests.get(f"http://{worker_name}:11626/info")
-                    logger.debug("Worker %s is running, response: %d", worker_name, response.status_code)
-                    worker_statuses.append({'worker_id': i, 'status': 'running', 'response': response.status_code})
+                    logger.debug("Worker %s is running, status code %d, response: %s", worker_name, response.status_code, response.json())
+                    worker_statuses.append({'worker_id': i, 'status': 'running', 'info': response.json()['info']['status']})
                     all_workers_down = False
                 except requests.exceptions.RequestException:
                     logger.debug("Worker %s is down", worker_name)
@@ -84,15 +98,18 @@ def update_status():
                 retry_jobs_in_progress()
 
             # Check the queue status
-            jobs_remain = redis_client.llen(JOB_QUEUE)
-            jobs_succeeded = redis_client.llen(SUCCESS_QUEUE)
-            jobs_failed = redis_client.llen(FAILED_QUEUE)
-            jobs_in_progress = redis_client.llen(PROGRESS_QUEUE)
+            # For remaining and successful jobs, we just print their count, do not care what they are and who owns it
+            num_remain = redis_client.llen(JOB_QUEUE)
+            num_succeeded = redis_client.llen(SUCCESS_QUEUE)
+            # For failed and in-progress jobs, we retrieve their full content
+            jobs_failed = redis_client.lrange(FAILED_QUEUE, 0, -1)
+            jobs_in_progress = redis_client.lrange(PROGRESS_QUEUE, 0, -1)
+
             # update the status
             with status_lock:
                 status = {
-                    'jobs_remain': jobs_remain,
-                    'jobs_succeeded': jobs_succeeded,
+                    'num_remain': num_remain,
+                    'num_succeeded': num_succeeded,
                     'jobs_failed': jobs_failed,
                     'jobs_in_progress': jobs_in_progress,
                     'workers': worker_statuses

--- a/src/MissionParallelCatchup/job_monitor.py
+++ b/src/MissionParallelCatchup/job_monitor.py
@@ -1,0 +1,117 @@
+import os
+import redis
+import requests
+import json
+import sys
+import logging
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from datetime import datetime, UTC
+
+# Configuration
+REDIS_HOST = 'redis'
+REDIS_PORT = 6379
+JOB_QUEUE = os.getenv('JOB_QUEUE', 'ranges')
+SUCCESS_QUEUE = os.getenv('SUCCESS_QUEUE', 'succeeded')
+FAILED_QUEUE = os.getenv('FAILED_QUEUE', 'failed')
+PROGRESS_QUEUE = os.getenv('PROGRESS_QUEUE', 'in_progress')
+WORKER_PREFIX = os.getenv('WORKER_PREFIX', 'stellar-core')
+NAMESPACE = os.getenv('NAMESPACE', 'default')
+WORKER_COUNT = int(os.getenv('WORKER_COUNT', 3))
+LOGGING_INTERVAL_SECONDS = int(os.getenv('LOGGING_INTERVAL_SECONDS', 10))
+
+# Initialize Redis client
+redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
+
+# Configure logging
+log_file_name = f"job_monitor_{datetime.now(UTC).strftime('%Y-%m-%d_%H-%M-%S')}.log"
+log_file_path = os.path.join('/data', log_file_name)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', handlers=[
+    logging.StreamHandler(sys.stdout),
+    logging.FileHandler(log_file_path),
+])
+logger = logging.getLogger()
+
+# In-memory status data structure and threading lock
+status = {
+    'jobs_remain': 1, # initialize the job remaining to non-zero to indicate something is running, just the status hasn't been updated yet
+    'jobs_succeeded': 0,
+    'jobs_failed': 0,
+    'jobs_in_progress': 0,
+    'workers': []
+}
+status_lock = threading.Lock()
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/status':
+            self.send_response(200)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            with status_lock:
+                self.wfile.write(json.dumps(status).encode())                
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+def retry_jobs_in_progress():
+    while redis_client.llen(PROGRESS_QUEUE) > 0:
+        job = redis_client.lmove(PROGRESS_QUEUE, JOB_QUEUE, "RIGHT", "LEFT")
+        logger.info("moved job %s from %s to %s", job, PROGRESS_QUEUE, JOB_QUEUE)
+
+def update_status():
+    global status
+    while True:
+        try:
+            # Ping each worker status
+            worker_statuses = []
+            all_workers_down = True
+            for i in range(WORKER_COUNT):
+                worker_name = f"{WORKER_PREFIX}-{i}.{WORKER_PREFIX}.{NAMESPACE}.svc.cluster.local"
+                try:
+                    response = requests.get(f"http://{worker_name}:11626/info")
+                    logger.debug("Worker %s is running, response: %d", worker_name, response.status_code)
+                    worker_statuses.append({'worker_id': i, 'status': 'running', 'response': response.status_code})
+                    all_workers_down = False
+                except requests.exceptions.RequestException:
+                    logger.debug("Worker %s is down", worker_name)
+                    worker_statuses.append({'worker_id': i, 'status': 'down'})
+            # Retry stuck jobs
+            if all_workers_down and redis_client.llen(PROGRESS_QUEUE) > 0:
+                logger.info("all workers are down but some jobs are stuck in progress")
+                logger.info("moving them from %s to %s queue", PROGRESS_QUEUE, JOB_QUEUE)
+                retry_jobs_in_progress()
+
+            # Check the queue status
+            jobs_remain = redis_client.llen(JOB_QUEUE)
+            jobs_succeeded = redis_client.llen(SUCCESS_QUEUE)
+            jobs_failed = redis_client.llen(FAILED_QUEUE)
+            jobs_in_progress = redis_client.llen(PROGRESS_QUEUE)
+            # update the status
+            with status_lock:
+                status = {
+                    'jobs_remain': jobs_remain,
+                    'jobs_succeeded': jobs_succeeded,
+                    'jobs_failed': jobs_failed,
+                    'jobs_in_progress': jobs_in_progress,
+                    'workers': worker_statuses
+                }
+            logger.info("Status: %s", json.dumps(status))
+        except Exception as e:
+            logger.error("Error while getting status: %s", str(e))
+
+        time.sleep(LOGGING_INTERVAL_SECONDS)
+
+def run(server_class=HTTPServer, handler_class=RequestHandler):
+    server_address = ('', 8080)
+    httpd = server_class(server_address, handler_class)
+    logger.info('Starting httpd server...')
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    log_thread = threading.Thread(target=update_status)
+    log_thread.daemon = True
+    log_thread.start()    
+
+    run()

--- a/src/MissionParallelCatchup/job_monitor.py
+++ b/src/MissionParallelCatchup/job_monitor.py
@@ -7,7 +7,7 @@ import logging
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 # Configuration
 REDIS_HOST = 'redis'
@@ -25,7 +25,7 @@ LOGGING_INTERVAL_SECONDS = int(os.getenv('LOGGING_INTERVAL_SECONDS', 10))
 redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 
 # Configure logging
-log_file_name = f"job_monitor_{datetime.now(UTC).strftime('%Y-%m-%d_%H-%M-%S')}.log"
+log_file_name = f"job_monitor_{datetime.now(timezone.utc).strftime('%Y-%m-%d_%H-%M-%S')}.log"
 log_file_path = os.path.join('/data', log_file_name)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', handlers=[
     logging.StreamHandler(sys.stdout),

--- a/src/MissionParallelCatchup/job_monitor.py
+++ b/src/MissionParallelCatchup/job_monitor.py
@@ -10,8 +10,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from datetime import datetime, timezone
 
 # Configuration
-REDIS_HOST = 'redis'
-REDIS_PORT = 6379
+REDIS_HOST = os.getenv('REDIS_HOST', 'redis')
+REDIS_PORT = int(os.getenv('REDIS_PORT', '6379'))
 JOB_QUEUE = os.getenv('JOB_QUEUE', 'ranges')
 SUCCESS_QUEUE = os.getenv('SUCCESS_QUEUE', 'succeeded')
 FAILED_QUEUE = os.getenv('FAILED_QUEUE', 'failed')

--- a/src/MissionParallelCatchup/parallel_catchup_helm/.helmignore
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/src/MissionParallelCatchup/parallel_catchup_helm/Chart.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: parallel-catchup
+description: A Helm chart for deploying the parallel-catchup application
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/logarithmic_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/logarithmic_range_generator.sh
@@ -30,7 +30,7 @@ generate_uniform () {
         redis-cli -h redis -p 6379 RPUSH ranges "${el}/${ledgersToApply}";
         el=$(( el - ledgersPerJob ));
         # sleep for a short duration to avoid overloading the redis-cli connection
-        sleep 0.5
+        sleep 1
     done
 }
 

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/logarithmic_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/logarithmic_range_generator.sh
@@ -27,7 +27,7 @@ generate_uniform () {
         ledgersToApply=$((ledgersPerJob + overlapLedgers));
         echo "${el}/${ledgersToApply}";
         # our queue assumes push-left-pop-right, but since we are generating the ranges in reverse order, here we push right
-        redis-cli -h redis -p 6379 RPUSH ranges "${el}/${ledgersToApply}";
+        redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" RPUSH ranges "${el}/${ledgersToApply}";
         el=$(( el - ledgersPerJob ));
         # sleep for a short duration to avoid overloading the redis-cli connection
         sleep 1

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/logarithmic_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/logarithmic_range_generator.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+floorSize=$LOGARITHMIC_FLOOR_LEDGERS
+overlapLedgers=$OVERLAP_LEDGERS
+startLedger=$(echo "$STARTING_LEDGER" | awk '{printf "%d", $1}')
+latestLedgerNum=$(echo "$LATEST_LEDGER_NUM" | awk '{printf "%d", $1}')
+numParallelism=$NUM_PARALLELISM
+
+echo "starting logarithmic range generationg with the following inputs: 
+floorSize=$floorSize
+overlapLedgers=$overlapLedgers
+startLedger=$startLedger
+latestLedgerNum=$latestLedgerNum
+numParallelism=$numParallelism"
+
+generate_uniform () {
+    sl="$1"
+    el="$2"
+    ss="$3"
+    echo "generating uniform ranges from parameters: startLedger=$sl, endLedger=$el, segSize=$ss"
+    while [ "$el" -gt "$sl" ]; do
+        ledgersToApply=$((ss + overlapLedgers));
+        echo "${el}/${ledgersToApply}";
+        # our queue assumes push-left-pop-right, but since we are generating the ranges in reverse order, here we push right
+        redis-cli -h redis -p 6379 RPUSH ranges "${el}/${ledgersToApply}";
+        el=$(( el - ledgersToApply ));
+        # sleep for a short duration to avoid overloading the redis-cli connection
+        sleep 0.5
+    done
+}
+
+endLedger=$((latestLedgerNum / 2))
+chunkSize=$(( (endLedger - startLedger + 1) / numParallelism ))
+while [ "$chunkSize" -gt "$floorSize" ]; do
+    generate_uniform "$startLedger" "$endLedger" "$chunkSize"
+    startLedger=$(( endLedger + 1 ))
+    chunkSize=$(( chunkSize / 2 ))
+    endLedger=$((startLedger + (chunkSize * numParallelism)  ))
+done
+
+# treat the rest with one uniform-ranged chunk
+generate_uniform "$((endLedger+1))" "$latestLedgerNum" "$floorSize"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/logarithmic_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/logarithmic_range_generator.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# Check if required environment variables are set
+if [ -z "$LOGARITHMIC_FLOOR_LEDGERS" ]; then echo "LOGARITHMIC_FLOOR_LEDGERS not set"; exit 1; fi
+if [ -z "$OVERLAP_LEDGERS" ]; then echo "OVERLAP_LEDGERS not set"; exit 1; fi
+if [ -z "$STARTING_LEDGER" ]; then echo "STARTING_LEDGER not set"; exit 1; fi
+if [ -z "$LATEST_LEDGER_NUM" ]; then echo "LATEST_LEDGER_NUM not set"; exit 1; fi
+if [ -z "$NUM_PARALLELISM" ]; then echo "NUM_PARALLELISM not set"; exit 1; fi
+if [ -z "$REDIS_HOST" ]; then echo "REDIS_HOST not set"; exit 1; fi
+if [ -z "$REDIS_PORT" ]; then echo "REDIS_PORT not set"; exit 1; fi
+
 floorSize=$LOGARITHMIC_FLOOR_LEDGERS
 overlapLedgers=$OVERLAP_LEDGERS
 startLedger=$(echo "$STARTING_LEDGER" | awk '{printf "%d", $1}')

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/stellar-core.cfg
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/stellar-core.cfg
@@ -3,7 +3,7 @@ PUBLIC_HTTP_PORT=true
 NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 DATABASE="sqlite3:///data/stellar.db"
 BUCKET_DIR_PATH="/data/buckets"
-LOG_FILE_PATH="/data/stellar-core-{datetime:%Y-%m-%d_%H-%M-%S}.log"    
+LOG_FILE_PATH="/data/stellar-core.log"
 ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
 DEPRECATED_SQL_LEDGER_STATE=false
 

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/stellar-core.cfg
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/stellar-core.cfg
@@ -1,0 +1,33 @@
+HTTP_PORT=11626
+PUBLIC_HTTP_PORT=true
+NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+DATABASE="sqlite3:///data/stellar.db"
+BUCKET_DIR_PATH="/data/buckets"
+LOG_FILE_PATH="/data/stellar-core-{datetime:%Y-%m-%d_%H-%M-%S}.log"    
+ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
+DEPRECATED_SQL_LEDGER_STATE=false
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="www.stellar.org"
+QUALITY="HIGH"
+
+[[VALIDATORS]]
+NAME = "SDF 1"
+PUBLIC_KEY = "GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
+ADDRESS = "core-live-a.stellar.org:11625"
+HISTORY = "curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
+HOME_DOMAIN = "www.stellar.org"
+
+[[VALIDATORS]]
+NAME = "SDF 2"
+PUBLIC_KEY = "GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK"
+ADDRESS = "core-live-b.stellar.org:11625"
+HISTORY = "curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
+HOME_DOMAIN = "www.stellar.org"
+
+[[VALIDATORS]]
+NAME = "SDF 3"
+PUBLIC_KEY = "GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ"
+ADDRESS = "core-live-c.stellar.org:11625"
+HISTORY = "curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
+HOME_DOMAIN = "www.stellar.org"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
@@ -5,11 +5,17 @@ overlapLedgers=$OVERLAP_LEDGERS
 startingLedger=$(echo "$STARTING_LEDGER" | awk '{printf "%d", $1}')
 endRange=$(echo "$LATEST_LEDGER_NUM" | awk '{printf "%d", $1}')
 
-echo "Generating uniform ledger ranges from parameters ledgersPerJob=$ledgersPerJob, overlapLedgers=$overlapLedgers, startingLedger=$startingLedger, endRange=$endRange"
+echo "Generating uniform ledger ranges from parameters 
+ledgersPerJob=$ledgersPerJob,
+overlapLedgers=$overlapLedgers,
+startingLedger=$startingLedger,
+endRange=$endRange"
 
 while [ "$endRange" -gt "$startingLedger" ]; do
     ledgersToApply=$((ledgersPerJob + overlapLedgers));
     echo "${endRange}/${ledgersToApply}";
     redis-cli -h redis -p 6379 RPUSH ranges "${endRange}/${ledgersToApply}";
     endRange=$(( endRange - ledgersPerJob ));
+    # sleep for a short duration to avoid overloading the redis-cli connection
+    sleep 0.5
 done

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
@@ -2,8 +2,8 @@
 
 ledgersPerJob=$LEDGERS_PER_JOB
 overlapLedgers=$OVERLAP_LEDGERS
-startingLedger=$STARTING_LEDGER
-endRange=$LATEST_LEDGER_NUM
+startingLedger=$(echo "$STARTING_LEDGER" | awk '{printf "%d", $1}')
+endRange=$(echo "$LATEST_LEDGER_NUM" | awk '{printf "%d", $1}')
 
 echo "Generating uniform ledger ranges from parameters ledgersPerJob=$ledgersPerJob, overlapLedgers=$overlapLedgers, startingLedger=$startingLedger, endRange=$endRange"
 

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
@@ -14,7 +14,7 @@ endRange=$endRange"
 while [ "$endRange" -gt "$startingLedger" ]; do
     ledgersToApply=$((ledgersPerJob + overlapLedgers));
     echo "${endRange}/${ledgersToApply}";
-    redis-cli -h redis -p 6379 RPUSH ranges "${endRange}/${ledgersToApply}";
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" RPUSH ranges "${endRange}/${ledgersToApply}";
     endRange=$(( endRange - ledgersPerJob ));
     # sleep for a short duration to avoid overloading the redis-cli connection
     sleep 1

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+ledgersPerJob=$LEDGERS_PER_JOB
+overlapLedgers=$OVERLAP_LEDGERS
+startingLedger=$STARTING_LEDGER
+endRange=$LATEST_LEDGER_NUM
+
+echo "Generating uniform ledger ranges from parameters ledgersPerJob=$ledgersPerJob, overlapLedgers=$overlapLedgers, startingLedger=$startingLedger, endRange=$endRange"
+
+while [ "$endRange" -gt "$startingLedger" ]; do
+    ledgersToApply=$((ledgersPerJob + overlapLedgers));
+    echo "${endRange}/${ledgersToApply}";
+    redis-cli -h redis -p 6379 RPUSH ranges "${endRange}/${ledgersToApply}";
+    endRange=$(( endRange - ledgersPerJob ));
+done

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
@@ -17,5 +17,5 @@ while [ "$endRange" -gt "$startingLedger" ]; do
     redis-cli -h redis -p 6379 RPUSH ranges "${endRange}/${ledgersToApply}";
     endRange=$(( endRange - ledgersPerJob ));
     # sleep for a short duration to avoid overloading the redis-cli connection
-    sleep 0.5
+    sleep 1
 done

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/uniform_range_generator.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# Check if required environment variables are set
+if [ -z "$LEDGERS_PER_JOB" ]; then echo "LEDGERS_PER_JOB not set"; exit 1; fi
+if [ -z "$OVERLAP_LEDGERS" ]; then echo "OVERLAP_LEDGERS not set"; exit 1; fi
+if [ -z "$STARTING_LEDGER" ]; then echo "STARTING_LEDGER not set"; exit 1; fi
+if [ -z "$LATEST_LEDGER_NUM" ]; then echo "LATEST_LEDGER_NUM not set"; exit 1; fi
+if [ -z "$REDIS_HOST" ]; then echo "REDIS_HOST not set"; exit 1; fi
+if [ -z "$REDIS_PORT" ]; then echo "REDIS_PORT not set"; exit 1; fi
+
 ledgersPerJob=$LEDGERS_PER_JOB
 overlapLedgers=$OVERLAP_LEDGERS
 startingLedger=$(echo "$STARTING_LEDGER" | awk '{printf "%d", $1}')

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+SLEEP_INTERVAL=10
+LOG_DIR="/data"
+REDIS_HOST="redis"
+REDIS_PORT=6379
+JOB_QUEUE=$JOB_QUEUE
+SUCCESS_QUEUE=$SUCCESS_QUEUE
+FAILED_QUEUE=$FAILED_QUEUE
+PROGRESS_QUEUE=$PROGRESS_QUEUE
+POD_NAME=$POD_NAME
+RELEASE_NAME=$RELEASE_NAME
+
+# First install redis-cli. Ideally this should be handled in the image itself but we don't want to bloat the core dependencies. 
+apt-get update && apt-get install -y redis-tools
+if [ $? -ne 0 ]; then
+echo "Faild to install redis-tools"
+exit 1
+fi
+
+while true; do
+# Fetch the next job key from the Redis queue. 
+# The queue operation is always push left pop right. 
+JOB_KEY=$(redis-cli -h $REDIS_HOST -p $REDIS_PORT LMOVE $JOB_QUEUE $PROGRESS_QUEUE RIGHT LEFT)
+
+if [ -n "$JOB_KEY" ]; then
+    # Start timer
+    START_TIME=$(date +%s)  
+    echo "Processing job: $JOB_KEY"
+
+    /usr/bin/stellar-core --conf /config/stellar-core.cfg new-db
+    /usr/bin/stellar-core --conf /config/stellar-core.cfg catchup $JOB_KEY --metric 'ledger.transaction.apply'
+    if [ $? -ne 0 ]; then
+    echo "Error processing job: $JOB_KEY"
+    redis-cli -h $REDIS_HOST -p $REDIS_PORT LPUSH $FAILED_QUEUE $JOB_KEY
+    else
+    echo "Successfully processed job: $JOB_KEY"
+    redis-cli -h $REDIS_HOST -p $REDIS_PORT LPUSH $SUCCESS_QUEUE $JOB_KEY
+    fi
+    redis-cli -h $REDIS_HOST -p $REDIS_PORT LREM $PROGRESS_QUEUE -1 $JOB_KEY
+
+    # Parse and extract the metrics from the log file
+    LOG_FILE=$(ls -t $LOG_DIR/stellar-core-*.log | head -n 1)
+    if [ -z "$LOG_FILE" ]; then
+    echo "No log file found."
+    exit 1
+    fi
+
+    transaction_sum=$(tac "$LOG_FILE" | grep -m 1 -B 11 "metric 'ledger.transaction.apply':" | grep "sum =" | awk '{print $NF}')
+    echo "Log file: $LOG_FILE"
+    echo "ledger.transaction.apply sum: $transaction_sum"
+
+    # End timer and duration
+    END_TIME=$(date +%s)
+    DURATION=$((END_TIME - START_TIME))
+    echo "Finish processing job: $JOB_KEY, duration (seconds): $DURATION"
+
+    # publish metrics
+    cat <<EOF | curl --data-binary @- http://pushgateway.services.stellar-ops.com:9091/metrics/job/${RELEASE_NAME}/instance/${POD_NAME}
+total_duration_seconds{catchup_to_ledger="${JOB_KEY%/*}",ledgers_to_apply="${JOB_KEY#*/}"} $DURATION
+ledger_transaction_apply_ms{catchup_to_ledger="${JOB_KEY%/*}",ledgers_to_apply="${JOB_KEY#*/}"} $(echo "$transaction_sum" | sed 's/ms$//')
+EOF
+
+else
+    echo "No more jobs in the queue. Sleeping for $SLEEP_INTERVAL seconds..."
+    sleep $SLEEP_INTERVAL
+fi
+done

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
@@ -2,8 +2,6 @@
 
 SLEEP_INTERVAL=10
 LOG_DIR="/data"
-REDIS_HOST="redis"
-REDIS_PORT=6379
 
 # ensure redis-cli is available
 if [ ! "$(redis-cli --version)" ]; then

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
@@ -31,7 +31,7 @@ if [ -n "$JOB_KEY" ]; then
     redis-cli -h $REDIS_HOST -p $REDIS_PORT LREM "$PROGRESS_QUEUE" -1 "$JOB_KEY"
 
     # Parse and extract the metrics from the log file
-    LOG_FILE=$(ls -t $LOG_DIR/stellar-core-*.log | head -n 1)
+    LOG_FILE=$(ls -t $LOG_DIR/stellar-core*.log | head -n 1)
     if [ -z "$LOG_FILE" ]; then
     echo "No log file found."
     exit 1

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
@@ -1,13 +1,23 @@
 #!/bin/sh
 
-SLEEP_INTERVAL=10
-LOG_DIR="/data"
+# Check if required environment variables are set
+if [ -z "$REDIS_HOST" ]; then echo "REDIS_HOST not set"; exit 1; fi
+if [ -z "$REDIS_PORT" ]; then echo "REDIS_PORT not set"; exit 1; fi
+if [ -z "$JOB_QUEUE" ]; then echo "JOB_QUEUE not set"; exit 1; fi
+if [ -z "$PROGRESS_QUEUE" ]; then echo "PROGRESS_QUEUE not set"; exit 1; fi
+if [ -z "$FAILED_QUEUE" ]; then echo "FAILED_QUEUE not set"; exit 1; fi
+if [ -z "$SUCCESS_QUEUE" ]; then echo "SUCCESS_QUEUE not set"; exit 1; fi
+if [ -z "$RELEASE_NAME" ]; then echo "RELEASE_NAME not set"; exit 1; fi
+if [ -z "$POD_NAME" ]; then echo "POD_NAME not set"; exit 1; fi
 
 # ensure redis-cli is available
 if [ ! "$(redis-cli --version)" ]; then
     echo "redis-cli not found, please ensure running with a supported stellar-core version"
     exit 1
 fi
+
+SLEEP_INTERVAL=10
+LOG_DIR="/data"
 
 while true; do
 # Fetch the next job key from the Redis queue. 

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -34,13 +34,13 @@ spec:
         # resource specs copied from the old supercluster mission
         resources:
           requests:
-            cpu: "{{ .Values.worker.request_cpu}}"
-            memory: "{{ .Values.worker.request_memory}}"
-            ephemeral-storage: "{{ .Values.worker.request_ephemeral_storage}}"
+            cpu: "{{ .Values.worker.resources.requests.cpu}}"
+            memory: "{{ .Values.worker.resources.requests.memory}}"
+            ephemeral-storage: "{{ .Values.worker.resources.requests.ephemeral_storage}}"
           limits:
-            cpu: "{{ .Values.worker.limit_cpu}}"
-            memory: "{{ .Values.worker.limit_memory}}"
-            ephemeral-storage: "{{ .Values.worker.limit_ephemeral_storage}}"
+            cpu: "{{ .Values.worker.resources.limits.cpu}}"
+            memory: "{{ .Values.worker.resources.limits.memory}}"
+            ephemeral-storage: "{{ .Values.worker.resources.limits.ephemeral_storage}}"
         command: ["/bin/sh", "/scripts/worker.sh"]
         ports:
         - containerPort: 11626

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -45,20 +45,13 @@ spec:
         ports:
         - containerPort: 11626
         env:
-        - name: JOB_QUEUE
-          value: "{{ .Values.redis.job_queue }}"
-        - name: SUCCESS_QUEUE
-          value: "{{ .Values.redis.success_queue }}"
-        - name: FAILED_QUEUE
-          value: "{{ .Values.redis.failed_queue }}"
-        - name: PROGRESS_QUEUE
-          value: "{{ .Values.redis.progress_queue }}"
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: RELEASE_NAME
-          value: "{{ .Release.Name }}"
+        envFrom:
+        - configMapRef:
+            name: worker-config
         volumeMounts:
         - name: config
           mountPath: /config
@@ -87,3 +80,16 @@ metadata:
 data:
   stellar-core.cfg: |-
     {{- (.Files.Get "files/stellar-core.cfg") | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: worker-config
+data:
+  REDIS_HOST: "{{ .Values.redis.hostname}}"
+  REDIS_PORT: "{{ .Values.redis.port}}"
+  JOB_QUEUE: "{{ .Values.redis.job_queue }}"
+  SUCCESS_QUEUE: "{{ .Values.redis.success_queue }}"
+  FAILED_QUEUE: "{{ .Values.redis.failed_queue }}"
+  PROGRESS_QUEUE: "{{ .Values.redis.progress_queue }}"
+  RELEASE_NAME: "{{ .Release.Name }}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -63,13 +63,17 @@ spec:
           mountPath: /config
         - name: script
           mountPath: /scripts
+      initContainers:
+      - name: wait-for-preload
+        image: redis:latest
+        command: ['sh', '-c', 'until [ $(redis-cli -h redis -p 6379 LLEN {{ .Values.redis.job_queue }}) -gt 0 ]; do echo waiting for preload; sleep 2; done; echo job available']
       volumes:
       - name: config
         configMap:
           name: stellar-core-config
       - name: script
         configMap:
-          name: worker-script          
+          name: worker-script
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -33,13 +33,13 @@ spec:
         # resource specs copied from the old supercluster mission
         resources:
           requests:
-            cpu: "250m"
-            memory: "1200Mi"
-            ephemeral-storage: "35Gi"
+            cpu: "{{ .Values.worker.request_cpu}}"
+            memory: "{{ .Values.worker.request_memory}}"
+            ephemeral-storage: "{{ .Values.worker.request_ephemeral_storage}}"
           limits:
-            cpu: "2000m"
-            memory: "6000Mi"
-            ephemeral-storage: "40Gi"
+            cpu: "{{ .Values.worker.limit_cpu}}"
+            memory: "{{ .Values.worker.limit_memory}}"
+            ephemeral-storage: "{{ .Values.worker.limit_ephemeral_storage}}"
         command: ["/bin/sh", "/scripts/worker.sh"]
         ports:
         - containerPort: 11626

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -29,7 +29,8 @@ spec:
     spec:
       containers:
       - name: stellar-core
-        image: jayz22/core-worker
+        image: {{ .Values.worker.stellar_core_image }}
+        imagePullPolicy: Always
         # resource specs copied from the old supercluster mission
         resources:
           requests:
@@ -63,10 +64,6 @@ spec:
           mountPath: /config
         - name: script
           mountPath: /scripts
-      initContainers:
-      - name: wait-for-preload
-        image: redis:latest
-        command: ['sh', '-c', 'until [ $(redis-cli -h redis -p 6379 LLEN {{ .Values.redis.job_queue }}) -gt 0 ]; do echo waiting for preload; sleep 2; done; echo job available']
       volumes:
       - name: config
         configMap:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stellar-core
+spec:
+  clusterIP: None
+  selector:
+    app: stellar-core
+  ports:
+    - port: 11626
+      targetPort: 11626
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: stellar-core
+  labels:
+    app: stellar-core
+spec:
+  serviceName: "stellar-core"
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      app: stellar-core
+  template:
+    metadata:
+      labels:
+        app: stellar-core
+    spec:
+      containers:
+      - name: stellar-core
+        image: jayz22/core-worker
+        # resource specs copied from the old supercluster mission
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "1200Mi"
+            ephemeral-storage: "35Gi"
+          limits:
+            cpu: "2000m"
+            memory: "6000Mi"
+            ephemeral-storage: "40Gi"
+        command: ["/bin/sh", "/scripts/worker.sh"]
+        ports:
+        - containerPort: 11626
+        env:
+        - name: JOB_QUEUE
+          value: "{{ .Values.redis.job_queue }}"
+        - name: SUCCESS_QUEUE
+          value: "{{ .Values.redis.success_queue }}"
+        - name: FAILED_QUEUE
+          value: "{{ .Values.redis.failed_queue }}"
+        - name: PROGRESS_QUEUE
+          value: "{{ .Values.redis.progress_queue }}"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: RELEASE_NAME
+          value: "{{ .Release.Name }}"
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        - name: script
+          mountPath: /scripts
+      volumes:
+      - name: config
+        configMap:
+          name: stellar-core-config
+      - name: script
+        configMap:
+          name: worker-script          
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: worker-script
+data:
+  worker.sh: |-
+    {{- (.Files.Get "files/worker.sh") | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stellar-core-config
+data:
+  stellar-core.cfg: |-
+    {{- (.Files.Get "files/stellar-core.cfg") | nindent 4 }}

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -73,9 +73,14 @@ spec:
         - name: LOGGING_INTERVAL_SECONDS
           value: "{{ .Values.monitor.logging_interval_seconds}}"
       initContainers:
-      - name: wait-for-redis
-        image: redis:latest
-        command: ['sh', '-c', 'until redis-cli -h redis -p 6379 ping; do echo waiting for redis; sleep 2; done; echo redis server ready']
       - name: wait-for-preload
-        image: redis:latest
-        command: ['sh', '-c', 'until [ $(redis-cli -h redis -p 6379 LLEN {{ .Values.redis.job_queue }}) -gt 0 ]; do echo waiting for preload; sleep 2; done; echo preload started']
+        image: redis:7
+        command: ['/bin/sh', '-c']
+        args:
+        - |-
+          # Wait until the job queue has items
+          until [ $(redis-cli -h redis -p 6379 LLEN {{ .Values.redis.job_queue }}) -gt 0 ]; do
+            echo waiting for preload
+            sleep 2
+          done
+          echo job available

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ingressClassName: private
   rules:
-  - host: ssc-job-monitor.services.stellar-ops.com
+  - host: "{{ .Values.monitor.hostname}}"
     http:
       paths:
       - path: /

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -49,6 +49,10 @@ spec:
         image: jayz22/job-monitor:latest
         ports:
         - containerPort: 8080
+        resources:
+          requests:
+            cpu: "{{ .Values.monitor.request_cpu}}"
+            memory: "{{ .Values.monitor.request_memory}}"
         env:
         - name: JOB_QUEUE
           value: "{{ .Values.redis.job_queue }}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -1,0 +1,77 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: job-monitor-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: private
+  rules:
+  - host: ssc-job-monitor.services.stellar-ops.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: job-monitor
+            port:
+              number: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: job-monitor
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: job-monitor
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: job-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: job-monitor
+  template:
+    metadata:
+      labels:
+        app: job-monitor
+    spec:
+      containers:
+      - name: job-monitor
+        image: jayz22/job-monitor:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: JOB_QUEUE
+          value: "{{ .Values.redis.job_queue }}"
+        - name: SUCCESS_QUEUE
+          value: "{{ .Values.redis.success_queue }}"
+        - name: FAILED_QUEUE
+          value: "{{ .Values.redis.failed_queue }}"
+        - name: PROGRESS_QUEUE
+          value: "{{ .Values.redis.progress_queue }}"
+        - name: WORKER_PREFIX
+          value: "stellar-core"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: WORKER_COUNT
+          value: "{{ .Values.worker.replicas }}"
+        - name: LOGGING_INTERVAL_SECONDS
+          value: "{{ .Values.monitor.logging_interval_seconds}}"
+      initContainers:
+      - name: wait-for-redis
+        image: redis:latest
+        command: ['sh', '-c', 'until redis-cli -h redis -p 6379 ping; do echo waiting for redis; sleep 2; done; echo redis server ready']
+      - name: wait-for-preload
+        image: redis:latest
+        command: ['sh', '-c', 'until [ $(redis-cli -h redis -p 6379 LLEN {{ .Values.redis.job_queue }}) -gt 0 ]; do echo waiting for preload; sleep 2; done; echo preload started']

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -88,3 +88,4 @@ data:
   WORKER_PREFIX: "stellar-core"
   WORKER_COUNT: "{{ .Values.worker.replicas }}"
   LOGGING_INTERVAL_SECONDS: "{{ .Values.monitor.logging_interval_seconds}}"
+  LOGGING_LEVEL: "{{ .Values.monitor.logging_level}}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
       - name: job-monitor
-        image: jayz22/job-monitor:latest
+        image: stellar/ssc-job-monitor:latest
         ports:
         - containerPort: 8080
         resources:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -51,8 +51,8 @@ spec:
         - containerPort: 8080
         resources:
           requests:
-            cpu: "{{ .Values.monitor.request_cpu}}"
-            memory: "{{ .Values.monitor.request_memory}}"
+            cpu: "{{ .Values.monitor.resources.requests.cpu}}"
+            memory: "{{ .Values.monitor.resources.requests.memory}}"
         env:
         - name: JOB_QUEUE
           value: "{{ .Values.redis.job_queue }}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -54,24 +54,13 @@ spec:
             cpu: "{{ .Values.monitor.resources.requests.cpu}}"
             memory: "{{ .Values.monitor.resources.requests.memory}}"
         env:
-        - name: JOB_QUEUE
-          value: "{{ .Values.redis.job_queue }}"
-        - name: SUCCESS_QUEUE
-          value: "{{ .Values.redis.success_queue }}"
-        - name: FAILED_QUEUE
-          value: "{{ .Values.redis.failed_queue }}"
-        - name: PROGRESS_QUEUE
-          value: "{{ .Values.redis.progress_queue }}"
-        - name: WORKER_PREFIX
-          value: "stellar-core"
         - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: WORKER_COUNT
-          value: "{{ .Values.worker.replicas }}"
-        - name: LOGGING_INTERVAL_SECONDS
-          value: "{{ .Values.monitor.logging_interval_seconds}}"
+        envFrom:
+        - configMapRef:
+            name: job-monitor-config
       initContainers:
       - name: wait-for-preload
         image: redis:7
@@ -79,8 +68,23 @@ spec:
         args:
         - |-
           # Wait until the job queue has items
-          until [ $(redis-cli -h redis -p 6379 LLEN {{ .Values.redis.job_queue }}) -gt 0 ]; do
+          until [ $(redis-cli -h {{ .Values.redis.hostname}} -p  {{ .Values.redis.port}} LLEN {{ .Values.redis.job_queue }}) -gt 0 ]; do
             echo waiting for preload
             sleep 2
           done
           echo job available
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: job-monitor-config
+data:
+  REDIS_HOST: "{{ .Values.redis.hostname}}"
+  REDIS_PORT: "{{ .Values.redis.port}}"
+  JOB_QUEUE: "{{ .Values.redis.job_queue }}"
+  SUCCESS_QUEUE: "{{ .Values.redis.success_queue }}"
+  FAILED_QUEUE: "{{ .Values.redis.failed_queue }}"
+  PROGRESS_QUEUE: "{{ .Values.redis.progress_queue }}"
+  WORKER_PREFIX: "stellar-core"
+  WORKER_COUNT: "{{ .Values.worker.replicas }}"
+  LOGGING_INTERVAL_SECONDS: "{{ .Values.monitor.logging_interval_seconds}}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
-  ingressClassName: private
+  ingressClassName: "{{ .Values.monitor.ingress_class_name}}"
   rules:
   - host: "{{ .Values.monitor.hostname}}"
     http:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
@@ -8,16 +8,31 @@ spec:
       containers:
       - name: preload
         image: redis:latest
-        command: ["/bin/sh", "/scripts/uniform_range_generator.sh"]
+        command: ["/bin/sh", "-c"]
+        args: 
+         - |-
+           if [ \"$STRATEGY\" = \"uniform\" ]; then 
+             /bin/sh /scripts/uniform_range_generator.sh
+           elif [ \"$STRATEGY\" = \"logarithmic\" ]; then 
+             /bin/sh /scripts/logarithmic_range_generator.sh
+           else 
+             echo 'Error: Unknown strategy' && exit 1
+           fi
         env:
-        - name: LEDGERS_PER_JOB
-          value: "{{ .Values.range_generator.ledgers_per_job }}"
-        - name: OVERLAP_LEDGERS
-          value: "{{ .Values.range_generator.overlap_ledgers }}"
+        - name: STRATEGY
+          value: "{{ .Values.range_generator.strategy }}"
         - name: STARTING_LEDGER
-          value: "{{ .Values.range_generator.starting_ledger }}"
+          value: "{{ .Values.range_generator.params.starting_ledger }}"
         - name: LATEST_LEDGER_NUM
-          value: "{{ .Values.range_generator.latest_ledger_num }}"
+          value: "{{ .Values.range_generator.params.latest_ledger_num }}"
+        - name: OVERLAP_LEDGERS
+          value: "{{ .Values.range_generator.params.overlap_ledgers }}"
+        - name: LEDGERS_PER_JOB
+          value: "{{ .Values.range_generator.params.uniform_ledgers_per_job }}"
+        - name: LOGARITHMIC_FLOOR_LEDGERS
+          value: "{{ .Values.range_generator.params.logarithmic_floor_ledgers }}"
+        - name: NUM_PARALLELISM
+          value: "128"
         volumeMounts:
         - name: script
           mountPath: /scripts
@@ -38,3 +53,5 @@ metadata:
 data:
   uniform_range_generator.sh: |-
     {{- (.Files.Get "files/uniform_range_generator.sh") | nindent 4 }}
+  logarithmic_range_generator.sh: |-
+    {{- (.Files.Get "files/logarithmic_range_generator.sh") | nindent 4 }}

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: preload
-        image: redis:latest
+        image: redis:7
         command: ["/bin/sh", "-c"]
         args: 
          - |-
@@ -38,7 +38,7 @@ spec:
           mountPath: /scripts
       initContainers:
       - name: wait-for-redis
-        image: redis:latest
+        image: redis:7
         command: ['sh', '-c', "until redis-cli -h redis -p 6379 ping; do echo waiting for redis; sleep 2; done;"]
       restartPolicy: OnFailure
       volumes:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
@@ -31,7 +31,7 @@ spec:
       initContainers:
       - name: wait-for-redis
         image: redis:7
-        command: ['sh', '-c', "until redis-cli -h redis -p 6379 ping; do echo waiting for redis; sleep 2; done;"]
+        command: ['sh', '-c', "until redis-cli -h {{ .Values.redis.hostname}} -p  {{ .Values.redis.port}} ping; do echo waiting for redis; sleep 2; done;"]
       restartPolicy: OnFailure
       volumes:
       - name: script
@@ -60,3 +60,5 @@ data:
   LEDGERS_PER_JOB: "{{ .Values.range_generator.params.uniform_ledgers_per_job }}"
   LOGARITHMIC_FLOOR_LEDGERS: "{{ .Values.range_generator.params.logarithmic_floor_ledgers }}"
   NUM_PARALLELISM: "128"
+  REDIS_HOST: "{{ .Values.redis.hostname}}"
+  REDIS_PORT: "{{ .Values.redis.port}}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: preload-redis
+spec:
+  template:
+    spec:
+      containers:
+      - name: preload
+        image: redis:latest
+        command: ["/bin/sh", "/scripts/uniform_range_generator.sh"]
+        env:
+        - name: LEDGERS_PER_JOB
+          value: "{{ .Values.range_generator.LEDGERS_PER_JOB }}"
+        - name: OVERLAP_LEDGERS
+          value: "{{ .Values.range_generator.OVERLAP_LEDGERS }}"
+        - name: STARTING_LEDGER
+          value: "{{ .Values.range_generator.STARTING_LEDGER }}"
+        - name: LATEST_LEDGER_NUM
+          value: "{{ .Values.range_generator.LATEST_LEDGER_NUM }}"
+        volumeMounts:
+        - name: script
+          mountPath: /scripts
+      initContainers:
+      - name: wait-for-redis
+        image: redis:latest
+        command: ['sh', '-c', "until redis-cli -h redis -p 6379 ping; do echo waiting for redis; sleep 2; done;"]
+      restartPolicy: OnFailure
+      volumes:
+      - name: script
+        configMap:
+          name: generator-script
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: generator-script
+data:
+  uniform_range_generator.sh: |-
+    {{- (.Files.Get "files/uniform_range_generator.sh") | nindent 4 }}

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
@@ -11,28 +11,20 @@ spec:
         command: ["/bin/sh", "-c"]
         args: 
          - |-
-           if [ \"$STRATEGY\" = \"uniform\" ]; then 
-             /bin/sh /scripts/uniform_range_generator.sh
-           elif [ \"$STRATEGY\" = \"logarithmic\" ]; then 
-             /bin/sh /scripts/logarithmic_range_generator.sh
-           else 
-             echo 'Error: Unknown strategy' && exit 1
-           fi
-        env:
-        - name: STRATEGY
-          value: "{{ .Values.range_generator.strategy }}"
-        - name: STARTING_LEDGER
-          value: "{{ .Values.range_generator.params.starting_ledger }}"
-        - name: LATEST_LEDGER_NUM
-          value: "{{ .Values.range_generator.params.latest_ledger_num }}"
-        - name: OVERLAP_LEDGERS
-          value: "{{ .Values.range_generator.params.overlap_ledgers }}"
-        - name: LEDGERS_PER_JOB
-          value: "{{ .Values.range_generator.params.uniform_ledgers_per_job }}"
-        - name: LOGARITHMIC_FLOOR_LEDGERS
-          value: "{{ .Values.range_generator.params.logarithmic_floor_ledgers }}"
-        - name: NUM_PARALLELISM
-          value: "128"
+           case "$STRATEGY" in
+             "uniform")
+               /bin/sh /scripts/uniform_range_generator.sh
+               ;;
+             "logarithmic")
+               /bin/sh /scripts/logarithmic_range_generator.sh
+               ;;
+             *)
+               echo 'Error: Unknown strategy' && exit 1
+               ;;
+           esac
+        envFrom:
+        - configMapRef:
+            name: range-generator-config
         volumeMounts:
         - name: script
           mountPath: /scripts
@@ -55,3 +47,16 @@ data:
     {{- (.Files.Get "files/uniform_range_generator.sh") | nindent 4 }}
   logarithmic_range_generator.sh: |-
     {{- (.Files.Get "files/logarithmic_range_generator.sh") | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: range-generator-config
+data:
+  STRATEGY: "{{ .Values.range_generator.strategy }}"
+  STARTING_LEDGER: "{{ .Values.range_generator.params.starting_ledger }}"
+  LATEST_LEDGER_NUM: "{{ .Values.range_generator.params.latest_ledger_num }}"
+  OVERLAP_LEDGERS: "{{ .Values.range_generator.params.overlap_ledgers }}"
+  LEDGERS_PER_JOB: "{{ .Values.range_generator.params.uniform_ledgers_per_job }}"
+  LOGARITHMIC_FLOOR_LEDGERS: "{{ .Values.range_generator.params.logarithmic_floor_ledgers }}"
+  NUM_PARALLELISM: "128"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
@@ -11,13 +11,13 @@ spec:
         command: ["/bin/sh", "/scripts/uniform_range_generator.sh"]
         env:
         - name: LEDGERS_PER_JOB
-          value: "{{ .Values.range_generator.LEDGERS_PER_JOB }}"
+          value: "{{ .Values.range_generator.ledgers_per_job }}"
         - name: OVERLAP_LEDGERS
-          value: "{{ .Values.range_generator.OVERLAP_LEDGERS }}"
+          value: "{{ .Values.range_generator.overlap_ledgers }}"
         - name: STARTING_LEDGER
-          value: "{{ .Values.range_generator.STARTING_LEDGER }}"
+          value: "{{ .Values.range_generator.starting_ledger }}"
         - name: LATEST_LEDGER_NUM
-          value: "{{ .Values.range_generator.LATEST_LEDGER_NUM }}"
+          value: "{{ .Values.range_generator.latest_ledger_num }}"
         volumeMounts:
         - name: script
           mountPath: /scripts

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
@@ -31,3 +31,7 @@ spec:
         ports:
         - containerPort: 6379
         command: ["redis-server"]
+        resources:
+          requests:
+            cpu: "{{ .Values.redis.request_cpu}}"
+            memory: "{{ .Values.redis.request_memory}}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:latest
+        ports:
+        - containerPort: 6379
+        command: ["redis-server"]

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
@@ -33,5 +33,5 @@ spec:
         command: ["redis-server"]
         resources:
           requests:
-            cpu: "{{ .Values.redis.request_cpu}}"
-            memory: "{{ .Values.redis.request_memory}}"
+            cpu: "{{ .Values.redis.resources.requests.cpu}}"
+            memory: "{{ .Values.redis.resources.requests.memory}}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:latest
+        image: redis:7
         ports:
         - containerPort: 6379
         command: ["redis-server"]

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis
+  name: "{{ .Values.redis.hostname}}"
 spec:
   type: ClusterIP
   ports:
-    - port: 6379
+    - port: {{ .Values.redis.port}}
       targetPort: 6379
   selector:
     app: redis

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -1,4 +1,6 @@
 redis:
+  hostname: "redis"
+  port: 6379
   job_queue: "ranges"
   success_queue: "succeeded"
   failed_queue: "failed"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -3,20 +3,22 @@ redis:
   success_queue: "succeeded"
   failed_queue: "failed"
   progress_queue: "in_progress"
+  request_cpu: "100m"
+  request_memory: "100Mi"
 
 worker:
   stellar_core_image: "stellar/stellar-core:latest"
   replicas: 5
-  request_cpu: "1000m"
-  request_memory: "6000Mi"
+  request_cpu: "1250m"
+  request_memory: "12Gi"
   request_ephemeral_storage: "35Gi"
-  limit_cpu: "4000m"
-  limit_memory: "12000Mi"
+  limit_cpu: "8"
+  limit_memory: "24Gi"
   limit_ephemeral_storage: "40Gi"
 
 monitor:
   logging_interval_seconds: 10
-  request_cpu: "200m"
+  request_cpu: "100m"
   request_memory: "100Mi"
 
 range_generator:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -24,6 +24,7 @@ worker:
       ephemeral_storage: "40Gi"
 
 monitor:
+  ingress_class_name: "private"
   hostname: "ssc-job-monitor.services.stellar-ops.com"
   logging_interval_seconds: 10
   resources:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -27,6 +27,7 @@ monitor:
   ingress_class_name: "private"
   hostname: "ssc-job-monitor.services.stellar-ops.com"
   logging_interval_seconds: 10
+  logging_level: "INFO" # 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
   resources:
     requests: 
       cpu: "100m"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -1,0 +1,18 @@
+redis:
+  job_queue: "ranges"
+  success_queue: "succeeded"
+  failed_queue: "failed"
+  progress_queue: "in_progress"
+
+worker:
+  stellar_core_image: "stellar/stellar-core:latest"
+  replicas: 5 # number of workers running in the StatefulSet
+
+monitor:
+  logging_interval_seconds: 10
+
+range_generator:
+  LEDGERS_PER_JOB: 1600
+  OVERLAP_LEDGERS: 0
+  STARTING_LEDGER: 0
+  LATEST_LEDGER_NUM: 10000

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -3,26 +3,33 @@ redis:
   success_queue: "succeeded"
   failed_queue: "failed"
   progress_queue: "in_progress"
-  request_cpu: "100m"
-  request_memory: "100Mi"
+  resources:
+    requests: 
+      cpu: "100m"
+      memory: "100Mi"
 
 worker:
   stellar_core_image: "stellar/stellar-core:latest"
   replicas: 5
-  request_cpu: "1"
-  request_memory: "10Gi"
-  request_ephemeral_storage: "35Gi"
-  limit_cpu: "4"
-  limit_memory: "30Gi"
-  limit_ephemeral_storage: "40Gi"
+  resources:
+    requests: 
+      cpu: "1"
+      memory: "10Gi"
+      ephemeral_storage: "35Gi"
+    limits:
+      cpu: "4"
+      memory: "30Gi"
+      ephemeral_storage: "40Gi"
 
 monitor:
   logging_interval_seconds: 10
-  request_cpu: "100m"
-  request_memory: "100Mi"
+  resources:
+    requests: 
+      cpu: "100m"
+      memory: "100Mi"
 
 range_generator:
-  strategy: "logarithmic" # "uniform" or "logarithmic"
+  strategy: "uniform" # "uniform" or "logarithmic"
   params:
     starting_ledger: 0
     latest_ledger_num: 100000

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -24,6 +24,7 @@ worker:
       ephemeral_storage: "40Gi"
 
 monitor:
+  hostname: "ssc-job-monitor.services.stellar-ops.com"
   logging_interval_seconds: 10
   resources:
     requests: 

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -6,13 +6,21 @@ redis:
 
 worker:
   stellar_core_image: "stellar/stellar-core:latest"
-  replicas: 5 # number of workers running in the StatefulSet
+  replicas: 5
+  request_cpu: "1000m"
+  request_memory: "6000Mi"
+  request_ephemeral_storage: "35Gi"
+  limit_cpu: "4000m"
+  limit_memory: "12000Mi"
+  limit_ephemeral_storage: "40Gi"
 
 monitor:
   logging_interval_seconds: 10
+  request_cpu: "200m"
+  request_memory: "100Mi"
 
 range_generator:
-  LEDGERS_PER_JOB: 1600
-  OVERLAP_LEDGERS: 0
-  STARTING_LEDGER: 0
-  LATEST_LEDGER_NUM: 10000
+  ledgers_per_job: 16000
+  overlap_ledgers: 320
+  starting_ledger: 0
+  latest_ledger_num: 100000

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -9,11 +9,11 @@ redis:
 worker:
   stellar_core_image: "stellar/stellar-core:latest"
   replicas: 5
-  request_cpu: "1250m"
-  request_memory: "24Gi"
+  request_cpu: "1"
+  request_memory: "10Gi"
   request_ephemeral_storage: "35Gi"
-  limit_cpu: "8"
-  limit_memory: "48Gi"
+  limit_cpu: "4"
+  limit_memory: "30Gi"
   limit_ephemeral_storage: "40Gi"
 
 monitor:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -10,10 +10,10 @@ worker:
   stellar_core_image: "stellar/stellar-core:latest"
   replicas: 5
   request_cpu: "1250m"
-  request_memory: "12Gi"
+  request_memory: "24Gi"
   request_ephemeral_storage: "35Gi"
   limit_cpu: "8"
-  limit_memory: "24Gi"
+  limit_memory: "48Gi"
   limit_ephemeral_storage: "40Gi"
 
 monitor:
@@ -22,7 +22,10 @@ monitor:
   request_memory: "100Mi"
 
 range_generator:
-  ledgers_per_job: 16000
-  overlap_ledgers: 320
-  starting_ledger: 0
-  latest_ledger_num: 100000
+  strategy: "logarithmic" # "uniform" or "logarithmic"
+  params:
+    starting_ledger: 0
+    latest_ledger_num: 100000
+    overlap_ledgers: 320
+    uniform_ledgers_per_job: 16000 # only for strategy="uniform"
+    logarithmic_floor_ledgers: 16000 # only for strategy="logarithmic"


### PR DESCRIPTION
## What
Resolves https://github.com/stellar/stellar-core-internal/issues/264, by adding:
- `./src/MissionParallelCatchup/parallel_catchup_helm` - a Helm project that encapsulates the core parallel catchup logic -- job queues and core workers -- inside Kubernetes
- `./src/MissionParallelCatchup/job_monitor.py` - an (containerized) application monitoring the component statuses, exposing them via an HTTP endpoint `/status`.
- `MissionHistoryPubnetParallelCatchupV2` - a new mission  which manages the Helm project and monitors job status.
- As pass-by improvement, upgrades `.NET` version to 8.0, and brings `stellar-dotnet-sdk` and `KubernetesClient` to the latest versions.

To try the new mission, run this command : 
`$ dotnet run mission HistoryPubnetParallelCatchupV2 --image=docker-registry.services.stellar-ops.com/dev/stellar-core:latest --pubnet-parallel-catchup-num-workers=6 --pubnet-parallel-catchup-starting-ledger=52500000` 
on your local machine (you need to first have access to an Kubernetes cluster, e.g. via sshuttle to the ssc)

## Why

The current parallel catchup mission frequently suffers from instability (e.g. see https://github.com/stellar/stellar-supercluster/issues/280 and https://github.com/stellar/supercluster/pull/150). The main reason is we are managing the lifecycle of pods, managing the job queue and performing status monitoring all inside the mission itself (outside Kubernetes cluster, by constantly querying Kubernetes API. There are many potential points of failure (e.g. a pod fails, a pod cannot be allocated, the K8s API times out) each would result in a total mission failure. 

By moving all of the core logic inside Kubernetes (leveraging k8s's rich resource and workload management capabilities) this design is more resilient to any single point of failure. It also eliminates virtually all API queries, by moving the status checking query on the job monitor HTTP endpoint (a single HTTP (*not* API) query every 30 secs), thus eliminating a main source of unreliability.

Besides, there are a few other improvements/benefits:
- Resilience and partial progress - The worker set can be partially allocated and make progress (when the cluster is resource restrained). Any pod failure due to Kubernetes will be retried later. 
- Eliminates the overhead of pod creation/deletion, saving the parallel catchup ~3hrs (or ~8%) of total run time.
- Stores worker timing metrics, making them available in Prometheus
- Mostly static (with customizable inputs via `value.yaml`) set of yaml files defining the Kubernetes objects -- better readability and maintainability
- Separates out range generation script, making it easy for future optimization on the range algorithm
- Tweaked resource request/limit of worker pods to improve performance (this is still an ongoing work)

Check out the [Design doc](https://docs.google.com/document/d/1qQpRaRqQWG6JP13voX-cRE2RLCuAJZQz6Wia-lzlMtU/edit?pli=1#heading=h.ggca9nms6hha) for more details

