### PR TITLE
Turn heartbeat into a pod logger that swallows errors

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -590,8 +590,7 @@ let main argv =
                              LogError "Heartbeat did not return any data."
                          else
                              DumpPodInfo kube mission.ApiRateLimit ns
-                     with x ->
-                         LogError "Connection issue! Api call failed."
+                     with x -> LogError "Connection issue! Api call failed."
 
                  let timer = new System.Threading.Timer(TimerCallback(podLogger), null, 1000, 300000)
 

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -581,21 +581,19 @@ let main argv =
                  let (kube, ns) = ConnectToCluster mission.KubeConfig mission.NamespaceProperty
                  let destination = Destination(mission.Destination)
 
-                 let heartbeatHandler _ =
+                 let podLogger _ =
                      try
                          ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (mission.ApiRateLimit)
                          let ranges = kube.ListNamespacedLimitRange(namespaceParameter = ns)
 
                          if isNull ranges then
-                             failwith "Connection issue!"
+                             LogError "Heartbeat did not return any data."
                          else
                              DumpPodInfo kube mission.ApiRateLimit ns
                      with x ->
-                         LogError "Connection issue!"
-                         reraise ()
+                         LogError "Connection issue! Api call failed."
 
-                 // Poll cluster every 5 minutes to make sure we don't have any issues
-                 let timer = new System.Threading.Timer(TimerCallback(heartbeatHandler), null, 1000, 300000)
+                 let timer = new System.Threading.Timer(TimerCallback(podLogger), null, 1000, 300000)
 
                  for m in mission.Missions do
                      LogInfo "-----------------------------------"


### PR DESCRIPTION
The api request is unreliable, so this PR just uses the handler for informational purposes.