### PR TITLE
Add links to new EKS and theoretical max TPS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ See [doc/missions.md](doc/missions.md) for a list of supported tests.
 
 See [doc/measuring-transaction-throughput.md](doc/measuring-transaction-throughput.md) for instructions on load testing using supercluster. 
 
+## Theoretical max TPS
+
+See [doc/theoretical-max-tps.md](doc/theoretical-max-tps.md) for a table of our theoretical max TPS results by release, as well as instructions on how to reproduce those numbers.
+
 ## License
 
 [Apache 2.0](COPYING)

--- a/doc/eks.md
+++ b/doc/eks.md
@@ -20,9 +20,9 @@ Before running the script, please follow
 
 ### AWS Quotas
 
-In order to run the theoretical max TPS test with the recommended parameters,
-you'll need a quota of at least 160 vCPUs for on-demand M instance types in the
-region you plan to run the test in.
+In order to run the [theoretical max TPS test](theoretical-max-tps.md) with the
+recommended parameters, you'll need a quota of at least 160 vCPUs for on-demand
+M instance types in the region you plan to run the test in.
 
 ## Running the Script
 
@@ -115,7 +115,11 @@ run supercluster.
 
 At this point you should see a message stating "Your cluster is ready!". Below
 that message are a set of flags you must add to any supercluster runs you wish
-to perform.
+to perform. Some useful documents on running supercluster missions include:
+
+* [Running a theoretical max TPS test](theoretical-max-tps.md)
+* [Measuring transaction throughput](measuring-transaction-throughput.md)
+* [List of supercluster missions](missions.md)
 
 ### Shutting Down
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,6 +1,7 @@
 # Getting started
 
   - Find or make a Kubernetes cluster. The easiest approach currently is probably [k3s](k3s.md) on an ubuntu system, but it should work on a variety of other kubernetes distributions.
+    - If you'd prefer to run Supercluster on AWS, the easiest way is to follow our [guide to creating a cluster on EKS](eks.md).
 
   - Make sure you have enabled at least the `dns` and `ingress` components on the Kubernetes cluster, and that the `ingress` controller is [nginx-ingress](https://kubernetes.github.io/ingress-nginx/).
 


### PR DESCRIPTION
This change adds links in our docs that point to the new docs added in #182.