### PR TITLE
bugfix: properly fail loadgen if all nodes failed at the same time

### DIFF
--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -335,3 +335,7 @@ type StellarFormation with
                     LogInfo "Loadgen: %s" (peer.StopLoadGen())
 
                 failwith "Loadgen failed!"
+
+        // Final check after the loop completes
+        if List.exists (fun (peer: Peer) -> peer.IsLoadGenComplete() = Failure) loadGenPeers then
+            failwith "Loadgen failed!"


### PR DESCRIPTION
Looks like loadgen status monitoring in Max TPS test isn't right. In case of a rare occurrence when loadgen on all nodes fails at the same time, the mission would report success instead of failure. 