### PR TITLE
Bump probe timeout

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -153,7 +153,7 @@ type MissionOptions
     [<Option("export-to-prometheus", HelpText = "Whether to export core metrics to prometheus")>]
     member self.ExportToPrometheus : bool = exportToPrometheus
 
-    [<Option("probe-timeout", HelpText = "Timeout for liveness probe", Required = false, Default = 5)>]
+    [<Option("probe-timeout", HelpText = "Timeout for liveness probe", Required = false, Default = 30)>]
     member self.ProbeTimeout = probeTimeout
 
     [<Value(0, Required = true)>]


### PR DESCRIPTION
Looks like Max TPS pods are getting killed due to liveness probe timeout, so bump it.