### PR TITLE
parallel catchup V2 read limits from StellarKubeCfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 *~
 *.swp
 **/.vscode/*
+**/venv/**
+**/logs/**
 /.vs
+.DS_Store
 
 # build artifacts
 /src/**/obj

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -14,7 +14,7 @@ redis:
 worker:
   stellar_core_image: "stellar/stellar-core:latest"
   replicas: 5
-  resources:
+  resources: # resources below are left empty on purpose, they are read and overridden from `StellarKubeCfg.fs`
     requests:
       cpu: ""
       memory: ""

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -16,13 +16,13 @@ worker:
   replicas: 5
   resources:
     requests:
-      cpu: "250m"
-      memory: "1200Mi"
-      ephemeral_storage: "35Gi"
+      cpu: ""
+      memory: ""
+      ephemeral_storage: ""
     limits:
-      cpu: "2"
-      memory: "6Gi"
-      ephemeral_storage: "40Gi"
+      cpu: ""
+      memory: ""
+      ephemeral_storage: ""
 
 monitor:
   ingress_class_name: "ingress-private"


### PR DESCRIPTION
ParallelCatchupV2 mission uses the V2 framework where limits are defined in `value.yaml`, not in the code where the rest of the missions are.

This PR makes the ParallelCatchupV2 read from the `StellarKubeCfg.fs` (the centralized place where V1 limits are defined and `V1ResourceRequirements` are created). Since that is already the customary place to look for those limits and override them.