### PR TITLE
Revert "Add suport for offline load generation; switch maxTPSTest to it"

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -110,8 +110,6 @@ type MissionOptions
         pubnetParallelCatchupNumWorkers: int,
         tag: string option,
         numRuns: int option,
-        numPregeneratedTxs: int option,
-        genesisTestAccountCount: int option,
         catchupSkipKnownResultsForTesting: bool option
     ) =
 
@@ -461,16 +459,6 @@ type MissionOptions
              Required = false)>]
     member self.NumRuns = numRuns
 
-    [<Option("num-pregenerated-txs",
-             HelpText = "Number of transactions to pregenerate for max TPS tests",
-             Required = false)>]
-    member self.NumPregeneratedTxs = numPregeneratedTxs
-
-    [<Option("genesis-test-account-count",
-             HelpText = "Number of test accounts to create in genesis (See GENESIS_TEST_ACCOUNT_COUNT)",
-             Required = false)>]
-    member self.GenesisTestAccountCount = genesisTestAccountCount
-
     [<Option("catchup-skip-known-results-for-testing",
              HelpText = "when this flag is provided, pubnet parallel catchup workers will run with CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = true, resulting in skipping application of failed transaction and signature verification",
              Required = false)>]
@@ -589,8 +577,6 @@ let main argv =
                   pubnetParallelCatchupNumWorkers = 128
                   tag = None
                   numRuns = None
-                  numPregeneratedTxs = None
-                  genesisTestAccountCount = None
                   enableTailLogging = true
                   catchupSkipKnownResultsForTesting = None
                   updateSorobanCosts = None }
@@ -729,11 +715,9 @@ let main argv =
                                pubnetParallelCatchupNumWorkers = mission.PubnetParallelCatchupNumWorkers
                                tag = mission.Tag
                                numRuns = mission.NumRuns
-                               numPregeneratedTxs = mission.NumPregeneratedTxs
                                enableTailLogging = true
                                catchupSkipKnownResultsForTesting = mission.CatchupSkipKnownResultsForTesting
-                               updateSorobanCosts = None
-                               genesisTestAccountCount = mission.GenesisTestAccountCount }
+                               updateSorobanCosts = None }
 
                          allMissions.[m] missionContext
 

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -117,11 +117,9 @@ let ctx : MissionContext =
       pubnetParallelCatchupNumWorkers = 128
       tag = None
       numRuns = None
-      numPregeneratedTxs = None
       enableTailLogging = true
       catchupSkipKnownResultsForTesting = None
-      updateSorobanCosts = None
-      genesisTestAccountCount = None }
+      updateSorobanCosts = None }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2024-08-01.json"
 let pubkeys = __SOURCE_DIRECTORY__ + "/../../../data/tier1keys.json"

--- a/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
+++ b/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
@@ -42,8 +42,7 @@ let databaseInplaceUpgrade (context: MissionContext) =
                         newHist = false
                         initialCatchup = false
                         waitForConsensus = true
-                        fetchDBFromPeer = fetchFromPeer
-                        pregenerateTxs = None } }
+                        fetchDBFromPeer = fetchFromPeer } }
 
     context.Execute
         [ beforeUpgradeCoreSet; coreSet; afterUpgradeCoreSet ]

--- a/src/FSLibrary/MissionMaxTPSClassic.fs
+++ b/src/FSLibrary/MissionMaxTPSClassic.fs
@@ -20,7 +20,7 @@ let maxTPSClassic (context: MissionContext) =
 
     let baseLoadGen =
         { LoadGen.GetDefault() with
-              mode = PayPregenerated
+              mode = GeneratePaymentLoad
               spikesize = context.spikeSize
               spikeinterval = context.spikeInterval
               offset = 0

--- a/src/FSLibrary/MissionVersionMixConsensus.fs
+++ b/src/FSLibrary/MissionVersionMixConsensus.fs
@@ -40,8 +40,7 @@ let versionMixConsensus (context: MissionContext) =
                         newHist = true
                         initialCatchup = false
                         waitForConsensus = false
-                        fetchDBFromPeer = fetchFromPeer
-                        pregenerateTxs = None } }
+                        fetchDBFromPeer = fetchFromPeer } }
 
     let oldCoreSet =
         MakeDeferredCoreSet
@@ -55,8 +54,7 @@ let versionMixConsensus (context: MissionContext) =
                         newHist = true
                         initialCatchup = false
                         waitForConsensus = false
-                        fetchDBFromPeer = fetchFromPeer
-                        pregenerateTxs = None } }
+                        fetchDBFromPeer = fetchFromPeer } }
 
     context.Execute
         [ beforeSet; newCoreSet; oldCoreSet ]

--- a/src/FSLibrary/PollRetry.fs
+++ b/src/FSLibrary/PollRetry.fs
@@ -7,7 +7,7 @@ module PollRetry
 open System.Threading
 open Logging
 
-let DefaultRetry = 300
+let DefaultRetry = 200
 
 let rec WebExceptionRetry (n: int) (f: unit -> 'a) : 'a =
     try

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -194,10 +194,6 @@ type StellarCoreCfg =
         t.Add("DEPRECATED_SQL_LEDGER_STATE", self.deprecatedSQLState) |> ignore
         t.Add("METADATA_DEBUG_LEDGERS", 0) |> ignore
 
-        match self.network.missionContext.genesisTestAccountCount with
-        | Some count -> t.Add("GENESIS_TEST_ACCOUNT_COUNT", count) |> ignore
-        | None -> ()
-
         match self.containerType with
         // REVERTME: temporarily use same nonzero port for both container types.
         | _ -> t.Add("HTTP_PORT", int64 (CfgVal.httpPort)) |> ignore

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -51,7 +51,6 @@ type LoadGenMode =
     | SorobanInvoke
     | MixedClassicSoroban
     | StopRun
-    | PayPregenerated
 
     override self.ToString() =
         match self with
@@ -65,7 +64,6 @@ type LoadGenMode =
         | SorobanInvoke -> "soroban_invoke"
         | MixedClassicSoroban -> "mixed_classic_soroban"
         | StopRun -> "stop"
-        | PayPregenerated -> "pay_pregenerated"
 
 type LoadGen =
     { mode: LoadGenMode

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -84,49 +84,42 @@ type CoreSetInitialization =
       newHist: bool
       initialCatchup: bool
       waitForConsensus: bool
-      fetchDBFromPeer: (CoreSetName * int) option
-      // (numTxs, numAccounts, offset)
-      pregenerateTxs: (int * int * int) option }
+      fetchDBFromPeer: (CoreSetName * int) option }
 
     static member Default =
         { newDb = true
           newHist = true
           initialCatchup = false
           waitForConsensus = false
-          fetchDBFromPeer = None
-          pregenerateTxs = None }
+          fetchDBFromPeer = None }
 
     static member DefaultNoForceSCP =
         { newDb = true
           newHist = true
           initialCatchup = false
           waitForConsensus = true
-          fetchDBFromPeer = None
-          pregenerateTxs = None }
+          fetchDBFromPeer = None }
 
     static member CatchupNoForceSCP =
         { newDb = true
           newHist = true
           initialCatchup = true
           waitForConsensus = true
-          fetchDBFromPeer = None
-          pregenerateTxs = None }
+          fetchDBFromPeer = None }
 
     static member OnlyNewDb =
         { newDb = true
           newHist = false
           initialCatchup = false
           waitForConsensus = true
-          fetchDBFromPeer = None
-          pregenerateTxs = None }
+          fetchDBFromPeer = None }
 
     static member NoInitCmds =
         { newDb = false
           newHist = false
           initialCatchup = false
           waitForConsensus = true
-          fetchDBFromPeer = None
-          pregenerateTxs = None }
+          fetchDBFromPeer = None }
 
 type GeoLoc = { lat: float; lon: float }
 

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -339,7 +339,6 @@ let WithProbes (container: V1Container) (probeTimeout: int) : V1Container =
             periodSeconds = System.Nullable<int>(1),
             failureThreshold = System.Nullable<int>(60),
             timeoutSeconds = System.Nullable<int>(probeTimeout),
-            initialDelaySeconds = System.Nullable<int>(180),
             httpGet = V1HTTPGetAction(path = "/info", port = httpPortStr)
         )
 
@@ -569,16 +568,6 @@ type NetworkCfg with
         // we want.
         let newHistIgnoreError = ignoreError newHist
 
-        let pregenerate =
-            match init.pregenerateTxs with
-            | None -> None
-            | Some (txs, accounts, offset) ->
-                runCoreIf
-                    true
-                    [| "pregenerate-loadgen-txs"
-                       "--count " + txs.ToString()
-                       "--accounts " + accounts.ToString()
-                       "--offset " + offset.ToString() |]
 
         let initialCatchup = runCoreIf init.initialCatchup [| "catchup"; "current/0" |]
 
@@ -591,7 +580,6 @@ type NetworkCfg with
                         setPgHost
                         waitForTime
                         newDb
-                        pregenerate
                         newHistIgnoreError
                         initialCatchup |])
                     createDbs)

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -99,12 +99,10 @@ type MissionContext =
       randomSeed: int
       tag: string option
       numRuns: int option
-      numPregeneratedTxs: int option
       networkSizeLimit: int
       pubnetParallelCatchupStartingLedger: int
       pubnetParallelCatchupEndLedger: int option
       pubnetParallelCatchupNumWorkers: int
-      genesisTestAccountCount: int option
 
       // Tail logging can cause the pubnet simulation missions like SorobanLoadGeneration
       // and SimulatePubnet to fail on the heartbeat handler due to what looks like a


### PR DESCRIPTION
I was too quick to merge #257: looks like it doesn't work properly between failed iterations in binary search. Working on a fix currently, but reverting for now to avoid breakages to our Max TPS test in CI. 