### PR TITLE
Increase parallel catchup v2 parallelism to 256

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
     - name: Run BootAndSync mission
       run: dotnet run --project src/App/App.fsproj --configuration Release -- mission BootAndSync --image stellar/stellar-core:stable --kubeconfig $KUBECONFIG --namespace default --ingress-class nginx --ingress-internal-domain local --ingress-external-host localhost --uneven-sched
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: destination
         path: destination/

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_preload_redis.yaml
@@ -59,6 +59,6 @@ data:
   OVERLAP_LEDGERS: "{{ .Values.range_generator.params.overlap_ledgers }}"
   LEDGERS_PER_JOB: "{{ .Values.range_generator.params.uniform_ledgers_per_job }}"
   LOGARITHMIC_FLOOR_LEDGERS: "{{ .Values.range_generator.params.logarithmic_floor_ledgers }}"
-  NUM_PARALLELISM: "128"
+  NUM_PARALLELISM: "256"
   REDIS_HOST: "{{ .Values.redis.hostname}}"
   REDIS_PORT: "{{ .Values.redis.port}}"


### PR DESCRIPTION
This is an experiment to measure the performance gain from doubling the number of pods. 

We are still prioritizing the other issues mentioned in https://github.com/stellar/stellar-supercluster/issues/305.