### PR TITLE
Account tuning

### DIFF
--- a/src/FSLibrary/MaxTPSTest.fs
+++ b/src/FSLibrary/MaxTPSTest.fs
@@ -144,7 +144,7 @@ let maxTPSTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg: LoadG
         { context with
               genesisTestAccountCount =
                   if baseLoadGen.mode = PayPregenerated then
-                      Some(context.genesisTestAccountCount |> Option.defaultValue 500000)
+                      Some(context.genesisTestAccountCount |> Option.defaultValue 100000)
                   else
                       None
               numPregeneratedTxs =


### PR DESCRIPTION
Follow-up to #259. After some more perf tuning, I discovered that too many unique accounts cause appending to the BucketList to become a bit expensive (BL ends up growing at a much higher rate, rather than merging re-used entries). Tune the number from 500'000 -> 100'000 to avoid the additional DB overhead. 