### PR TITLE
fix resource limit setting

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -146,8 +146,8 @@ let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
 
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
-    // 8000MB RAM, 0.25 vCPUs, and 35 GB of disk bursting to 2vCPU, 16000MB and 40 GB
-    makeResourceRequirementsWithStorageLimit 250 1200 8000 16000 35 40
+    // 0.25 vCPUs, 8000MB RAM and 35 GB of disk bursting to 2vCPU, 16000MB and 40 GB
+    makeResourceRequirementsWithStorageLimit 250 8000 2000 16000 35 40
 
 let NonParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing non-parallel catchup, we give each container


### PR DESCRIPTION
Fixing the mistakes in previous memory limit-setting. 
The previous "memory request" was set incorrectly into the "cpu limit" field. 
Effectively all workers were being heavily memory-throttled, since they only had 1.2GB guaranteed memory to work with.
This is likely the cause of the recent mission timeout https://buildmeister-v3.stellar-ops.com/job/Core/job/stellar-supercluster/1135/