### PR TITLE
Increase parallel catchup memory limit

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   complete:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -124,8 +124,8 @@ let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
 
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
-    // 0.25 vCPUs, 1200MB RAM and 35 GB of disk bursting to 2vCPU, 6000MB and 40 GB
-    makeResourceRequirementsWithStorageLimit 250 1200 2000 6000 35 40
+    // 0.25 vCPUs, 1200MB RAM and 35 GB of disk bursting to 2vCPU, 6250MB and 40 GB
+    makeResourceRequirementsWithStorageLimit 250 1200 2000 6250 35 40
 
 let NonParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing non-parallel catchup, we give each container


### PR DESCRIPTION
We had pods OOM killed. Memory usage was expected to go up with the last release, so it makes sense to bump limits a little. 