### PR TITLE
Bump simulate pubnet limits

### DIFF
--- a/src/FSLibrary/MissionSimulatePubnet.fs
+++ b/src/FSLibrary/MissionSimulatePubnet.fs
@@ -19,7 +19,7 @@ open StellarCoreHTTP
 let simulatePubnet (context: MissionContext) =
     let context =
         { context with
-              coreResources = SimulatePubnetResources context.networkSizeLimit
+              coreResources = SimulatePubnetResources
               // As the goal of `SimulatePubnet` is to simulate a pubnet,
               // network delays are, in general, indispensable.
               // Therefore, unless explicitly told otherwise, we will use

--- a/src/FSLibrary/MissionSimulatePubnetMixedLoad.fs
+++ b/src/FSLibrary/MissionSimulatePubnetMixedLoad.fs
@@ -21,7 +21,7 @@ let simulatePubnetMixedLoad (baseContext: MissionContext) =
     let context =
         { baseContext with
               numAccounts = 30000
-              coreResources = SimulatePubnetMixedLoadResources
+              coreResources = SimulatePubnetResources
               // As the goal of `SimulatePubnet` is to simulate a pubnet,
               // network delays are, in general, indispensable.
               // Therefore, unless explicitly told otherwise, we will use

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -120,22 +120,16 @@ let NetworkDelayScriptResourceRequirements : V1ResourceRequirements =
 let GetSimulatePubnetResources networkSize : V1ResourceRequirements =
     // Running simulate-pubnet _needs_ a ways over 200MB RSS per node, and
     // depending on queue backups it can spike over 300MB; we have 64GB limit
-    // for quota so to be generous we give each node 600MB limit and run only
-    // 100 nodes (despite survey showing many more).
+    // for quota so to be generous we give each node 1500MB limit.
     //
-    // We also have a 100vCPU quota but only really 72 cores to play with, so
-    // to keep some spare room for other jobs without stressing the workers we
-    // want to stay under 50vCPU, again divided 100 ways across our simulated
-    // nodes.
-    //
-    // So we allocate a 64MB RAM request and 600MB RAM limit to each, and a
-    // 0.025vCPU request and 0.5vCPU limit to each.
+    // So we allocate a 64MB RAM request and 1500MB RAM limit to each, and a
+    // 0.025vCPU request and 4.0vCPU limit to each.
     //
     // It increases the resource requirement in case the network size is big.
     let cpuReqMili = 25
     let memReqMebi = 64
-    let cpuLimMili = 500
-    let memLimMebi = 600
+    let cpuLimMili = 4000
+    let memLimMebi = 1500
     makeResourceRequirements cpuReqMili memReqMebi cpuLimMili memLimMebi
 
 let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -116,22 +116,6 @@ let NetworkDelayScriptResourceRequirements : V1ResourceRequirements =
     // The network delay script needs 0.1 vCPU and 32MB RAM
     makeResourceRequirements 20 32 100 32
 
-
-let GetSimulatePubnetResources networkSize : V1ResourceRequirements =
-    // Running simulate-pubnet _needs_ a ways over 200MB RSS per node, and
-    // depending on queue backups it can spike over 300MB; we have 64GB limit
-    // for quota so to be generous we give each node 1500MB limit.
-    //
-    // So we allocate a 64MB RAM request and 1500MB RAM limit to each, and a
-    // 0.025vCPU request and 4.0vCPU limit to each.
-    //
-    // It increases the resource requirement in case the network size is big.
-    let cpuReqMili = 25
-    let memReqMebi = 64
-    let cpuLimMili = 4000
-    let memLimMebi = 1500
-    makeResourceRequirements cpuReqMili memReqMebi cpuLimMili memLimMebi
-
 let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
     // Tier1 perf simulation is interested in "how fast can we go in practice"
     // which means configuring the nodes like a real operator would: 1-4 vCPU
@@ -169,7 +153,7 @@ let AcceptanceTestCoreResourceRequirements : V1ResourceRequirements =
     // RAM required.
     makeResourceRequirements 4000 4096 4000 4096
 
-let SimulatePubnetMixedLoadResourceRequirements : V1ResourceRequirements =
+let SimulatePubnetResources : V1ResourceRequirements =
     // Guarantee all pods 0.65 vCPUs, which is about as high as we can guarantee
     // with ~600 nodes. However, allow them to burst up to 4 vCPUs. This is
     // helpful because validators experience heavy CPU and wind up throttled if
@@ -330,12 +314,11 @@ let CoreContainerForCommand
         | SmallTestResources -> SmallTestCoreResourceRequirements
         | MediumTestResources -> MediumTestCoreResourceRequirements
         | AcceptanceTestResources -> AcceptanceTestCoreResourceRequirements
-        | SimulatePubnetResources size -> GetSimulatePubnetResources size
+        | SimulatePubnetResources -> SimulatePubnetResources
         | SimulatePubnetTier1PerfResources -> SimulatePubnetTier1PerfCoreResourceRequirements
         | ParallelCatchupResources -> ParallelCatchupCoreResourceRequirements
         | NonParallelCatchupResources -> NonParallelCatchupCoreResourceRequirements
         | UpgradeResources -> UpgradeCoreResourceRequirements
-        | SimulatePubnetMixedLoadResources -> SimulatePubnetMixedLoadResourceRequirements
 
     V1Container(
         name = containerName,

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -25,12 +25,11 @@ type CoreResources =
     | SmallTestResources
     | MediumTestResources
     | AcceptanceTestResources
-    | SimulatePubnetResources of int
+    | SimulatePubnetResources
     | SimulatePubnetTier1PerfResources
     | ParallelCatchupResources
     | NonParallelCatchupResources
     | UpgradeResources
-    | SimulatePubnetMixedLoadResources
 
 type MissionContext =
     { kube: Kubernetes


### PR DESCRIPTION
This change allows pods in the SimulatePubnet mission to burst higher, both in memory and CPU. These limits match the ones we used for the large scale simulations to simulate the impact of adding more orgs (see `SimulatePubnetMixedLoadResourceRequirements`), so the cluster should tolerate the increase well.

I also removed a comment about CPU quotas that I believe is not true anymore. Our vCPU quota is much higher than 100 these days.