### PR TITLE
Use new stellar-core config option to skip HIGH and CRITICAL validator checks

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -113,7 +113,8 @@ type MissionOptions
         numPregeneratedTxs: int option,
         genesisTestAccountCount: int option,
         catchupSkipKnownResultsForTesting: bool option,
-        checkEventsAreConsistentWithEntryDiffs: bool option
+        checkEventsAreConsistentWithEntryDiffs: bool option,
+        enableRelaxedAutoQsetConfig: bool
     ) =
 
     [<Option('k', "kubeconfig", HelpText = "Kubernetes config file", Required = false, Default = "~/.kube/config")>]
@@ -482,6 +483,13 @@ type MissionOptions
              Required = false)>]
     member self.CheckEventsAreConsistentWithEntryDiffs = checkEventsAreConsistentWithEntryDiffs
 
+    [<Option("enable-relaxed-auto-qset-config",
+             HelpText = "Enables the use of automatic quorum set configuration on missions that may create core sets with invalid HIGH quality validators. Requires a stellar-core version that supports the SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING config option.",
+             Required = false,
+             Default = false)>]
+    member self.EnableRelaxedAutoQsetConfig = enableRelaxedAutoQsetConfig
+
+
 let splitLabel (lab: string) : (string * string option) =
     match lab.Split ':' with
     | [| x |] -> (x, None)
@@ -600,7 +608,8 @@ let main argv =
                   enableTailLogging = true
                   catchupSkipKnownResultsForTesting = None
                   checkEventsAreConsistentWithEntryDiffs = None
-                  updateSorobanCosts = None }
+                  updateSorobanCosts = None
+                  enableRelaxedAutoQsetConfig = false }
 
             let nCfg = MakeNetworkCfg ctx [] None
             use formation = kube.MakeEmptyFormation nCfg
@@ -741,7 +750,8 @@ let main argv =
                                catchupSkipKnownResultsForTesting = mission.CatchupSkipKnownResultsForTesting
                                checkEventsAreConsistentWithEntryDiffs = mission.CheckEventsAreConsistentWithEntryDiffs
                                updateSorobanCosts = None
-                               genesisTestAccountCount = mission.GenesisTestAccountCount }
+                               genesisTestAccountCount = mission.GenesisTestAccountCount
+                               enableRelaxedAutoQsetConfig = mission.EnableRelaxedAutoQsetConfig }
 
                          allMissions.[m] missionContext
 

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -123,7 +123,8 @@ let ctx : MissionContext =
       catchupSkipKnownResultsForTesting = None
       checkEventsAreConsistentWithEntryDiffs = None
       updateSorobanCosts = None
-      genesisTestAccountCount = None }
+      genesisTestAccountCount = None
+      enableRelaxedAutoQsetConfig = false }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2024-08-01.json"
 let pubkeys = __SOURCE_DIRECTORY__ + "/../../../data/tier1keys.json"

--- a/src/FSLibrary/MissionCatchupHelpers.fs
+++ b/src/FSLibrary/MissionCatchupHelpers.fs
@@ -60,7 +60,12 @@ let MakeCatchupSets (options: CatchupMissionOptions) =
         { CoreSetOptions.GetDefault options.generatorImage with
               nodeCount = 1
               quorumSet = CoreSetQuorum(CoreSetName "generator")
-              accelerateTime = true }
+              accelerateTime = true
+              // FIXME: Remove these options once the stable (old) image in
+              // CI supports skipping validator quality checks
+              skipHighCriticalValidatorChecks = false
+              quorumSetConfigType = RequireExplicitQset }
+
 
     let generatorSet = MakeLiveCoreSet "generator" generatorOptions
 
@@ -69,7 +74,11 @@ let MakeCatchupSets (options: CatchupMissionOptions) =
               nodeCount = 1
               quorumSet = CoreSetQuorum(CoreSetName "generator")
               accelerateTime = true
-              initialization = CoreSetInitialization.DefaultNoForceSCP }
+              initialization = CoreSetInitialization.DefaultNoForceSCP
+              // FIXME: Remove these options once the stable (old) image in
+              // CI supports skipping validator quality checks
+              skipHighCriticalValidatorChecks = false
+              quorumSetConfigType = RequireExplicitQset }
 
     let minimal1Options = { newNodeOptions with catchupMode = CatchupRecent(0) }
     let minimal1Set = MakeDeferredCoreSet "minimal1" minimal1Options
@@ -124,7 +133,11 @@ let MakeCatchupSets (options: CatchupMissionOptions) =
         { CoreSetOptions.GetDefault options.versionImage with
               nodeCount = 1
               quorumSet = CoreSetQuorum(CoreSetName "version")
-              accelerateTime = true }
+              accelerateTime = true
+              // FIXME: Remove these options once the stable (old) image in
+              // CI supports skipping validator quality checks
+              skipHighCriticalValidatorChecks = false
+              quorumSetConfigType = RequireExplicitQset }
 
     let versionSet = MakeLiveCoreSet "version" versionOptions
 

--- a/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
+++ b/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
@@ -26,7 +26,13 @@ let databaseInplaceUpgrade (context: MissionContext) =
     let beforeUpgradeCoreSet =
         MakeLiveCoreSet
             "before-upgrade"
-            { CoreSetOptions.GetDefault oldImage with nodeCount = 1; quorumSet = quorumSet }
+            { CoreSetOptions.GetDefault oldImage with
+                  nodeCount = 1
+                  quorumSet = quorumSet
+                  // FIXME: Remove these options once the stable (old) image in
+                  // CI supports skipping validator quality checks
+                  skipHighCriticalValidatorChecks = false
+                  quorumSetConfigType = RequireExplicitQset }
 
     let fetchFromPeer = Some(CoreSetName("before-upgrade"), 0)
 

--- a/src/FSLibrary/MissionMixedImageLoadGeneration.fs
+++ b/src/FSLibrary/MissionMixedImageLoadGeneration.fs
@@ -46,7 +46,11 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecksAndEvents
                   accelerateTime = false
                   dumpDatabase = false
-                  quorumSet = qSet }
+                  quorumSet = qSet
+                  // FIXME: Remove these options once the stable (old) image in
+                  // CI supports skipping validator quality checks
+                  skipHighCriticalValidatorChecks = false
+                  quorumSetConfigType = RequireExplicitQset }
 
     let newCoreSet =
         MakeLiveCoreSet

--- a/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
+++ b/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
@@ -119,7 +119,11 @@ let mixedImageNetworkSurvey (context: MissionContext) =
               { CoreSetOptions.GetDefault oldImage with
                     nodeCount = oldKeys.Length
                     accelerateTime = false
-                    surveyPhaseDuration = Some surveyPhaseDurationMinutes } }
+                    surveyPhaseDuration = Some surveyPhaseDurationMinutes
+                    // FIXME: Remove these options once the stable (old) image
+                    // in CI supports skipping validator quality checks
+                    skipHighCriticalValidatorChecks = false
+                    quorumSetConfigType = RequireExplicitQset } }
 
     let newCoreSet =
         { name = CoreSetName newName

--- a/src/FSLibrary/MissionMixedNominationLeaderElection.fs
+++ b/src/FSLibrary/MissionMixedNominationLeaderElection.fs
@@ -40,7 +40,7 @@ let mixedNominationAlgorithm (oldCount: int) (context: MissionContext) =
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecksAndEvents
                   accelerateTime = false
                   dumpDatabase = false
-                  requireAutoQset = true }
+                  quorumSetConfigType = RequireAutoQset }
 
     let coreSets = [ oldCoreSet; newCoreSet ]
 

--- a/src/FSLibrary/MissionProtocolUpgradeWithLoad.fs
+++ b/src/FSLibrary/MissionProtocolUpgradeWithLoad.fs
@@ -20,10 +20,10 @@ let protocolUpgradeWithLoad (context: MissionContext) =
                   invariantChecks = AllInvariantsExceptBucketConsistencyChecksAndEvents
                   dumpDatabase = false
                   updateSorobanCosts = Some(true)
-                  // Set `requireAutoQset` to `true` as an extra check that this
-                  // mission uses the application-specific nomination leader
-                  // election protocol.
-                  requireAutoQset = true }
+                  // Set `quorumSetConfigType` to `RequireAutoQset` as an extra
+                  // check that this mission uses the application-specific
+                  // nomination leader election protocol.
+                  quorumSetConfigType = RequireAutoQset }
 
     let context =
         { context.WithSmallLoadgenOptions with

--- a/src/FSLibrary/MissionVersionMixConsensus.fs
+++ b/src/FSLibrary/MissionVersionMixConsensus.fs
@@ -28,8 +28,7 @@ let versionMixConsensus (context: MissionContext) =
                   // FIXME: Remove these options once the stable (old) image in
                   // CI supports skipping validator quality checks
                   skipHighCriticalValidatorChecks = false
-                  quorumSetConfigType = RequireExplicitQset
-                  }
+                  quorumSetConfigType = RequireExplicitQset }
 
     let fetchFromPeer = Some(CoreSetName("before"), 0)
 

--- a/src/FSLibrary/MissionVersionMixConsensus.fs
+++ b/src/FSLibrary/MissionVersionMixConsensus.fs
@@ -24,7 +24,12 @@ let versionMixConsensus (context: MissionContext) =
             "before"
             { CoreSetOptions.GetDefault oldImage with
                   nodeCount = 2
-                  quorumSet = CoreSetQuorum(CoreSetName "before") }
+                  quorumSet = CoreSetQuorum(CoreSetName "before")
+                  // FIXME: Remove these options once the stable (old) image in
+                  // CI supports skipping validator quality checks
+                  skipHighCriticalValidatorChecks = false
+                  quorumSetConfigType = RequireExplicitQset
+                  }
 
     let fetchFromPeer = Some(CoreSetName("before"), 0)
 
@@ -50,6 +55,10 @@ let versionMixConsensus (context: MissionContext) =
                   nodeCount = 2
                   historyNodes = Some([])
                   quorumSet = CoreSetQuorumList([ CoreSetName "new-core"; CoreSetName "old-core" ])
+                  // FIXME: Remove these options once the stable (old) image in
+                  // CI supports skipping validator quality checks
+                  skipHighCriticalValidatorChecks = false
+                  quorumSetConfigType = RequireExplicitQset
                   initialization =
                       { newDb = true
                         newHist = true

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -516,7 +516,7 @@ type NetworkCfg with
             | RequireAutoQset, Some hd
             | PreferAutoQset, Some hd -> toAutoQSet (List.ofArray nks) hd
             | PreferAutoQset, None
-            | RequireExplicitQset, _-> toExplicitQSet nks None
+            | RequireExplicitQset, _ -> toExplicitQSet nks None
             | RequireAutoQset, None -> failwith "Auto quorum set configuration requires a home domain"
 
         let checkAutoQSetIncompatability (mode: string) =

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -497,7 +497,7 @@ type NetworkCfg with
 
         let toAutoQSet (nks: (PeerShortName * KeyPair) list) (homeDomain: string) =
             LogInfo "Using auto quorum set configuration"
-            let homeDomains = [ { name = homeDomain; quality = High } ]
+            let homeDomains = [ { name = homeDomain; quality = Medium } ]
 
             let validators =
                 List.map (fun (n: PeerShortName, k) -> { name = n; homeDomain = homeDomain; keys = k }) nks
@@ -509,15 +509,7 @@ type NetworkCfg with
         // configuration if possible.
         let simpleQuorum (nks: (PeerShortName * KeyPair) array) =
             match o.homeDomain with
-            | Some hd ->
-                if nks.Length >= 3 then
-                    // There are enough validators to use auto quorum set config
-                    toAutoQSet (List.ofArray nks) hd
-                else if o.requireAutoQset then
-                    failwith "Auto quorum set configuration requires at least 3 validators"
-                else
-                    // Fall back on manual quorum set configuration
-                    toExplicitQSet nks None
+            | Some hd -> toAutoQSet (List.ofArray nks) hd
             | None ->
                 if o.requireAutoQset then
                     failwith "Auto quorum set configuration requires a home domain"

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -222,8 +222,7 @@ type CoreSetOptions =
       // `skipHighCriticalValidatorChecks` exists to allow supercluster to
       // remain compatible with older stellar-core images that do not have the
       // ability to turn of validator checks for HIGH and CRITICAL validators
-      skipHighCriticalValidatorChecks: bool
-      }
+      skipHighCriticalValidatorChecks: bool }
 
     member self.WithWaitForConsensus(w: bool) =
         { self with initialization = { self.initialization with waitForConsensus = w } }
@@ -262,7 +261,7 @@ type CoreSetOptions =
           deprecatedSQLState = false
           surveyPhaseDuration = None
           updateSorobanCosts = None
-          skipHighCriticalValidatorChecks = true}
+          skipHighCriticalValidatorChecks = true }
 
 type CoreSet =
     { name: CoreSetName

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -177,10 +177,14 @@ type InvariantChecksSpec =
 // Determines how quorum set configurations should be generated
 type QuorumSetConfiguration =
     // Prefer automatic quorum set configuration. Fall back on explicit quorum
-    // set configuration if automatic configuration is not possible.
+    // set configuration if automatic configuration is not possible, or if
+    // --enable-relaxed-auto-qset-config is not set.
     | PreferAutoQset
     // Require automatic quorum set configuration. Fail if automatic
-    // configuration is not possible.
+    // configuration is not possible. Uses automatic configuration even if
+    // --enable-relaxed-auto-qset-config is not set, so missions using this
+    // option *must* satisfy the HIGH quality validator checks present in
+    // stellar-core.
     | RequireAutoQset
     // Require explicit quorum set configuration.
     | RequireExplicitQset

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -174,6 +174,17 @@ type InvariantChecksSpec =
     | AllInvariantsExceptBucketConsistencyChecksAndEvents
     | NoInvariants
 
+// Determines how quorum set configurations should be generated
+type QuorumSetConfiguration =
+    // Prefer automatic quorum set configuration. Fall back on explicit quorum
+    // set configuration if automatic configuration is not possible.
+    | PreferAutoQset
+    // Require automatic quorum set configuration. Fail if automatic
+    // configuration is not possible.
+    | RequireAutoQset
+    // Require explicit quorum set configuration.
+    | RequireExplicitQset
+
 type CoreSetOptions =
     { nodeCount: int
       nodeLocs: GeoLoc list option
@@ -181,11 +192,7 @@ type CoreSetOptions =
       emptyDirType: EmptyDirType
       syncStartupDelay: int option
       quorumSet: QuorumSetSpec
-      // `requireAutoQset` checks and fails if the quorum set is not
-      // auto-generated. Setting this flag has no impact on whether the
-      // algorithm chooses to use auto quorum set generation, only on whether
-      // supercluster will fail if it is not used.
-      requireAutoQset: bool
+      quorumSetConfigType: QuorumSetConfiguration
       forceOldStyleLeaderElection: bool
       historyNodes: CoreSetName list option
       preferredPeersMap: Map<byte [], byte [] list> option
@@ -211,7 +218,12 @@ type CoreSetOptions =
       addArtificialDelayUsec: int option
       deprecatedSQLState: bool
       surveyPhaseDuration: int option
-      updateSorobanCosts: bool option }
+      updateSorobanCosts: bool option
+      // `skipHighCriticalValidatorChecks` exists to allow supercluster to
+      // remain compatible with older stellar-core images that do not have the
+      // ability to turn of validator checks for HIGH and CRITICAL validators
+      skipHighCriticalValidatorChecks: bool
+      }
 
     member self.WithWaitForConsensus(w: bool) =
         { self with initialization = { self.initialization with waitForConsensus = w } }
@@ -224,7 +236,7 @@ type CoreSetOptions =
           syncStartupDelay = Some(5)
           quorumSet = AllPeersQuorum
           forceOldStyleLeaderElection = false
-          requireAutoQset = false
+          quorumSetConfigType = PreferAutoQset
           historyNodes = None
           preferredPeersMap = None
           historyGetCommands = Map.empty
@@ -249,7 +261,8 @@ type CoreSetOptions =
           addArtificialDelayUsec = None
           deprecatedSQLState = false
           surveyPhaseDuration = None
-          updateSorobanCosts = None }
+          updateSorobanCosts = None
+          skipHighCriticalValidatorChecks = true}
 
 type CoreSet =
     { name: CoreSetName

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -113,4 +113,5 @@ type MissionContext =
       enableTailLogging: bool
       catchupSkipKnownResultsForTesting: bool option
       checkEventsAreConsistentWithEntryDiffs: bool option
-      updateSorobanCosts: bool option }
+      updateSorobanCosts: bool option
+      enableRelaxedAutoQsetConfig: bool }


### PR DESCRIPTION
Some tests (such as `VersionMixConsensus`) have enough nodes to reach the `HIGH` quality threshold for validators, but explicitly disable history archives. Supercluster improperly marked these nodes as `HIGH` quality, and stellar-core would refuse to start due to the lack of history archives.

This PR uses the new `SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING` introduced in stellar/stellar-core#4703 to disable these checks when using automatic quorum set configuration.

To maintain compatibility with older stellar-core versions, this change configures coresets of older stellar-core nodes to continue using explicit quorum set configuration. 