### PR TITLE
Cleanup helm when running the clean command

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -14,6 +14,7 @@ open StellarNetworkCfg
 open StellarMission
 open StellarMissionContext
 open StellarSupercluster
+open MissionHistoryPubnetParallelCatchupV2
 
 open System.Threading
 
@@ -441,6 +442,8 @@ type MissionOptions
              Required = false)>]
     member self.NumRuns = numRuns
 
+let localCleanup () = cleanupParallelCatchupV2 ()
+
 let splitLabel (lab: string) : (string * string option) =
     match lab.Split ':' with
     | [| x |] -> (x, None)
@@ -556,6 +559,7 @@ let main argv =
             let nCfg = MakeNetworkCfg ctx [] None
             use formation = kube.MakeEmptyFormation nCfg
             formation.CleanNamespace()
+            localCleanup ()
             0
 
         | :? MissionOptions as mission ->

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -94,21 +94,22 @@ let installProject (context: MissionContext) =
     | _ -> ()
 
 // Cleanup on exit
-let cleanup () =
+let cleanupParallelCatchupV2 () =
     if toPerformCleanup then
         toPerformCleanup <- false
         LogInfo "Cleaning up resources..."
 
         runCommand [| "helm"
                       "uninstall"
-                      helmReleaseName |]
+                      helmReleaseName
+                      "--ignore-not-found" |]
         |> ignore
 
-System.AppDomain.CurrentDomain.ProcessExit.Add(fun _ -> cleanup ())
+System.AppDomain.CurrentDomain.ProcessExit.Add(fun _ -> cleanupParallelCatchupV2 ())
 
 Console.CancelKeyPress.Add
     (fun _ ->
-        cleanup ()
+        cleanupParallelCatchupV2 ()
         Environment.Exit(0))
 
 let getJobMonitorStatus (endPoint: String) =
@@ -194,7 +195,7 @@ let historyPubnetParallelCatchupV2 (context: MissionContext) =
                 timeoutLeft <- timeoutLeft - jobMonitorStatusCheckIntervalSecs
                 if timeoutLeft <= 0 then failwith "job monitor not reachable"
         with ex ->
-            cleanup ()
+            cleanupParallelCatchupV2 ()
             raise ex
 
-    cleanup ()
+    cleanupParallelCatchupV2 ()


### PR DESCRIPTION
We've seen that helm doesn't always get cleaned up on some SSC errors, so this adds the helm cleanup to the `clean` command.