### PR TITLE
Revert "Reduce limits for parallel catchup v2"

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -147,8 +147,8 @@ let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
 
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
-    // 1200MB RAM, 0.25 vCPUs, and 20 GB of disk bursting to 2vCPU, 6000MB and 25 GB
-    makeResourceRequirementsWithStorageLimit 250 1200 2000 6000 20 25
+    // 1200MB RAM, 0.25 vCPUs, and 35 GB of disk bursting to 2vCPU, 6000MB and 40 GB
+    makeResourceRequirementsWithStorageLimit 250 1200 2000 6000 35 40
 
 let NonParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing non-parallel catchup, we give each container

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -18,11 +18,11 @@ worker:
     requests:
       cpu: "250m"
       memory: "1200Mi"
-      ephemeral_storage: "20Gi"
+      ephemeral_storage: "35Gi"
     limits:
       cpu: "2"
       memory: "6Gi"
-      ephemeral_storage: "25Gi"
+      ephemeral_storage: "40Gi"
 
 monitor:
   ingress_class_name: "private"


### PR DESCRIPTION
This reverts commit 8c664729556c1a0ff8e59f43effc470d102c910c.

We hit the 25 GB limit in parallel catchup v2