### PR TITLE
Update config to remove need for multiple Ingress objects

### DIFF
--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -137,7 +137,7 @@ type Tests(output: ITestOutputHelper) =
         let peer1DNS = (nCfg.PeerDnsName coreSet 1).StringName
         let peer2DNS = (nCfg.PeerDnsName coreSet 2).StringName
         let nonceStr = nCfg.networkNonce.ToString()
-        let domain = nonceStr + "-stellar-core." + ctx.namespaceProperty + ".svc.cluster.local"
+        let domain = nonceStr + "-sts-core." + ctx.namespaceProperty + ".svc.cluster.local"
         Assert.Equal(nonceStr + "-sts-test-0." + domain, peer0DNS)
         Assert.Equal(nonceStr + "-sts-test-1." + domain, peer1DNS)
         Assert.Equal(nonceStr + "-sts-test-2." + domain, peer2DNS)

--- a/src/FSLibrary/StellarNetworkCfg.fs
+++ b/src/FSLibrary/StellarNetworkCfg.fs
@@ -91,7 +91,7 @@ type NetworkCfg =
     member self.PeerShortName (cs: CoreSet) (n: int) : PeerShortName =
         PeerShortName(sprintf "%s-%d" cs.name.StringName n)
 
-    member self.ServiceName : string = sprintf "%s-stellar-core" self.Nonce
+    member self.ServiceName : string = sprintf "%s-sts-core" self.Nonce
 
     member self.IngressName : string = sprintf "%s-stellar-core-ingress" self.Nonce
 

--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -145,10 +145,10 @@ type Kubernetes with
 
             if not (List.isEmpty statefulSets) then
                 let ing = nCfg.ToIngress()
-                LogInfo "Creating Ingress %s" ing.Metadata.Name
+                LogInfo "Skipping creation of Ingress %s" ing.Metadata.Name
                 ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (rps)
-                let ingress = self.CreateNamespacedIngress(namespaceParameter = nsStr, body = ing)
-                namespaceContent.Add(ingress)
+                //let ingress = self.CreateNamespacedIngress(namespaceParameter = nsStr, body = ing)
+                //namespaceContent.Add(ingress)
 
             let formation =
                 new StellarFormation(


### PR DESCRIPTION
This code removes supercluster deployed Ingress and it modified the code to allow the `SimplePayment` mission to pass with a catch-all nginx proxy.
Proxy config I used is:
```
server {
  listen 80 default_server;
  server_name _;
  resolver 10.96.0.10 ipv6=off;
  location ~ ^/(.+)-([0-9]+)/core$ {
    proxy_pass http://$1-$2.$1.stellar-supercluster.svc.cluster.local:11626/;
  }
  location ~ ^/(.+)-([0-9]+)/core/(.*)$ {
    proxy_pass http://$1-$2.$1.stellar-supercluster.svc.cluster.local:11626/$3$is_args$args;
  }

  location ~ ^/(.+)-([0-9]+)/history$ {
    proxy_pass http://$1-$2.$1.stellar-supercluster.svc.cluster.local:80/;
  }
  location ~ ^/(.+)-([0-9]+)/history/(.*)$ {
    proxy_pass http://$1-$2.$1.stellar-supercluster.svc.cluster.local:80/$3;
  }
}
```

To allow me to target pods directly I had to modify serviceName in the StatefulSet