### PR TITLE
Use v1 resources for parallel catchup v2

### DIFF
--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/stellar-core.cfg
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/stellar-core.cfg
@@ -1,33 +1,43 @@
-HTTP_PORT=11626
-PUBLIC_HTTP_PORT=true
-NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
-DATABASE="sqlite3:///data/stellar.db"
-BUCKET_DIR_PATH="/data/buckets"
-LOG_FILE_PATH="/data/stellar-core-{datetime:%Y-%m-%d_%H-%M-%S}.log"
-ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
-DEPRECATED_SQL_LEDGER_STATE=false
+DATABASE = "sqlite3:///data/stellar.db"
+DEPRECATED_SQL_LEDGER_STATE = false
+METADATA_DEBUG_LEDGERS = 0
+HTTP_PORT = 11626
+PUBLIC_HTTP_PORT = true
+BUCKET_DIR_PATH = "/data/buckets"
+NETWORK_PASSPHRASE = "Public Global Stellar Network ; September 2015"
+NODE_SEED = "SCQ5T4EDPI5KPGQDR6EFZZYOAMHBSFFKH6GLE27D5PYNOCCITJLJGU3Q"
+NODE_IS_VALIDATOR = false
+RUN_STANDALONE = false
+PREFERRED_PEERS = ["core-live4.stellar.org", "core-live5.stellar.org", "core-live6.stellar.org"]
+PREFERRED_PEERS_ONLY = false
+COMMANDS = []
+CATCHUP_COMPLETE = true
+MAXIMUM_LEDGER_CLOSETIME_DRIFT = 120
+CATCHUP_RECENT = 0
+MAX_SLOTS_TO_REMEMBER = 12
+MAX_BATCH_WRITE_COUNT = 1024
+AUTOMATIC_MAINTENANCE_PERIOD = 10
+AUTOMATIC_MAINTENANCE_COUNT = 50000
+ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = false
+ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = true
+TARGET_PEER_CONNECTIONS = 16
+MAX_ADDITIONAL_PEER_CONNECTIONS = 48
+QUORUM_INTERSECTION_CHECKER = false
+MANUAL_CLOSE = false
+INVARIANT_CHECKS = ["(?!BucketListIsConsistentWithDatabase).*"]
+UNSAFE_QUORUM = true
+FAILURE_SAFETY = 0
 
-[[HOME_DOMAINS]]
-HOME_DOMAIN="www.stellar.org"
-QUALITY="HIGH"
+[QUORUM_SET]
+VALIDATORS = ["GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH core_live_001", "GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK core_live_002", "GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ core_live_003"]
 
-[[VALIDATORS]]
-NAME = "SDF 1"
-PUBLIC_KEY = "GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
-ADDRESS = "core-live-a.stellar.org:11625"
-HISTORY = "curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
-HOME_DOMAIN = "www.stellar.org"
+[HISTORY]
 
-[[VALIDATORS]]
-NAME = "SDF 2"
-PUBLIC_KEY = "GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK"
-ADDRESS = "core-live-b.stellar.org:11625"
-HISTORY = "curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
-HOME_DOMAIN = "www.stellar.org"
+[HISTORY.core_live_001]
+get = "curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
 
-[[VALIDATORS]]
-NAME = "SDF 3"
-PUBLIC_KEY = "GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ"
-ADDRESS = "core-live-c.stellar.org:11625"
-HISTORY = "curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
-HOME_DOMAIN = "www.stellar.org"
+[HISTORY.core_live_002]
+get = "curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
+
+[HISTORY.core_live_003]
+get = "curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -16,12 +16,12 @@ worker:
   replicas: 5
   resources:
     requests:
-      cpu: "1"
-      memory: "10Gi"
+      cpu: "250m"
+      memory: "1200Mi"
       ephemeral_storage: "35Gi"
     limits:
-      cpu: "4"
-      memory: "30Gi"
+      cpu: "2"
+      memory: "6Gi"
       ephemeral_storage: "40Gi"
 
 monitor:


### PR DESCRIPTION
Parallel catchup V2 is taking longer than V1, so this is an attempt to reduce the variables between them. 