### PR TITLE
Set up path-based routes for job-monitor ingress

### DIFF
--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -207,6 +207,7 @@ type StellarCoreCfg =
         t.Add("PREFERRED_PEERS_ONLY", self.preferredPeersOnly) |> ignore
         t.Add("COMMANDS", logLevelCommands) |> ignore
         t.Add("CATCHUP_COMPLETE", self.catchupMode = CatchupComplete) |> ignore
+
         if self.network.missionContext.enableBackggroundOverlay then
             t.Add("EXPERIMENTAL_BACKGROUND_OVERLAY_PROCESSING", true) |> ignore
 

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -3,14 +3,15 @@ kind: Ingress
 metadata:
   name: job-monitor-ingress
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   ingressClassName: "{{ .Values.monitor.ingress_class_name}}"
   rules:
   - host: "{{ .Values.monitor.hostname}}"
     http:
       paths:
-      - path: /
+      - path: "{{ .Values.monitor.path}}"
         pathType: Prefix
         backend:
           service:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -27,6 +27,7 @@ worker:
 monitor:
   ingress_class_name: "private"
   hostname: "ssc-job-monitor.services.stellar-ops.com"
+  path: "/default/(.*)"
   logging_interval_seconds: 300
   logging_level: "INFO" # 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
   resources:


### PR DESCRIPTION
Resolves https://github.com/stellar/stellar-supercluster/issues/310

Set up path-based ingress routes based on the the Kubernetes namespace, such that requests to the job-monitor host does not route to service from another namespace.
E.g. in scenarios when there is a production run simultaneous to local testing, the queries will be separately routed :
- (my namespace for testing) http://ssc-job-monitor.services.stellar-ops.com/jay/status
- (production namespace) http://ssc-job-monitor.services.stellar-ops.com/stellar-supercluster/metrics

Tested in https://buildmeister-v3.stellar-ops.com/job/Core/job/stellar-supercluster-test/41/ and verified the production mission does not return response from my local job-monitor service. 