### PR TITLE
Enable console logging and improve parallel catchup diagnostics

### DIFF
--- a/src/FSLibrary/StellarDestination.fs
+++ b/src/FSLibrary/StellarDestination.fs
@@ -45,3 +45,8 @@ type Destination(path: string) =
         let fullPath = Path.Combine [| path; name |]
         LogInfo "Writing data to %s" fullPath
         File.WriteAllText(fullPath, content)
+
+    member public self.WriteLines (name: string) (content: string array) : unit =
+        let fullPath = Path.Combine [| path; name |]
+        LogInfo "Writing data to %s" fullPath
+        File.WriteAllLines(fullPath, content)

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
@@ -30,8 +30,8 @@ if [ -n "$JOB_KEY" ]; then
     START_TIME=$(date +%s)  
     echo "Processing job: $JOB_KEY"
 
-    if [ ! "$(/usr/bin/stellar-core --conf /config/stellar-core.cfg new-db&&
-    /usr/bin/stellar-core --conf /config/stellar-core.cfg catchup "$JOB_KEY" --metric 'ledger.transaction.apply')" ]; then
+    if [ ! "$(/usr/bin/stellar-core --conf /config/stellar-core.cfg new-db --console&&
+    /usr/bin/stellar-core --conf /config/stellar-core.cfg catchup "$JOB_KEY" --metric 'ledger.transaction.apply' --console)" ]; then
     echo "Error processing job: $JOB_KEY"
     redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" LPUSH "$FAILED_QUEUE" "$JOB_KEY|$POD_NAME" # enhance the entry with pod name for tracking
     else


### PR DESCRIPTION
Resolves https://github.com/stellar/supercluster/issues/215 by
- Enable worker console logging
- On the mission side, log the last x (x=1000) lines to the console (the additional logs to file stay the same)
- Increase logging frequency to make sure any failure status is caught on time

Initially we disabled console logging and increased logging intervals due to suspecting it degraded catchup performance. However it turned out not to be the case, so here it should be safe to increase it back.