### PR TITLE
Fix failing pubnet conversion test

### DIFF
--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -238,7 +238,7 @@ type Tests(output: ITestOutputHelper) =
              Assert.Contains(coreSets, (fun cs -> cs.name = sdfCoreSetName))
              // Ensure that 'validator.stellar.expert' got a different name from
              // 'www.stellar.org'.
-             Assert.Contains(coreSets, (fun cs -> cs.name = (CoreSetName "expert")))
+             Assert.Contains(coreSets, (fun cs -> cs.name = (CoreSetName "expert-non-tier1")))
              let sdfCoreSet = List.find (fun cs -> cs.name = sdfCoreSetName) coreSets
              Assert.Equal(3, sdfCoreSet.options.nodeCount)
              let cfg = nCfg.StellarCoreCfg(sdfCoreSet, 0, MainCoreContainer)


### PR DESCRIPTION
The "Public network conversion looks reasonable" test expects the Stellar expert validators to belong to a coreset called `expert`. However, #220 changed some of the coreset name mangling logic, so the expected name is now `expert-non-tier1`. This PR fixes the test to check for the correct name.