### PR TITLE
Disable HTTP2 in kubernetes client

### DIFF
--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -54,6 +54,8 @@ let ConnectToCluster (cfgFile: string) (nsOpt: string option) : (Kubernetes * st
                  "stellar-supercluster")
 
     let clientConfig = KubernetesClientConfiguration.BuildConfigFromConfigObject(kCfg)
+    // Disable HTTP2 to avoid intermittent issues with the cluster
+    clientConfig.DisableHttp2 <- true
     let kube = new k8s.Kubernetes(clientConfig)
     (kube, ns)
 


### PR DESCRIPTION
This change disables HTTP2 in the kubernetes client to hopefully resolve some cluster instability. It passed some local runs, but given that the issue is intermittent, it's hard to know if this will solve the problem.