### PR TITLE
Temporarily disable events consistency invariant by default

### DIFF
--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -83,11 +83,11 @@ let installProject (context: MissionContext) =
             "worker.catchup_skip_known_results_for_testing=%b"
             (Option.defaultValue true context.catchupSkipKnownResultsForTesting)
     )
-    // Check events consistency invariant by default
+    // Do not check events consistency invariant by default
     setOptions.Add(
         sprintf
             "worker.check_events_are_consistent_with_entry_diffs=%b"
-            (Option.defaultValue true context.checkEventsAreConsistentWithEntryDiffs)
+            (Option.defaultValue false context.checkEventsAreConsistentWithEntryDiffs)
     )
 
     // read the resource requirements defined in StellarKubeSpecs.fs (where resource for various missions are centralized)


### PR DESCRIPTION
The `--check-events-are-consistent-with-entry-diffs` flag sets a config option that doesn't exist in the v22.3.0 build. This change temporarily disables that flag by default. We should re-enable it by default after the v22.3.0 release.