### PR TITLE
make job-monitor host name unique

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -114,7 +114,8 @@ type MissionOptions
         genesisTestAccountCount: int option,
         catchupSkipKnownResultsForTesting: bool option,
         checkEventsAreConsistentWithEntryDiffs: bool option,
-        enableRelaxedAutoQsetConfig: bool
+        enableRelaxedAutoQsetConfig: bool,
+        jobMonitorExternalHost: string option
     ) =
 
     [<Option('k', "kubeconfig", HelpText = "Kubernetes config file", Required = false, Default = "~/.kube/config")>]
@@ -489,6 +490,11 @@ type MissionOptions
              Default = false)>]
     member self.EnableRelaxedAutoQsetConfig = enableRelaxedAutoQsetConfig
 
+    [<Option("job-monitor-external-host",
+             HelpText = "Cluster-external hostname to connect to for access to job monitor",
+             Required = false)>]
+    member self.JobMonitorExternalHost = jobMonitorExternalHost
+
 
 let splitLabel (lab: string) : (string * string option) =
     match lab.Split ':' with
@@ -609,7 +615,8 @@ let main argv =
                   catchupSkipKnownResultsForTesting = None
                   checkEventsAreConsistentWithEntryDiffs = None
                   updateSorobanCosts = None
-                  enableRelaxedAutoQsetConfig = false }
+                  enableRelaxedAutoQsetConfig = false
+                  jobMonitorExternalHost = None }
 
             let nCfg = MakeNetworkCfg ctx [] None
             use formation = kube.MakeEmptyFormation nCfg
@@ -751,7 +758,8 @@ let main argv =
                                checkEventsAreConsistentWithEntryDiffs = mission.CheckEventsAreConsistentWithEntryDiffs
                                updateSorobanCosts = None
                                genesisTestAccountCount = mission.GenesisTestAccountCount
-                               enableRelaxedAutoQsetConfig = mission.EnableRelaxedAutoQsetConfig }
+                               enableRelaxedAutoQsetConfig = mission.EnableRelaxedAutoQsetConfig
+                               jobMonitorExternalHost = mission.JobMonitorExternalHost }
 
                          allMissions.[m] missionContext
 

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -124,7 +124,8 @@ let ctx : MissionContext =
       checkEventsAreConsistentWithEntryDiffs = None
       updateSorobanCosts = None
       genesisTestAccountCount = None
-      enableRelaxedAutoQsetConfig = false }
+      enableRelaxedAutoQsetConfig = false
+      jobMonitorExternalHost = None }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2024-08-01.json"
 let pubkeys = __SOURCE_DIRECTORY__ + "/../../../data/tier1keys.json"

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -114,4 +114,5 @@ type MissionContext =
       catchupSkipKnownResultsForTesting: bool option
       checkEventsAreConsistentWithEntryDiffs: bool option
       updateSorobanCosts: bool option
-      enableRelaxedAutoQsetConfig: bool }
+      enableRelaxedAutoQsetConfig: bool
+      jobMonitorExternalHost: string option }

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -26,7 +26,7 @@ worker:
 
 monitor:
   ingress_class_name: "ingress-private"
-  hostname: "ssc-job-monitor.services.stellar-ops.com"
+  hostname: "" # to be set by the mission
   path: "/default/(.*)"
   logging_interval_seconds: 300
   logging_level: "INFO" # 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'


### PR DESCRIPTION
## What
Resolves https://github.com/stellar/supercluster/issues/264
Adds a command line option `job-monitor-external-host` for specifying the external host name for job-monitor service. 

## Why
In the short term this unblocks EKS migration. 
Longer term this is a necessary step toward supporting multiple simultaneous parallel-catchup runs.

## Testing
```
dotnet run mission HistoryPubnetParallelCatchupV2 --image=docker-registry.services.stellar-ops.com/dev/stellar-core:22.2.1-2426.8ca7f2638.focal-buildtests --job-monitor-external-host="test-host" --pubnet-parallel-catchup-num-workers=2 --pubnet-parallel-catchup-starting-ledger=0 --pubnet-parallel-catchup-end-ledger=100000 --destination ./logs
```

![Screenshot 2025-05-01 at 11 11 23](https://github.com/user-attachments/assets/2fff963b-423e-423e-a8f9-3ecf082cad33)




