### PR TITLE
Add reproducable theoretical max TPS test

### DIFF
--- a/doc/eks.md
+++ b/doc/eks.md
@@ -1,0 +1,128 @@
+# Creating a Supercluster Compatible EKS Cluster
+
+This document explains how to use the `eks-init.py` script in the `scripts`
+directory to build a supercluster compatible EKS cluster on AWS.
+
+## Requirements
+
+The script requires that you have the following programs installed:
+* AWS CLI
+* eksctl
+* kubectl
+* helm
+* dig
+* ssh
+
+### Set up AWS CLI tools
+
+Before running the script, please follow
+[Amazon's guide for setting up tools to manage EKS clusters](https://docs.aws.amazon.com/eks/latest/userguide/setting-up.html).
+
+### AWS Quotas
+
+In order to run the theoretical max TPS test with the recommended parameters,
+you'll need a quota of at least 160 vCPUs for on-demand M instance types in the
+region you plan to run the test in.
+
+## Running the Script
+
+`eks-init.py` is an interactive script that automates the creation and
+configuration of a supercluster compatible EKS cluster. The script periodically
+prompts for information to configure the cluster. The majority of prompts have
+default values in brackets. Pressing `<enter>` will choose the default value.
+Otherwise, type your desired value followed by `<enter>`.
+
+### Initial Prompts
+
+To start, `eks-init.py` will ask for the following:
+
+* Cluster name: The name you would like give the cluster.
+* Region: The AWS region you would like to create the cluster in.
+* SSH public key: The public key you would like to use for SSH access into the
+  instances the script will spin up.
+
+### Creating a Cluster
+
+Next, the script will ask if you would like to create an EKS cluster.  You
+should only say "no" here if you have already created an EKS cluster and you are
+using the script to configure it.  If you say "yes", the script will ask for the
+following:
+
+* Number of nodes: The number of EC2 instances to create. We recommend 10 if you
+  plan to run the theoretical max TPS test.
+* Node type: The EC2 instance type to use for each node. We recommend
+  `m5d.4xlarge` if you plan to run the theoretical max TPS test.
+
+After answering the previous prompts, the script will create a cluster using
+`eksctl`. This may take 10-20 minutes. Once it is complete the script will list
+the public IP addresses of the nodes in the cluster.
+
+### Mounting NVMe Drives
+
+Next, the script will ask if you would like to mount NVMe drives on the cluster
+instances. If you are using an instance type with NVMe drives and you have not
+manually mounted them yourself, then you should answer "yes". Answering "yes"
+will result in the following prompt:
+
+* SSH private key: Private key corresponding to the public key you provided earlier.
+
+After answering the previous prompt, the script will SSH into each instance to
+format and mount the NVMe drives such that kubernetes pods will run on them.
+
+### Installing an Ingress Controller
+
+Next, the script will ask if you would like to install an ingress controller.
+This is required for supercluster, so you should say "yes" unless you plan to
+manually install an ingress controller. Upon answering "yes", the script will
+install the controller. There are no additional prompts to this portion of the
+script.
+
+### Configuring DNS
+
+Next, the script will prompt for your ingress domain. This is the domain name
+supercluster will use to communicate with the stellar-core nodes running on the
+cluster. This may be a subdomain (such as `ssc.example.com`).
+
+After entering the ingress domain, the script will print out instructions for
+configuring DNS for the domain. You will need to add the wildcard CNAME record
+the script generates. Note that not all registrars permit wildcard CNAME
+records. One registrar that we know supports wildcard CNAME records is
+[Namecheap](https://www.namecheap.com/), which allows the addition of CNAME
+records via the "Advanced DNS" section of a domain's control panel.
+
+**IMPORTANT**: The trailing dot at the end of the CNAME target is required. The
+record will not work without it.
+
+### Testing DNS Propagation
+
+Next, the script will ask if you would like to test DNS propagation. This is
+completely optional and does not affect the operation of your cluster in any
+way. If you say "yes", the script will check for a CNAME record at
+`*.<your ingress domain>` every 60 seconds to see if it matches the expected
+CNAME record. It will continue checking until it finds a match. After each
+failed check, it will print a reason for the failure (missing record, or
+misconfigured record).
+
+In our tests, propagation generally takes only a few minutes. However, it can
+theoretically take much longer than that. While waiting for propagation, you
+should expect to see failure messages from the DNS propagation checker.
+
+Regardless of whether or not you use the builtin propagation checker, you will
+need to wait for the CNAME record to propagate to your computer before you can
+run supercluster.
+
+### Supercluster Options
+
+At this point you should see a message stating "Your cluster is ready!". Below
+that message are a set of flags you must add to any supercluster runs you wish
+to perform.
+
+### Shutting Down
+
+The last thing the script prints is the `eksctl` command you need to use to shut
+down your cluster when you are done using it. In case you closed your terminal
+window after running the script, the command is:
+
+```bash
+eksctl delete cluster --name <cluster-name> --region <aws-region>
+```

--- a/doc/theoretical-max-tps.md
+++ b/doc/theoretical-max-tps.md
@@ -1,0 +1,31 @@
+# Theoretical Max TPS Test
+
+The theoretical max TPS test is a configuration of the `MaxTPSClassic` mission
+that searches for a maximum transaction-per-second rate that stellar-core can
+support under ideal circumstances. It uses a 7 node network with 3 validators.
+We provide this topology in
+[`/topologies/theoretical-max-tps.json`](../topologies/theoretical-max-tps.json).
+
+To run the test, first [set up an EKS cluster](eks.md). Then, run a
+`MaxTPSClassic` mission with the following template:
+```bash
+dotnet run --project src/App/App.fsproj --configuration Release -- mission MaxTPSClassic --image=<core-image> --netdelay-image=stellar/sdf-netdelay:latest --pubnet-data=<path-to-repo>/topologies/theoretical-max-tps.json --num-runs=<runs> --tx-rate=<min-tx-rate> --max-tx-rate=<max-tx-rate> --namespace default --ingress-internal-domain=<domain> --ingress-class=nginx
+```
+For more information about how to set the parameters in the above command, see
+[Measuring Transaction Throughput](measuring-transaction-throughput.md).
+
+At the end of the test you should see a line that looks like:
+```
+Final tx rate averaged to <rate> over <runs> runs for image <core-image>
+```
+
+Finally, don't forget to shut down your EKS cluster.
+
+## Results
+
+This table contains the theoretical max TPS stellar-core achieved, ordered by
+stellar-core release.
+
+| Core Version | Core Image | EC2 Instance Type | Number of Instances | Max TPS |
+|--------------|------------|-------------------|---------------------|---------|
+| 21.1.0 | `stellar/unsafe-stellar-core:21.0.1-1917.52a449ff3.focal-testing-asan-disabled-perftests` | m5d.4xlarge | 10 | 1137 |

--- a/scripts/eks-init.py
+++ b/scripts/eks-init.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+
+import glob
+import json
+import os
+import subprocess
+import time
+
+# eksctl constants
+DEFAULT_NAME = "ssc"
+DEFAULT_REGION = "us-west-2"
+# DEFAULT_NUM_NODES should be the number of nodes in the theoretical max TPS
+# topology plus 3 to cover the ingress controller and two coredns instances.
+DEFAULT_NUM_NODES = 10
+DEFAULT_NODE_TYPE = "m5d.4xlarge"
+KUBERNETES_VERSION = "1.28"
+SSH_USERNAME = "ec2-user"
+NVME_MOUNT_SCRIPT = "https://raw.githubusercontent.com/awslabs/amazon-eks-ami/86105105a83fdc80e682b850aac6f626119a6951/templates/shared/runtime/bin/setup-local-disks"
+DNS_RETRY_INTERVAL_SECONDS = 60
+
+def run(command):
+    """ Run a command and exit if it fails. Prints the command's output. """
+    print(f"Running: {command}")
+    res = os.system(command)
+    if res != 0:
+        print(f"Command '{command}' failed with exit code {res}")
+        exit(1)
+
+def run_capture_output(command):
+    """ Run a command and exit if it fails. Returns the command's output. """
+    try:
+        return subprocess.check_output(command)
+    except subprocess.CalledProcessError as e:
+        print(f"Command '{command}' failed with exit code {e.returncode}")
+        exit(1)
+
+def prompt_with_default(prompt, default):
+    """ Prompt the user for input with a default value. """
+    res = input(f"{prompt} [{default}]: ")
+    return res if res else default
+
+def prompt_yes_no(prompt, default):
+    """ Prompt the user for a yes/no answer with a default value. """
+    full_prompt = f"{prompt} [Y/n]: " if default else f"{prompt} [y/N]: "
+    res = input(full_prompt)
+    return res.lower() in ["y", "yes"] if res else default
+
+def prompt_ssh_public_key():
+    """
+    Prompt the user for an SSH public key. Attempts to find a default key to
+    suggest.
+    """
+    # Look for a key to use by default
+    prompt = "SSH public key"
+    keys = glob.glob(os.path.expanduser("~/.ssh/*.pub"))
+    if keys:
+        return prompt_with_default(prompt, keys[0])
+    return input(f"{prompt}: ")
+
+def create_cluster(name, region, num_nodes, node_type, ssh_public_key):
+    """ Create an EKS cluster with the given parameters. """
+    run( "eksctl create cluster "
+        f"--name {name} "
+        f"--region {region} "
+        f"--nodes {num_nodes} "
+        f"--node-type {node_type} "
+        f"--version {KUBERNETES_VERSION} "
+         "--ssh-access "
+        f"--ssh-public-key {ssh_public_key} "
+        )
+
+def node_is_in_cluster(cluster_name, node):
+    """
+    Check if a node is in the given cluster. `node` must be an `Instance` object
+    from the `aws ec2 describe-instances` command.
+    """
+    if "Tags" not in node.keys():
+        return False
+
+    if node["State"]["Name"] != "running":
+        # describe-instances may return recently terminated nodes from a
+        # previous version of the cluster. This check ensures those are
+        # discarded.
+        return False
+
+    tags = node["Tags"]
+    for tag in tags:
+        try:
+            if (tag["Key"] == "eks:cluster-name" and
+                tag["Value"] == cluster_name):
+                return True
+        except KeyError:
+            pass
+    return False
+
+
+def get_node_ips(region, cluster_name):
+    """
+    Get the public IP addresses of the nodes in the given cluster. Returns a
+    list of IPs as strings of dotted quads.
+    """
+    reservations = json.loads(run_capture_output(
+        ["aws", "--region", region, "ec2", "describe-instances",
+         "--output", "json", "--no-paginate"
+        ]))
+    ips = []
+    for reservation in reservations["Reservations"]:
+        for instance in reservation["Instances"]:
+            if node_is_in_cluster(cluster_name, instance):
+                ips.append(instance["PublicIpAddress"])
+    return ips
+
+def mount_nvme(ips, public_key):
+    """
+    Mount NVMe drives on the given instances. `ips` is a list of IP addresses to
+    SSH into for the purposes of mounting the drives. `public_key` is the path
+    to the public key to use for SSH.
+    """
+    private_key = prompt_with_default("SSH private key",
+                                      public_key.replace(".pub", ""))
+    command = f"wget {NVME_MOUNT_SCRIPT} && sudo bash setup-local-disks raid0"
+    for ip in ips:
+        print(f"Mounting NVMe drives on {ip}...")
+        run(f"ssh -o StrictHostKeyChecking=no -i {private_key} "
+            f"{SSH_USERNAME}@{ip} '{command}'")
+        print()
+
+def setup_ingress_controller():
+    """
+    Setup an nginx ingress controller in the cluster. This implicitly spins up
+    an AWS Classic Load Balancer.
+    """
+    run("helm repo add ingress-nginx "
+        "https://kubernetes.github.io/ingress-nginx")
+    run("helm upgrade "
+        "--install ingress-nginx ingress-nginx "
+        "--repo https://kubernetes.github.io/ingress-nginx "
+        "--namespace ingress-nginx "
+        "--create-namespace")
+
+def emit_dns_instructions(domain):
+    """
+    Prints instructions for adding wildcard CNAME record for the given domain.
+    Returns the target hostname to use in the CNAME record.
+    """
+    service = json.loads(run_capture_output(
+        ["kubectl", "get", "services", "ingress-nginx-controller",
+         "-n", "ingress-nginx",
+         "-o", "json"
+        ]))
+    hostname = service["status"]["loadBalancer"]["ingress"][0]["hostname"]
+    print()
+    print("Before running supercluster, you must add a CNAME record for "
+          f"'*.{domain}' pointing to '{hostname}.'.")
+    print("Important considerations:")
+    print("* Your registrar must support wildcard CNAME records.")
+    print("* The trailing dot in the target hostname is important.")
+    print("* DNS propagation may take some time. In many cases it will take ")
+    print("  on the order of minutes, but it can take significantly longer.")
+    return hostname
+
+def test_dns_propagation(domain, target):
+    """
+    Block until the CNAME record for `*.domain` points to `target`.
+    """
+    lookup_domain = f"*.{domain}"
+    while True:
+        record = run_capture_output([
+            "dig", "+noall", "+answer", lookup_domain, "CNAME"
+        ]).decode("utf-8")
+        if record:
+            print("Found CNAME record:")
+            print(record)
+            if target in record:
+                print("DNS propagation successful!")
+                break
+            else:
+                print(f"CNAME record target does not match "
+                      f"expected target '{target}'. Checking again in "
+                      f"{DNS_RETRY_INTERVAL_SECONDS} seconds.")
+        else:
+            print(f"No CNAME record found. Checking again in "
+                  f"{DNS_RETRY_INTERVAL_SECONDS} seconds.")
+        time.sleep(DNS_RETRY_INTERVAL_SECONDS)
+
+def main():
+    """ Interactively create and initialize an EKS cluster """
+    cluster_name = prompt_with_default("Cluster name", DEFAULT_NAME)
+    region = prompt_with_default("Region", DEFAULT_REGION)
+    ssh_public_key = prompt_ssh_public_key()
+    num_nodes = None
+    if prompt_yes_no("Create EKS cluster", True):
+        num_nodes = prompt_with_default("Number of nodes", DEFAULT_NUM_NODES)
+        node_type = prompt_with_default("Node type", DEFAULT_NODE_TYPE)
+        print("Creating EKS cluster...")
+        create_cluster(cluster_name,
+                       region,
+                       num_nodes,
+                       node_type,
+                       ssh_public_key)
+
+    ips = get_node_ips(region, cluster_name)
+    print(f"Cluster instance IP addresses: {ips}")
+    if num_nodes is not None and len(ips) != int(num_nodes):
+        print("Error: The number of IP addresses found does not match the "
+              "number of requested nodes.")
+        exit(1)
+
+    if prompt_yes_no("Mount NVMe drives on cluster instances", True):
+        mount_nvme(ips, ssh_public_key)
+
+    if prompt_yes_no("Install ingress controller", True):
+        print("Setting up ingress controller...")
+        setup_ingress_controller()
+
+    ingress_domain = input("Ingress domain: ")
+    cname_target = emit_dns_instructions(ingress_domain)
+
+    if prompt_yes_no("Test DNS propagation", True):
+        test_dns_propagation(ingress_domain, cname_target)
+
+    print()
+    print("Your cluster is ready!")
+    print("Add the following flags to your supercluster runs:")
+    print(f"--ingress-domain {ingress_domain} "
+          "--ingress-class nginx "
+          "--namespace default")
+
+    print()
+    print("To shut down the cluster, run "
+          f"'eksctl delete cluster --name {cluster_name} --region {region}'")
+
+if __name__ == "__main__":
+    main()

--- a/topologies/theoretical-max-tps.json
+++ b/topologies/theoretical-max-tps.json
@@ -1,0 +1,82 @@
+[
+  {
+    "publicKey": 0,
+    "peers": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "sb_homeDomain": "sdf"
+  },
+  {
+    "publicKey": 1,
+    "peers": [
+      0,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "sb_homeDomain": "lo"
+  },
+  {
+    "publicKey": 2,
+    "peers": [
+      0,
+      1,
+      3,
+      4,
+      5,
+      6
+    ],
+    "sb_homeDomain": "pn"
+  },
+  {
+    "publicKey": 3,
+    "peers": [
+      0,
+      1,
+      2,
+      4,
+      5,
+      6
+    ]
+  },
+  {
+    "publicKey": 4,
+    "peers": [
+      0,
+      1,
+      2,
+      3,
+      5,
+      6
+    ]
+  },
+  {
+    "publicKey": 5,
+    "peers": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      6
+    ]
+  },
+  {
+    "publicKey": 6,
+    "peers": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ]
+  }
+]


### PR DESCRIPTION
Closes #170

This change adds documentation on how to run a theoretical max TPS test and publishes our first set of results. It also adds a script to enable anyone to spin up a supercluster-compatable EKS instance so that they may reproduce our results.