### PR TITLE
Allow disabling of skipping known results in pubnet catchup

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -110,7 +110,7 @@ type MissionOptions
         pubnetParallelCatchupNumWorkers: int,
         tag: string option,
         numRuns: int option,
-        catchupSkipKnownResultsForTesting: bool
+        catchupSkipKnownResultsForTesting: bool option
     ) =
 
     [<Option('k', "kubeconfig", HelpText = "Kubernetes config file", Required = false, Default = "~/.kube/config")>]
@@ -461,8 +461,7 @@ type MissionOptions
 
     [<Option("catchup-skip-known-results-for-testing",
              HelpText = "when this flag is provided, pubnet parallel catchup workers will run with CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = true, resulting in skipping application of failed transaction and signature verification",
-             Required = false,
-             Default = true)>]
+             Required = false)>]
     member self.CatchupSkipKnownResultsForTesting = catchupSkipKnownResultsForTesting
 
 let splitLabel (lab: string) : (string * string option) =
@@ -579,7 +578,7 @@ let main argv =
                   tag = None
                   numRuns = None
                   enableTailLogging = true
-                  catchupSkipKnownResultsForTesting = true
+                  catchupSkipKnownResultsForTesting = None
                   updateSorobanCosts = None }
 
             let nCfg = MakeNetworkCfg ctx [] None

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -118,7 +118,7 @@ let ctx : MissionContext =
       tag = None
       numRuns = None
       enableTailLogging = true
-      catchupSkipKnownResultsForTesting = false
+      catchupSkipKnownResultsForTesting = None
       updateSorobanCosts = None }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2024-08-01.json"

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -69,7 +69,12 @@ let installProject (context: MissionContext) =
     setOptions.Add(sprintf "worker.stellar_core_image=%s" context.image)
     setOptions.Add(sprintf "worker.replicas=%d" context.pubnetParallelCatchupNumWorkers)
     setOptions.Add(sprintf "range_generator.params.starting_ledger=%d" context.pubnetParallelCatchupStartingLedger)
-    setOptions.Add(sprintf "worker.catchup_skip_known_results_for_testing=%b" context.catchupSkipKnownResultsForTesting)
+    // Skip known results by default
+    setOptions.Add(
+        sprintf
+            "worker.catchup_skip_known_results_for_testing=%b"
+            (Option.defaultValue true context.catchupSkipKnownResultsForTesting)
+    )
 
     // read the resource requirements defined in StellarKubeSpecs.fs (where resource for various missions are centralized)
     let resourceRequirements = ParallelCatchupCoreResourceRequirements

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -109,5 +109,5 @@ type MissionContext =
       // server disconnection. Our solution for now is to just disable tail logging on
       // those missions.
       enableTailLogging: bool
-      catchupSkipKnownResultsForTesting: bool
+      catchupSkipKnownResultsForTesting: bool option
       updateSorobanCosts: bool option }


### PR DESCRIPTION
The `--catchup-skip-known-results-for-testing` flag was implemented as a 0 argument flag whose presence enables the feature. However, the flag was also enabled by default, leaving no way to turn it off. This changes the flag to an option that takes a boolean argument, allowing for the flag to be disabled by setting it to false
(--catchup-skip-known-results-for-testing=false).