### PR TITLE
Re-enable loadgen upgrade setup check

### DIFF
--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -273,7 +273,7 @@ type StellarFormation with
         let loadgen =
             { LoadGen.GetDefault() with
                   mode = SetupSorobanUpgrade
-                  minSorobanPercentSuccess = Some 0 }
+                  minSorobanPercentSuccess = Some 100 }
 
         self.RunLoadgen coreSet loadgen
 


### PR DESCRIPTION
Closes #180

This change enforces that soroban upgrade setup succeeds now that repeated calls to soroban upgrade setup are fixed in loadgen (see stellar/stellar-core#4425)