### PR TITLE
Update ingress class to ingress-private from private

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -131,7 +131,7 @@ type MissionOptions
     [<Option("ingress-class",
              HelpText = "Value for kubernetes.io/ingress.class, on ingress",
              Required = false,
-             Default = "private")>]
+             Default = "ingress-private")>]
     member self.IngressClass = ingressClass
 
     [<Option("ingress-internal-domain",
@@ -529,7 +529,7 @@ let main argv =
                   numNodes = 3
                   namespaceProperty = ns
                   logLevels = ll
-                  ingressClass = "private"
+                  ingressClass = "ingress-private"
                   ingressInternalDomain = "local"
                   ingressExternalHost = None
                   ingressExternalPort = 80

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -52,7 +52,7 @@ let ctx : MissionContext =
       numNodes = 100
       namespaceProperty = "stellar-supercluster"
       logLevels = { LogDebugPartitions = []; LogTracePartitions = [] }
-      ingressClass = "private"
+      ingressClass = "ingress-private"
       ingressInternalDomain = "local"
       ingressExternalHost = None
       ingressExternalPort = 80

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -25,7 +25,7 @@ worker:
       ephemeral_storage: "40Gi"
 
 monitor:
-  ingress_class_name: "private"
+  ingress_class_name: "ingress-private"
   hostname: "ssc-job-monitor.services.stellar-ops.com"
   path: "/default/(.*)"
   logging_interval_seconds: 300


### PR DESCRIPTION
### What:

Update ingress class to ingress-private from private


### Why:

We are migrating to upstream ingress controller. We have installed upstream ingress controller to all clusters. New class name for private ingress controller is `ingress-private`


### Issue:

https://github.com/stellar/ops/issues/3412 