### PR TITLE
Add option to use CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING in PubnetParallelCatchupV2

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -109,7 +109,8 @@ type MissionOptions
         pubnetParallelCatchupEndLedger: int option,
         pubnetParallelCatchupNumWorkers: int,
         tag: string option,
-        numRuns: int option
+        numRuns: int option,
+        catchupSkipKnownResultsForTesting: bool
     ) =
 
     [<Option('k', "kubeconfig", HelpText = "Kubernetes config file", Required = false, Default = "~/.kube/config")>]
@@ -458,6 +459,12 @@ type MissionOptions
              Required = false)>]
     member self.NumRuns = numRuns
 
+    [<Option("catchup-skip-known-results-for-testing",
+             HelpText = "when this flag is provided, pubnet parallel catchup workers will run with CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = true, resulting in skipping application of failed transaction and signature verification",
+             Required = false,
+             Default = true)>]
+    member self.CatchupSkipKnownResultsForTesting = catchupSkipKnownResultsForTesting
+
 let splitLabel (lab: string) : (string * string option) =
     match lab.Split ':' with
     | [| x |] -> (x, None)
@@ -571,7 +578,8 @@ let main argv =
                   pubnetParallelCatchupNumWorkers = 128
                   tag = None
                   numRuns = None
-                  enableTailLogging = true }
+                  enableTailLogging = true
+                  catchupSkipKnownResultsForTesting = true }
 
             let nCfg = MakeNetworkCfg ctx [] None
             use formation = kube.MakeEmptyFormation nCfg
@@ -707,7 +715,8 @@ let main argv =
                                pubnetParallelCatchupNumWorkers = mission.PubnetParallelCatchupNumWorkers
                                tag = mission.Tag
                                numRuns = mission.NumRuns
-                               enableTailLogging = true }
+                               enableTailLogging = true
+                               catchupSkipKnownResultsForTesting = mission.CatchupSkipKnownResultsForTesting }
 
                          allMissions.[m] missionContext
 

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -117,7 +117,8 @@ let ctx : MissionContext =
       pubnetParallelCatchupNumWorkers = 128
       tag = None
       numRuns = None
-      enableTailLogging = true }
+      enableTailLogging = true
+      catchupSkipKnownResultsForTesting = false }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2024-08-01.json"
 let pubkeys = __SOURCE_DIRECTORY__ + "/../../../data/tier1keys.json"

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -67,6 +67,7 @@ let installProject (context: MissionContext) =
     setOptions.Add(sprintf "worker.stellar_core_image=%s" context.image)
     setOptions.Add(sprintf "worker.replicas=%d" context.pubnetParallelCatchupNumWorkers)
     setOptions.Add(sprintf "range_generator.params.starting_ledger=%d" context.pubnetParallelCatchupStartingLedger)
+    setOptions.Add(sprintf "worker.catchup_skip_known_results_for_testing=%b" context.catchupSkipKnownResultsForTesting)
 
     let endLedger =
         match context.pubnetParallelCatchupEndLedger with

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -109,4 +109,5 @@ type MissionContext =
       // and SimulatePubnet to fail on the heartbeat handler due to what looks like a
       // server disconnection. Our solution for now is to just disable tail logging on
       // those missions.
-      enableTailLogging: bool }
+      enableTailLogging: bool
+      catchupSkipKnownResultsForTesting: bool }

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -102,6 +102,10 @@ metadata:
   name: stellar-core-config
 data:
   stellar-core.cfg: |-
+    {{- if .Values.worker.catchup_skip_known_results_for_testing }}
+    {{ "\n" }}
+    CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = true
+    {{- end }}
     {{- (.Files.Get "files/stellar-core.cfg") | nindent 4 }}
 ---
 apiVersion: v1


### PR DESCRIPTION
# Overview
* Adds `--catchup-use-known-results-for-testing` cli flag to supercluster, which results `PubnetParallelCatchupV2` running with `CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING=true` in its config
* Adds `worker.catchup_skip_known_results_for_testing` kube set option, which is set to true if supercluster was run with `--catchup-use-known-results-for-testing`
* The catchup workers `config` volume is sourced from `stellar-core-config` configMap
*  if `worker.use_known_results_config` is true, the data of the `stellar-core-config` `configMap` includes `CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = true`


# Testing:
- Currently, the [catchup worker invocation](https://github.com/stellar/supercluster/compare/main...ThomasBrady:supercluster:add-catchup-skip-known-results-missionops?expand=1#diff-8ad1481eef0b22a40c79c91cf31a8a6866ca404224797fab02378208636f9799R34) is set to `--ll=INFO` to allow for log message which validate results are downloaded and used for catchup 
- Locally I have run `PubnetParallelCatchupV2` via helm and been able to see the `--use_known_results_config` flag resulting in Results being downloaded via logs
```
stellar_core_image: docker-registry.services.stellar-ops.com/dev/stellar-core:22.0.1-2178.fb725ab9b.focal-do-not-use-in-prd-buildtests
  use_known_results_config: true
  ```
  - Next step is to test via the [supercluster test pipeline](https://buildmeister-v3.stellar-ops.com/job/Core/job/stellar-supercluster-test/) with [my changes to `stellar-supercluster`](https://github.com/stellar/stellar-supercluster/pull/323)
  
  # Future
  It would be nice to have a dynamic (or templated) generation of config files for this mission. We use a TOML library in the other missions to generate config files, perhaps we can do something similar for `PubnetParallelCatchupV2`?