### PR TITLE
Update theoretical max TPS results for all releases from 21.2.0 up

### DIFF
--- a/doc/theoretical-max-tps.md
+++ b/doc/theoretical-max-tps.md
@@ -26,6 +26,11 @@ Finally, don't forget to shut down your EKS cluster.
 This table contains the theoretical max TPS stellar-core achieved, ordered by
 stellar-core release.
 
-| Core Version | Core Image | Topology (total # of stellar-core nodes / # of validators) | EC2 Instance Type | Number of EC2 Instances | Max TPS |
-|--------------|------------|------------------------------------------------------------|-------------------|-------------------------|---------|
-| 21.1.0 | `stellar/unsafe-stellar-core:21.0.1-1917.52a449ff3.focal-testing-asan-disabled-perftests` | 7 / 3 | m5d.4xlarge | 10 | 1137 |
+| Core Version | Core Image | Database Backend | Topology (total # of stellar-core nodes / # of validators) | EC2 Instance Type | Number of EC2 Instances | Max TPS |
+|--------------|------------|------------------|------------------------------------------------------------|-------------------|-------------------------|---------|
+| 22.0.0rc2 | `stellar/unsafe-stellar-core:22.0.0-2095.rc2.1bccbc921.focal-perftests` | BucketListDB | 7 / 3 | md5.4xlarge | 10 | 958 |
+| 21.3.1 | `stellar/unsafe-stellar-core:21.3.1-2007.4ede19620.focal-perftests` | BucketListDB | 7 / 3 | m5d.4xlarge | 10 | 1110 |
+| 21.3.1 | `stellar/unsafe-stellar-core:21.3.1-2007.4ede19620.focal-perftests` | SQLite in-memory | 7 / 3 | m5d.4xlarge | 10 | 1170 |
+| 21.2.0 | `stellar/unsafe-stellar-core:21.2.0-1953.d78f48eac.focal-perftests` | BucketListDB | 7 / 3 | m5d.4xlarge | 10 | 1059 |
+| 21.2.0 | `stellar/unsafe-stellar-core:21.2.0-1953.d78f48eac.focal-perftests` | SQLite in-memory | 7 / 3 | m5d.4xlarge | 10 | 1053 |
+| 21.1.0 | `stellar/unsafe-stellar-core:21.0.1-1917.52a449ff3.focal-testing-asan-disabled-perftests` | SQLite in-memory | 7 / 3 | m5d.4xlarge | 10 | 1137 |

--- a/scripts/eks-init.py
+++ b/scripts/eks-init.py
@@ -13,7 +13,7 @@ DEFAULT_REGION = "us-west-2"
 # topology plus 3 to cover the ingress controller and two coredns instances.
 DEFAULT_NUM_NODES = 10
 DEFAULT_NODE_TYPE = "m5d.4xlarge"
-KUBERNETES_VERSION = "1.28"
+KUBERNETES_VERSION = "1.29"
 SSH_USERNAME = "ec2-user"
 NVME_MOUNT_SCRIPT = "https://raw.githubusercontent.com/awslabs/amazon-eks-ami/86105105a83fdc80e682b850aac6f626119a6951/templates/shared/runtime/bin/setup-local-disks"
 DNS_RETRY_INTERVAL_SECONDS = 60


### PR DESCRIPTION
This change adds theoretical max TPS results for v21.2.0, v21.3.1, and v22.0.0rc2. For v21.2.0 and v21.3.1 it includes results for both the SQLite in-memory database backend and the BucketListDB backend.

Additionally, this change bumps the default kubernetes version in the `eks-init.py` script to match the version supercluster targets.