### PR TITLE
Update the renamed Soroban config parameters.

### DIFF
--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -412,7 +412,7 @@ type Peer with
 
     member self.GetLedgerMaxInstructions() : int64 = self.GetSorobanInfo().Ledger.MaxInstructions
 
-    member self.GetLedgerReadBytes() : int = self.GetSorobanInfo().Ledger.MaxReadBytes
+    member self.GetLedgerReadBytes() : int = self.GetSorobanInfo().Ledger.MaxDiskReadBytes
 
     member self.GetLedgerWriteBytes() : int = self.GetSorobanInfo().Ledger.MaxWriteBytes
 
@@ -426,7 +426,7 @@ type Peer with
 
     member self.GetTxMaxInstructions() : int64 = self.GetSorobanInfo().Tx.MaxInstructions
 
-    member self.GetTxReadBytes() : int = self.GetSorobanInfo().Tx.MaxReadBytes
+    member self.GetTxReadBytes() : int = self.GetSorobanInfo().Tx.MaxDiskReadBytes
 
     member self.GetTxWriteBytes() : int = self.GetSorobanInfo().Tx.MaxWriteBytes
 

--- a/src/FSLibrary/json-type-samples/sample-soroban-info.json
+++ b/src/FSLibrary/json-type-samples/sample-soroban-info.json
@@ -10,7 +10,7 @@
     "fee_write_ledger_entry" : 3000,
     "ledger" : {
         "max_instructions" : 1000000000000000000,
-        "max_read_bytes" : 133120,
+        "max_disk_read_bytes" : 133120,
         "max_read_ledger_entries" : 30,
         "max_tx_count" : 30,
         "max_tx_size_bytes" : 71680,
@@ -36,7 +36,7 @@
     "tx" : {
         "max_contract_events_size_bytes" : 2048,
         "max_instructions" : 1000000000000000000,
-        "max_read_bytes" : 133120,
+        "max_disk_read_bytes" : 133120,
         "max_read_ledger_entries" : 30,
         "max_size_bytes" : 71680,
         "max_write_bytes" : 66560,


### PR DESCRIPTION
These renames were introduced accidentally in p23 migration PR due to find-and-replace. But we should actually update the names consistently both in Core and in supercluster.

I've opened https://github.com/stellar/supercluster/issues/282 for the proper rename.