### PR TITLE
Propagate flag for updating Soroban costs to the relevant missions.

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -579,7 +579,8 @@ let main argv =
                   tag = None
                   numRuns = None
                   enableTailLogging = true
-                  catchupSkipKnownResultsForTesting = true }
+                  catchupSkipKnownResultsForTesting = true
+                  updateSorobanCosts = None }
 
             let nCfg = MakeNetworkCfg ctx [] None
             use formation = kube.MakeEmptyFormation nCfg
@@ -716,7 +717,8 @@ let main argv =
                                tag = mission.Tag
                                numRuns = mission.NumRuns
                                enableTailLogging = true
-                               catchupSkipKnownResultsForTesting = mission.CatchupSkipKnownResultsForTesting }
+                               catchupSkipKnownResultsForTesting = mission.CatchupSkipKnownResultsForTesting
+                               updateSorobanCosts = None }
 
                          allMissions.[m] missionContext
 

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -118,7 +118,8 @@ let ctx : MissionContext =
       tag = None
       numRuns = None
       enableTailLogging = true
-      catchupSkipKnownResultsForTesting = false }
+      catchupSkipKnownResultsForTesting = false
+      updateSorobanCosts = None }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2024-08-01.json"
 let pubkeys = __SOURCE_DIRECTORY__ + "/../../../data/tier1keys.json"

--- a/src/FSLibrary/MissionInMemoryMode.fs
+++ b/src/FSLibrary/MissionInMemoryMode.fs
@@ -13,7 +13,11 @@ open StellarCoreHTTP
 
 let runInMemoryMode (context: MissionContext) =
     let coreSet =
-        MakeLiveCoreSet "core" { CoreSetOptions.GetDefault context.image with dumpDatabase = false }
+        MakeLiveCoreSet
+            "core"
+            { CoreSetOptions.GetDefault context.image with
+                  dumpDatabase = false
+                  updateSorobanCosts = Some(true) }
 
     let coreSetWithCaptiveCore =
         MakeLiveCoreSet
@@ -25,7 +29,8 @@ let runInMemoryMode (context: MissionContext) =
                   validate = false
                   localHistory = false
                   quorumSet = CoreSetQuorum(CoreSetName "core")
-                  deprecatedSQLState = true }
+                  deprecatedSQLState = true
+                  updateSorobanCosts = Some(true) }
 
     let context =
         { context.WithSmallLoadgenOptions with

--- a/src/FSLibrary/MissionLoadGenerationWithTxSetLimit.fs
+++ b/src/FSLibrary/MissionLoadGenerationWithTxSetLimit.fs
@@ -17,7 +17,8 @@ let loadGenerationWithTxSetLimit (context: MissionContext) =
             "core"
             { CoreSetOptions.GetDefault context.image with
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecks
-                  dumpDatabase = false }
+                  dumpDatabase = false
+                  updateSorobanCosts = Some(true) }
 
     let context =
         { context.WithSmallLoadgenOptions with

--- a/src/FSLibrary/MissionProtocolUpgradeWithLoad.fs
+++ b/src/FSLibrary/MissionProtocolUpgradeWithLoad.fs
@@ -18,7 +18,8 @@ let protocolUpgradeWithLoad (context: MissionContext) =
             "core"
             { CoreSetOptions.GetDefault context.image with
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecks
-                  dumpDatabase = false }
+                  dumpDatabase = false
+                  updateSorobanCosts = Some(true) }
 
     let context =
         { context.WithSmallLoadgenOptions with

--- a/src/FSLibrary/MissionSorobanCatchupWithPrevAndCurr.fs
+++ b/src/FSLibrary/MissionSorobanCatchupWithPrevAndCurr.fs
@@ -19,7 +19,8 @@ let sorobanCatchupWithPrevAndCurr (context: MissionContext) =
             "core"
             { CoreSetOptions.GetDefault context.image with
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecks
-                  emptyDirType = DiskBackedEmptyDir }
+                  emptyDirType = DiskBackedEmptyDir
+                  updateSorobanCosts = Some(true) }
 
     let quorumSet = CoreSetQuorum(CoreSetName("core"))
 
@@ -30,7 +31,8 @@ let sorobanCatchupWithPrevAndCurr (context: MissionContext) =
             { CoreSetOptions.GetDefault context.image with
                   nodeCount = 1
                   quorumSet = quorumSet
-                  catchupMode = CatchupComplete }
+                  catchupMode = CatchupComplete
+                  updateSorobanCosts = Some(true) }
 
     let context =
         { context.WithMediumLoadgenOptions with

--- a/src/FSLibrary/MissionSorobanConfigUpgrades.fs
+++ b/src/FSLibrary/MissionSorobanConfigUpgrades.fs
@@ -26,6 +26,7 @@ let sorobanConfigUpgrades (context: MissionContext) =
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecks
                   emptyDirType = DiskBackedEmptyDir
                   quorumSet = quorumSet
+                  updateSorobanCosts = Some(true)
                   nodeCount = 5 }
 
     let context =

--- a/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
+++ b/src/FSLibrary/MissionSorobanInvokeHostLoad.fs
@@ -17,7 +17,8 @@ let sorobanInvokeHostLoad (context: MissionContext) =
             "core"
             { CoreSetOptions.GetDefault context.image with
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecks
-                  emptyDirType = DiskBackedEmptyDir }
+                  emptyDirType = DiskBackedEmptyDir
+                  updateSorobanCosts = Some(true) }
 
     let context =
         { context.WithMediumLoadgenOptions with

--- a/src/FSLibrary/MissionSorobanLoadGeneration.fs
+++ b/src/FSLibrary/MissionSorobanLoadGeneration.fs
@@ -25,7 +25,8 @@ let sorobanLoadGeneration (context: MissionContext) =
               numTxs = rate * 2000
               skipLowFeeTxs = true
               maxFeeRate = Some 100000000
-              enableTailLogging = false }
+              enableTailLogging = false
+              updateSorobanCosts = Some(true) }
 
     let fullCoreSet = FullPubnetCoreSets context true true
 

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -151,6 +151,7 @@ type StellarCoreCfg =
       automaticMaintenanceCount: int
       accelerateTime: bool
       generateLoad: bool
+      updateSorobanCosts: bool option
       manualClose: bool
       invariantChecks: InvariantChecksSpec
       unsafeQuorum: bool
@@ -252,6 +253,10 @@ type StellarCoreCfg =
         t.Add("AUTOMATIC_MAINTENANCE_COUNT", self.automaticMaintenanceCount) |> ignore
         t.Add("ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING", self.accelerateTime) |> ignore
         t.Add("ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING", self.generateLoad) |> ignore
+
+        if self.updateSorobanCosts.IsSome then
+            t.Add("UPDATE_SOROBAN_COSTS_DURING_PROTOCOL_UPGRADE_FOR_TESTING", self.updateSorobanCosts.Value)
+            |> ignore
 
         if self.network.missionContext.peerFloodCapacityBytes.IsSome then
             t.Add("PEER_FLOOD_READING_CAPACITY_BYTES", self.network.missionContext.peerFloodCapacityBytes.Value)
@@ -484,6 +489,7 @@ type NetworkCfg with
           automaticMaintenanceCount = if opts.performMaintenance then 50000 else 0
           accelerateTime = opts.accelerateTime
           generateLoad = true
+          updateSorobanCosts = opts.updateSorobanCosts
           manualClose = false
           invariantChecks = opts.invariantChecks
           unsafeQuorum = opts.unsafeQuorum
@@ -522,6 +528,7 @@ type NetworkCfg with
           automaticMaintenanceCount = if c.options.performMaintenance then 50000 else 0
           accelerateTime = c.options.accelerateTime
           generateLoad = true
+          updateSorobanCosts = c.options.updateSorobanCosts
           manualClose = false
           invariantChecks = c.options.invariantChecks
           unsafeQuorum = c.options.unsafeQuorum

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -172,7 +172,8 @@ type CoreSetOptions =
       inMemoryMode: bool
       addArtificialDelayUsec: int option
       deprecatedSQLState: bool
-      surveyPhaseDuration: int option }
+      surveyPhaseDuration: int option
+      updateSorobanCosts: bool option }
 
     member self.WithWaitForConsensus(w: bool) =
         { self with initialization = { self.initialization with waitForConsensus = w } }
@@ -206,7 +207,8 @@ type CoreSetOptions =
           inMemoryMode = false
           addArtificialDelayUsec = None
           deprecatedSQLState = false
-          surveyPhaseDuration = None }
+          surveyPhaseDuration = None
+          updateSorobanCosts = None }
 
 type CoreSet =
     { name: CoreSetName

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -110,4 +110,5 @@ type MissionContext =
       // server disconnection. Our solution for now is to just disable tail logging on
       // those missions.
       enableTailLogging: bool
-      catchupSkipKnownResultsForTesting: bool }
+      catchupSkipKnownResultsForTesting: bool
+      updateSorobanCosts: bool option }

--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -556,7 +556,8 @@ let FullPubnetCoreSets (context: MissionContext) (manualclose: bool) (enforceMin
               // sync before all the nodes are online.
               syncStartupDelay = Some(30)
               invariantChecks = AllInvariantsExceptBucketConsistencyChecks
-              dumpDatabase = false }
+              dumpDatabase = false
+              updateSorobanCosts = context.updateSorobanCosts }
 
     // Sorted list of known geolocations.
     // We can choose an arbitrary geolocation such that the distribution follows that of the given data


### PR DESCRIPTION
The flag has been added to all the missions that generate Soroban load and don't use the nodes with the old image. While the fix is necessary only for 'invoke' load, it makes sense to have all the Soroban missions to use the proper costs.