### PR TITLE
Parallel-catchup miscellaneous improvements

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -103,6 +103,7 @@ type MissionOptions
         nonTier1NodesToAdd: int,
         randomSeed: int,
         pubnetParallelCatchupStartingLedger: int,
+        pubnetParallelCatchupEndLedger: int option,
         pubnetParallelCatchupNumWorkers: int,
         tag: string option,
         numRuns: int option
@@ -423,6 +424,9 @@ type MissionOptions
              Default = 0)>]
     member self.PubnetParallelCatchupStartingLedger = pubnetParallelCatchupStartingLedger
 
+    [<Option("pubnet-parallel-catchup-end-ledger", HelpText = "end ledger to run parallel catchup on", Required = false)>]
+    member self.PubnetParallelCatchupEndLedger = pubnetParallelCatchupEndLedger
+
     [<Option("pubnet-parallel-catchup-num-workers",
              HelpText = "number of workers to run parallel catchup with (only supported for V2)",
              Required = false,
@@ -543,6 +547,7 @@ let main argv =
                   randomSeed = 0
                   networkSizeLimit = 0
                   pubnetParallelCatchupStartingLedger = 0
+                  pubnetParallelCatchupEndLedger = None
                   pubnetParallelCatchupNumWorkers = 128
                   tag = None
                   numRuns = None
@@ -678,6 +683,7 @@ let main argv =
                                networkSizeLimit = mission.NetworkSizeLimit
                                randomSeed = mission.RandomSeed
                                pubnetParallelCatchupStartingLedger = mission.PubnetParallelCatchupStartingLedger
+                               pubnetParallelCatchupEndLedger = mission.PubnetParallelCatchupEndLedger
                                pubnetParallelCatchupNumWorkers = mission.PubnetParallelCatchupNumWorkers
                                tag = mission.Tag
                                numRuns = mission.NumRuns

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -110,6 +110,7 @@ let ctx : MissionContext =
       nonTier1NodesToAdd = 0
       randomSeed = 0
       pubnetParallelCatchupStartingLedger = 0
+      pubnetParallelCatchupEndLedger = None
       pubnetParallelCatchupNumWorkers = 128
       tag = None
       numRuns = None

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -24,9 +24,11 @@ let helmReleaseName = "parallel-catchup"
 let helmChartPath = "/supercluster/src/MissionParallelCatchup/parallel_catchup_helm"
 let valuesFilePath = helmChartPath + "/values.yaml"
 let jobMonitorHostName = "ssc-job-monitor.services.stellar-ops.com"
-let jobMonitorEndPoint = "/status"
-let jobMonitorStatusCheckIntervalSecs = 30
-let jobMonitorStatusCheckTimeOutSecs = 300
+let jobMonitorStatusEndPoint = "/status"
+let jobMonitorMetricsEndPoint = "/metrics"
+let jobMonitorStatusCheckIntervalSecs = 60
+let jobMonitorMetricsCheckIntervalSecs = 300
+let jobMonitorStatusCheckTimeOutSecs = 600
 let mutable toPerformCleanup = true
 
 let runCommand (command: string []) =
@@ -62,7 +64,13 @@ let installProject (context: MissionContext) =
     setOptions.Add(sprintf "worker.stellar_core_image=%s" context.image)
     setOptions.Add(sprintf "worker.replicas=%d" context.pubnetParallelCatchupNumWorkers)
     setOptions.Add(sprintf "range_generator.params.starting_ledger=%d" context.pubnetParallelCatchupStartingLedger)
-    setOptions.Add(sprintf "range_generator.params.latest_ledger_num=%d" (GetLatestPubnetLedgerNumber()))
+
+    let endLedger =
+        match context.pubnetParallelCatchupEndLedger with
+        | Some value -> value
+        | None -> GetLatestPubnetLedgerNumber()
+
+    setOptions.Add(sprintf "range_generator.params.latest_ledger_num=%d" endLedger)
     setOptions.Add(sprintf "monitor.hostname=%s" jobMonitorHostName)
 
     Environment.SetEnvironmentVariable("KUBECONFIG", context.kubeCfg)
@@ -102,22 +110,17 @@ Console.CancelKeyPress.Add
         cleanup ()
         Environment.Exit(0))
 
-let getJobMonitorStatus () =
+let getJobMonitorStatus (endPoint: String) =
     try
         use client = new HttpClient()
 
-        let response =
-            client
-                .GetStringAsync(
-                    "http://" + jobMonitorHostName + jobMonitorEndPoint
-                )
-                .Result
+        let response = client.GetStringAsync("http://" + jobMonitorHostName + endPoint).Result
 
-        LogInfo "job monitor response: %s" response
+        LogInfo "job monitor '%s': %s" endPoint response
         let json = JObject.Parse(response)
         Some(json)
     with ex ->
-        LogError "Error querying job monitor: %s" ex.Message
+        LogError "Error querying job monitor '%s': %s" endPoint ex.Message
         None
 
 
@@ -141,10 +144,11 @@ let historyPubnetParallelCatchupV2 (context: MissionContext) =
 
     let mutable allJobsFinished = false
     let mutable timeoutLeft = jobMonitorStatusCheckTimeOutSecs
+    let mutable timeBeforeNextMetricsCheck = jobMonitorMetricsCheckIntervalSecs
 
     while not allJobsFinished do
         Thread.Sleep(jobMonitorStatusCheckIntervalSecs * 1000)
-        let statusOpt = getJobMonitorStatus ()
+        let statusOpt = getJobMonitorStatus (jobMonitorStatusEndPoint)
 
         try
             match statusOpt with
@@ -163,6 +167,9 @@ let historyPubnetParallelCatchupV2 (context: MissionContext) =
                     failwith (sprintf "Catch up failed on these ranges: %s" res)
 
                 if remainSize = 0 && JobsInProgress.Count = 0 then
+                    // perform a final get for the metrics
+                    getJobMonitorStatus (jobMonitorMetricsEndPoint) |> ignore
+
                     // check all workers are down
                     let allWorkersDown =
                         status.["workers"] :?> JArray
@@ -173,6 +180,14 @@ let historyPubnetParallelCatchupV2 (context: MissionContext) =
 
                     LogInfo "No job left and all workers are down."
                     allJobsFinished <- true
+
+                // check the metrics
+                timeBeforeNextMetricsCheck <- timeBeforeNextMetricsCheck - jobMonitorStatusCheckIntervalSecs
+
+                if timeBeforeNextMetricsCheck <= 0 then
+                    getJobMonitorStatus (jobMonitorMetricsEndPoint) |> ignore
+                    timeBeforeNextMetricsCheck <- jobMonitorMetricsCheckIntervalSecs
+
             | None ->
                 LogError "no status"
                 timeoutLeft <- timeoutLeft - jobMonitorStatusCheckIntervalSecs

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -73,6 +73,7 @@ let installProject (context: MissionContext) =
     setOptions.Add(sprintf "range_generator.params.latest_ledger_num=%d" endLedger)
     setOptions.Add(sprintf "monitor.hostname=%s" jobMonitorHostName)
 
+    // comment out the line below when doing local testing
     Environment.SetEnvironmentVariable("KUBECONFIG", context.kubeCfg)
 
     runCommand [| "helm"

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -91,6 +91,7 @@ type MissionContext =
       numRuns: int option
       networkSizeLimit: int
       pubnetParallelCatchupStartingLedger: int
+      pubnetParallelCatchupEndLedger: int option
       pubnetParallelCatchupNumWorkers: int
 
       // Tail logging can cause the pubnet simulation missions like SorobanLoadGeneration

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/stellar-core.cfg
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/stellar-core.cfg
@@ -3,7 +3,7 @@ PUBLIC_HTTP_PORT=true
 NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 DATABASE="sqlite3:///data/stellar.db"
 BUCKET_DIR_PATH="/data/buckets"
-LOG_FILE_PATH="/data/stellar-core.log"
+LOG_FILE_PATH="/data/stellar-core-{datetime:%Y-%m-%d_%H-%M-%S}.log"
 ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
 DEPRECATED_SQL_LEDGER_STATE=false
 

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
@@ -7,6 +7,7 @@ if [ -z "$JOB_QUEUE" ]; then echo "JOB_QUEUE not set"; exit 1; fi
 if [ -z "$PROGRESS_QUEUE" ]; then echo "PROGRESS_QUEUE not set"; exit 1; fi
 if [ -z "$FAILED_QUEUE" ]; then echo "FAILED_QUEUE not set"; exit 1; fi
 if [ -z "$SUCCESS_QUEUE" ]; then echo "SUCCESS_QUEUE not set"; exit 1; fi
+if [ -z "$METRICS" ]; then echo "METRICS not set"; exit 1; fi
 if [ -z "$RELEASE_NAME" ]; then echo "RELEASE_NAME not set"; exit 1; fi
 if [ -z "$POD_NAME" ]; then echo "POD_NAME not set"; exit 1; fi
 
@@ -22,22 +23,22 @@ LOG_DIR="/data"
 while true; do
 # Fetch the next job key from the Redis queue. 
 # The queue operation is always push left pop right. 
-JOB_KEY=$(redis-cli -h $REDIS_HOST -p $REDIS_PORT LMOVE "$JOB_QUEUE" "$PROGRESS_QUEUE" RIGHT LEFT)
+JOB_KEY=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" LMOVE "$JOB_QUEUE" "$PROGRESS_QUEUE" RIGHT LEFT)
 
 if [ -n "$JOB_KEY" ]; then
     # Start timer
     START_TIME=$(date +%s)  
     echo "Processing job: $JOB_KEY"
 
-    if [ ! "$(/usr/bin/stellar-core --conf /config/stellar-core.cfg new-db --console&&
-    /usr/bin/stellar-core --conf /config/stellar-core.cfg catchup "$JOB_KEY" --metric 'ledger.transaction.apply' --console)" ]; then
+    if [ ! "$(/usr/bin/stellar-core --conf /config/stellar-core.cfg new-db&&
+    /usr/bin/stellar-core --conf /config/stellar-core.cfg catchup "$JOB_KEY" --metric 'ledger.transaction.apply')" ]; then
     echo "Error processing job: $JOB_KEY"
-    redis-cli -h $REDIS_HOST -p $REDIS_PORT LPUSH "$FAILED_QUEUE" "$JOB_KEY|$POD_NAME" # enhance the entry with pod name for tracking
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" LPUSH "$FAILED_QUEUE" "$JOB_KEY|$POD_NAME" # enhance the entry with pod name for tracking
     else
     echo "Successfully processed job: $JOB_KEY"
-    redis-cli -h $REDIS_HOST -p $REDIS_PORT LPUSH "$SUCCESS_QUEUE" "$JOB_KEY"
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" LPUSH "$SUCCESS_QUEUE" "$JOB_KEY"
     fi
-    redis-cli -h $REDIS_HOST -p $REDIS_PORT LREM "$PROGRESS_QUEUE" -1 "$JOB_KEY"
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" LREM "$PROGRESS_QUEUE" -1 "$JOB_KEY"
 
     # Parse and extract the metrics from the log file
     LOG_FILE=$(ls -t $LOG_DIR/stellar-core*.log | head -n 1)
@@ -46,21 +47,17 @@ if [ -n "$JOB_KEY" ]; then
     exit 1
     fi
 
-    transaction_sum=$(tac "$LOG_FILE" | grep -m 1 -B 11 "metric 'ledger.transaction.apply':" | grep "sum =" | awk '{print $NF}')
+    tx_apply_ms=$(tac "$LOG_FILE" | grep -m 1 -B 11 "metric 'ledger.transaction.apply':" | grep "sum =" | awk '{print $NF}')
     echo "Log file: $LOG_FILE"
-    echo "ledger.transaction.apply sum: $transaction_sum"
+    echo "ledger.transaction.apply sum: $tx_apply_ms"
 
     # End timer and duration
     END_TIME=$(date +%s)
-    DURATION=$((END_TIME - START_TIME))
-    echo "Finish processing job: $JOB_KEY, duration (seconds): $DURATION"
+    DURATION=$((END_TIME - START_TIME))s
+    echo "Finish processing job: $JOB_KEY, duration: $DURATION"
 
-    # publish metrics
-    cat <<EOF | curl --data-binary @- http://pushgateway.services.stellar-ops.com:9091/metrics/job/${RELEASE_NAME}/instance/${POD_NAME}
-total_duration_seconds{catchup_to_ledger="${JOB_KEY%/*}",ledgers_to_apply="${JOB_KEY#*/}"} $DURATION
-ledger_transaction_apply_ms{catchup_to_ledger="${JOB_KEY%/*}",ledgers_to_apply="${JOB_KEY#*/}"} $(echo "$transaction_sum" | sed 's/ms$//')
-EOF
-
+    # push metrics
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" SADD "$METRICS" "$JOB_KEY|$tx_apply_ms|$DURATION"
 else
     echo "No more jobs in the queue. Sleeping for $SLEEP_INTERVAL seconds..."
     sleep $SLEEP_INTERVAL

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
@@ -57,7 +57,8 @@ if [ -n "$JOB_KEY" ]; then
     echo "Finish processing job: $JOB_KEY, duration: $DURATION"
 
     # push metrics
-    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" SADD "$METRICS" "$JOB_KEY|$tx_apply_ms|$DURATION"
+    core_id=$(echo "$POD_NAME" | grep -o '[0-9]\+')
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" SADD "$METRICS" "$JOB_KEY|$core_id|$tx_apply_ms|$DURATION"
 else
     echo "No more jobs in the queue. Sleeping for $SLEEP_INTERVAL seconds..."
     sleep $SLEEP_INTERVAL

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -31,16 +31,10 @@ spec:
       - name: stellar-core
         image: {{ .Values.worker.stellar_core_image }}
         imagePullPolicy: Always
-        # resource specs copied from the old supercluster mission
+        {{- if (.Values.worker).resources }}
         resources:
-          requests:
-            cpu: "{{ .Values.worker.resources.requests.cpu}}"
-            memory: "{{ .Values.worker.resources.requests.memory}}"
-            ephemeral-storage: "{{ .Values.worker.resources.requests.ephemeral_storage}}"
-          limits:
-            cpu: "{{ .Values.worker.resources.limits.cpu}}"
-            memory: "{{ .Values.worker.resources.limits.memory}}"
-            ephemeral-storage: "{{ .Values.worker.resources.limits.ephemeral_storage}}"
+        {{ toYaml .Values.worker.resources | indent 10 }}
+        {{- end }}
         command: ["/bin/sh", "/scripts/worker.sh"]
         ports:
         - containerPort: 11626
@@ -92,4 +86,5 @@ data:
   SUCCESS_QUEUE: "{{ .Values.redis.success_queue }}"
   FAILED_QUEUE: "{{ .Values.redis.failed_queue }}"
   PROGRESS_QUEUE: "{{ .Values.redis.progress_queue }}"
+  METRICS: "{{ .Values.redis.metrics }}"
   RELEASE_NAME: "{{ .Release.Name }}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -31,10 +31,15 @@ spec:
       - name: stellar-core
         image: {{ .Values.worker.stellar_core_image }}
         imagePullPolicy: Always
-        {{- if (.Values.worker).resources }}
         resources:
-        {{ toYaml .Values.worker.resources | indent 6 }}
-        {{- end }}
+          requests:
+            cpu: "{{ .Values.worker.resources.requests.cpu}}"
+            memory: "{{ .Values.worker.resources.requests.memory}}"
+            ephemeral-storage: "{{ .Values.worker.resources.requests.ephemeral_storage}}"
+          limits:
+            cpu: "{{ .Values.worker.resources.limits.cpu}}"
+            memory: "{{ .Values.worker.resources.limits.memory}}"
+            ephemeral-storage: "{{ .Values.worker.resources.limits.ephemeral_storage}}"
         command: ["/bin/sh", "/scripts/worker.sh"]
         ports:
         - containerPort: 11626

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -33,7 +33,7 @@ spec:
         imagePullPolicy: Always
         {{- if (.Values.worker).resources }}
         resources:
-        {{ toYaml .Values.worker.resources | indent 10 }}
+        {{ toYaml .Values.worker.resources | indent 6 }}
         {{- end }}
         command: ["/bin/sh", "/scripts/worker.sh"]
         ports:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -50,10 +50,10 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
-        {{- if (.Values.monitor).resources }}
         resources:
-        {{ toYaml .Values.monitor.resources | indent 6 }}
-        {{- end }}
+          requests:
+            cpu: "{{ .Values.monitor.resources.requests.cpu}}"
+            memory: "{{ .Values.monitor.resources.requests.memory}}"
         env:
         - name: NAMESPACE
           valueFrom:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -52,7 +52,7 @@ spec:
         - containerPort: 8080
         {{- if (.Values.monitor).resources }}
         resources:
-        {{ toYaml .Values.monitor.resources | indent 10 }}
+        {{ toYaml .Values.monitor.resources | indent 6 }}
         {{- end }}
         env:
         - name: NAMESPACE

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -47,12 +47,13 @@ spec:
       containers:
       - name: job-monitor
         image: stellar/ssc-job-monitor:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        {{- if (.Values.monitor).resources }}
         resources:
-          requests:
-            cpu: "{{ .Values.monitor.resources.requests.cpu}}"
-            memory: "{{ .Values.monitor.resources.requests.memory}}"
+        {{ toYaml .Values.monitor.resources | indent 10 }}
+        {{- end }}
         env:
         - name: NAMESPACE
           valueFrom:
@@ -85,6 +86,7 @@ data:
   SUCCESS_QUEUE: "{{ .Values.redis.success_queue }}"
   FAILED_QUEUE: "{{ .Values.redis.failed_queue }}"
   PROGRESS_QUEUE: "{{ .Values.redis.progress_queue }}"
+  METRICS: "{{ .Values.redis.metrics }}"
   WORKER_PREFIX: "stellar-core"
   WORKER_COUNT: "{{ .Values.worker.replicas }}"
   LOGGING_INTERVAL_SECONDS: "{{ .Values.monitor.logging_interval_seconds}}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
@@ -31,7 +31,7 @@ spec:
         ports:
         - containerPort: 6379
         command: ["redis-server"]
-        {{- if (.Values.redis).resources }}
         resources:
-        {{ toYaml .Values.redis.resources | indent 6 }}
-        {{- end }}
+          requests:
+            cpu: "{{ .Values.redis.resources.requests.cpu}}"
+            memory: "{{ .Values.redis.resources.requests.memory}}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
@@ -31,7 +31,7 @@ spec:
         ports:
         - containerPort: 6379
         command: ["redis-server"]
+        {{- if (.Values.redis).resources }}
         resources:
-          requests:
-            cpu: "{{ .Values.redis.resources.requests.cpu}}"
-            memory: "{{ .Values.redis.resources.requests.memory}}"
+        {{ toYaml .Values.redis.resources | indent 10 }}
+        {{- end }}

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/redis_queue.yaml
@@ -33,5 +33,5 @@ spec:
         command: ["redis-server"]
         {{- if (.Values.redis).resources }}
         resources:
-        {{ toYaml .Values.redis.resources | indent 10 }}
+        {{ toYaml .Values.redis.resources | indent 6 }}
         {{- end }}

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -5,10 +5,11 @@ redis:
   success_queue: "succeeded"
   failed_queue: "failed"
   progress_queue: "in_progress"
-  resources:
-    requests: 
-      cpu: "100m"
-      memory: "100Mi"
+  metrics: "metrics"
+  # resources:
+  #   requests: 
+  #     cpu: "100m"
+  #     memory: "100Mi"
 
 worker:
   stellar_core_image: "stellar/stellar-core:latest"
@@ -26,12 +27,12 @@ worker:
 monitor:
   ingress_class_name: "private"
   hostname: "ssc-job-monitor.services.stellar-ops.com"
-  logging_interval_seconds: 10
+  logging_interval_seconds: 30
   logging_level: "INFO" # 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
-  resources:
-    requests: 
-      cpu: "100m"
-      memory: "100Mi"
+  # resources:
+  #   requests: 
+  #     cpu: "100m"
+  #     memory: "100Mi"
 
 range_generator:
   strategy: "uniform" # "uniform" or "logarithmic"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -6,16 +6,16 @@ redis:
   failed_queue: "failed"
   progress_queue: "in_progress"
   metrics: "metrics"
-  # resources:
-  #   requests: 
-  #     cpu: "100m"
-  #     memory: "100Mi"
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "100Mi"
 
 worker:
   stellar_core_image: "stellar/stellar-core:latest"
   replicas: 5
   resources:
-    requests: 
+    requests:
       cpu: "1"
       memory: "10Gi"
       ephemeral_storage: "35Gi"
@@ -29,10 +29,10 @@ monitor:
   hostname: "ssc-job-monitor.services.stellar-ops.com"
   logging_interval_seconds: 30
   logging_level: "INFO" # 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
-  # resources:
-  #   requests: 
-  #     cpu: "100m"
-  #     memory: "100Mi"
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "100Mi"
 
 range_generator:
   strategy: "uniform" # "uniform" or "logarithmic"


### PR DESCRIPTION
- Store metrics in Redis and expose `/metrics` endpoint in job-monitor
- Reduce logging
- Add option "PubnetParallelCatchupEndLedger"
- ~Make resource optional~