### PR TITLE
Fix helm chart path in parallel-catchup-v2

### DIFF
--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -20,7 +20,7 @@ open k8s
 
 // Constants
 let helmReleaseName = "parallel-catchup"
-let helmChartPath = "../MissionParallelCatchup/parallel_catchup_helm"
+let helmChartPath = "/supercluster/src/MissionParallelCatchup/parallel_catchup_helm"
 let valuesFilePath = helmChartPath + "/values.yaml"
 let jobMonitorHostName = "ssc-job-monitor.services.stellar-ops.com"
 let jobMonitorEndPoint = "/status"


### PR DESCRIPTION
Fix supercluster run.
It was using a relative path for testing. But during Jenkins run it spins up the container with entry point `/supercluster` thus the path needs to be adjusted accordingly. 