### PR TITLE
Remove num-runs parameter completely

### DIFF
--- a/doc/measuring-transaction-throughput.md
+++ b/doc/measuring-transaction-throughput.md
@@ -6,7 +6,7 @@ Supercluster provides two missions that measure the maximum number of Transactio
 
 Other than the type of load generated, these two missions are identical. They both spin up a configurable network of stellar-core nodes, then measure the maximum TPS of the network using a binary search over a configurable range of TPS values. For each tested TPS value, the missions generate roughly 15 minutes of load, then check whether the mission was successful. To be considered successful, a mission must close 5-second ledgers at a sustained TPS value. That is, generated transactions must end up in the ledger (cannot be dropped) and all nodes must remain in sync. If the mission determines a run was successful, it will try again with a higher target TPS value. Otherwise, it will retry with a lower target TPS value.
 
-The missions perform the binary search a configurable number of times, then average the highest successful values from each run. Upon completion, the missions emit a log line of the form, “Final tx rate averaged to 1000 over 3 runs for image ...".
+The missions perform the binary search to find the maximum sustainable TPS value. Upon completion, the missions emit a log line of the form, "Final tx rate: 1000 for image ...".
 
 ## Docker images with performance tests enabled
 
@@ -24,7 +24,6 @@ These parameters affect both `MaxTPSClassic` and `MaxTPSMixed` missions:
 
 * `--tx-rate`: Binary search lower bound. If a run fails to achieve at least this value it will fail with an error and you should rerun the mission with a lower value.
 * `--max-tx-rate`: Binary search upper bound. If a run succeeds at this value you should rerun the mission with a higher value.
-* `--num-runs`: Number of max TPS runs to average to get a final TPS value. Defaults to 3.
 * `--pubnet-data`: Network topology to use. Defaults to a topology of tier 1 validators. See [Specifying network topologies](#specifying-network-topologies) for details on how to specify a custom topology.
 * `--netdelay-image`: Helper image providing simulated network delay for latency simulation. SDF provides a public image on dockerhub at `stellar/sdf-netdelay`.
 

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -109,7 +109,6 @@ type MissionOptions
         pubnetParallelCatchupEndLedger: int option,
         pubnetParallelCatchupNumWorkers: int,
         tag: string option,
-        numRuns: int option,
         numPregeneratedTxs: int option,
         genesisTestAccountCount: int option,
         catchupSkipKnownResultsForTesting: bool option,
@@ -459,11 +458,6 @@ type MissionOptions
     [<Option("tag", HelpText = "optional name to tag the run with", Required = false)>]
     member self.Tag = tag
 
-    [<Option("num-runs",
-             HelpText = "optional number of max TPS runs (more runs increase result accuracy)",
-             Required = false)>]
-    member self.NumRuns = numRuns
-
     [<Option("num-pregenerated-txs",
              HelpText = "Number of transactions to pregenerate for max TPS tests",
              Required = false)>]
@@ -608,7 +602,6 @@ let main argv =
                   pubnetParallelCatchupEndLedger = None
                   pubnetParallelCatchupNumWorkers = 128
                   tag = None
-                  numRuns = None
                   numPregeneratedTxs = None
                   genesisTestAccountCount = None
                   enableTailLogging = true
@@ -751,7 +744,6 @@ let main argv =
                                pubnetParallelCatchupEndLedger = mission.PubnetParallelCatchupEndLedger
                                pubnetParallelCatchupNumWorkers = mission.PubnetParallelCatchupNumWorkers
                                tag = mission.Tag
-                               numRuns = mission.NumRuns
                                numPregeneratedTxs = mission.NumPregeneratedTxs
                                enableTailLogging = true
                                catchupSkipKnownResultsForTesting = mission.CatchupSkipKnownResultsForTesting

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -117,7 +117,6 @@ let ctx : MissionContext =
       pubnetParallelCatchupEndLedger = None
       pubnetParallelCatchupNumWorkers = 128
       tag = None
-      numRuns = None
       numPregeneratedTxs = None
       enableTailLogging = true
       catchupSkipKnownResultsForTesting = None

--- a/src/FSLibrary/MaxTPSTest.fs
+++ b/src/FSLibrary/MaxTPSTest.fs
@@ -307,20 +307,11 @@ let maxTPSTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg: LoadG
 
                 finalTxRate.Value
 
-            let mutable results = []
             // As the runs take a while, set a threshold of 10, so we get a
             // reasonable approximation
             let threshold = 10
-            let numRuns = if context.numRuns.IsSome then context.numRuns.Value else 1
 
-            for run in 1 .. numRuns do
-                LogInfo "Starting max TPS run %i out of %i" run numRuns
-                let resultRate = binarySearchWithThreshold context.txRate context.maxTxRate threshold
-                results <- List.append results [ resultRate ]
-                if run < numRuns then restartCoreSetsOrWait allNodes
+            LogInfo "Starting max TPS run"
+            let resultRate = binarySearchWithThreshold context.txRate context.maxTxRate threshold
 
-            LogInfo
-                "Final tx rate averaged to %i over %i runs for image %s"
-                (results |> List.map float |> List.average |> int)
-                numRuns
-                context.image)
+            LogInfo "Final tx rate: %i for image %s" resultRate context.image)

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -98,7 +98,6 @@ type MissionContext =
       nonTier1NodesToAdd: int
       randomSeed: int
       tag: string option
-      numRuns: int option
       numPregeneratedTxs: int option
       networkSizeLimit: int
       pubnetParallelCatchupStartingLedger: int


### PR DESCRIPTION
- Remove num-runs option from Program.fs
- Remove numRuns field from StellarMissionContext.fs
- Update MaxTPSTest.fs to always use a single run
- Update documentation to reflect these changes

🤖 Generated with [Claude Code](https://claude.ai/code)