### PR TITLE
Add theoretical max TPS results for stellar-core v22.3.0

### DIFF
--- a/doc/measuring-transaction-throughput.md
+++ b/doc/measuring-transaction-throughput.md
@@ -26,6 +26,7 @@ These parameters affect both `MaxTPSClassic` and `MaxTPSMixed` missions:
 * `--max-tx-rate`: Binary search upper bound. If a run succeeds at this value you should rerun the mission with a higher value.
 * `--pubnet-data`: Network topology to use. Defaults to a topology of tier 1 validators. See [Specifying network topologies](#specifying-network-topologies) for details on how to specify a custom topology.
 * `--netdelay-image`: Helper image providing simulated network delay for latency simulation. SDF provides a public image on dockerhub at `stellar/sdf-netdelay`.
+* `--run-for-max-tps`: Enables additional, potentially experimental, performance features in stellar-core.
 
 ### Additional options for mixed soroban and classic traffic
 
@@ -89,5 +90,5 @@ Supercluster supports running missions with artificially generated network topol
 
 To run a mission with a custom topology that searches for a max TPS between 500 and 1500, your command would look roughly like:
 ```bash
-dotnet run --project src/App/App.fsproj --configuration Release -- mission MaxTPSClassic --image=stellar/unsafe-stellar-core:<stellar-core-perftest-build> --netdelay-image=stellar/sdf-netdelay:latest --pubnet-data=generated-overlay-topology.json --tx-rate=500 --max-tx-rate=1500
+dotnet run --project src/App/App.fsproj --configuration Release -- mission MaxTPSClassic --image=stellar/unsafe-stellar-core:<stellar-core-perftest-build> --netdelay-image=stellar/sdf-netdelay:latest --pubnet-data=generated-overlay-topology.json --tx-rate=500 --max-tx-rate=1500 --run-for-max-tps
 ```

--- a/doc/theoretical-max-tps.md
+++ b/doc/theoretical-max-tps.md
@@ -5,11 +5,13 @@ that searches for a maximum transaction-per-second rate that stellar-core can
 support under ideal circumstances. It uses a network of 7 stellar-core nodes, of
 which 3 are validators.  We provide this topology in
 [`/topologies/theoretical-max-tps.json`](../topologies/theoretical-max-tps.json).
+Each node gets their own EC2 `m5d.4xlarge` instance.
 
-To run the test, first [set up an EKS cluster](eks.md). Then, run a
-`MaxTPSClassic` mission with the following template:
+To run the test, first [set up an EKS cluster](eks.md). Accepting the default
+settings will produce a topology identical to what we use in our test setup.
+Then, run a `MaxTPSClassic` mission with the following template:
 ```bash
-dotnet run --project src/App/App.fsproj --configuration Release -- mission MaxTPSClassic --image=<core-image> --netdelay-image=stellar/sdf-netdelay:latest --pubnet-data=<path-to-repo>/topologies/theoretical-max-tps.json --num-runs=<runs> --tx-rate=<min-tx-rate> --max-tx-rate=<max-tx-rate> --namespace default --ingress-internal-domain=<domain> --ingress-class=nginx
+dotnet run --project src/App/App.fsproj --configuration Release -- mission MaxTPSClassic --image=<core-image> --pubnet-data=<path-to-repo>/topologies/theoretical-max-tps.json --tx-rate=<min-tx-rate> --max-tx-rate=<max-tx-rate> --namespace default --ingress-internal-domain=<domain> --ingress-class=nginx --run-for-max-tps
 ```
 For more information about how to set the parameters in the above command, see
 [Measuring Transaction Throughput](measuring-transaction-throughput.md).
@@ -24,16 +26,26 @@ Finally, don't forget to shut down your EKS cluster.
 ## Results
 
 This table contains the theoretical max TPS stellar-core achieved, ordered by
-stellar-core release.
+stellar-core release. The columns are as follows:
 
-| Core Version | Core Image | Supercluster Commit | Database Backend | Topology (total # of stellar-core nodes / # of validators) | EC2 Instance Type | Number of EC2 Instances | Max TPS | Notes |
-|--------------|------------|---------------------|------------------|------------------------------------------------------------|-------------------|-------------------------|---------|-------|
-| 22.2.0 | `stellar/unsafe-stellar-core:22.2.0-2361.e6c1f3bfc.focal-perftests` | `b49c0810f159e0305328e127057e1f6fc08a0524` | BucketListDB | 7 / 3 | m5d.4xlarge | 10 | 1079 | Performance improvement due to BucketList caching changes |
-| 22.1.0rc1 | `stellar/unsafe-stellar-core:22.1.0-2189.rc1.fdd833d57.focal-perftests` | | BucketListDB | 7 / 3 | m5d.4xlarge | 10 | 989 | Performance improvement due to [networking changes](https://github.com/stellar/stellar-core/pull/4544) |
-| 22.0.0 | `stellar/unsafe-stellar-core:22.0.0-2138.721fd0a65.focal-perftests` | | BucketListDB | 7 / 3 | m5d.4xlarge | 10 | 902 | |
-| 22.0.0rc2 | `stellar/unsafe-stellar-core:22.0.0-2095.rc2.1bccbc921.focal-perftests` | | BucketListDB | 7 / 3 | m5d.4xlarge | 10 | 958 | First version with mandatory BucketListDB backend |
-| 21.3.1 | `stellar/unsafe-stellar-core:21.3.1-2007.4ede19620.focal-perftests` | | BucketListDB | 7 / 3 | m5d.4xlarge | 10 | 1110 | |
-| 21.3.1 | `stellar/unsafe-stellar-core:21.3.1-2007.4ede19620.focal-perftests` | | SQLite in-memory | 7 / 3 | m5d.4xlarge | 10 | 1170 | |
-| 21.2.0 | `stellar/unsafe-stellar-core:21.2.0-1953.d78f48eac.focal-perftests` | | BucketListDB | 7 / 3 | m5d.4xlarge | 10 | 1059 | |
-| 21.2.0 | `stellar/unsafe-stellar-core:21.2.0-1953.d78f48eac.focal-perftests` | | SQLite in-memory | 7 / 3 | m5d.4xlarge | 10 | 1053 | |
-| 21.1.0 | `stellar/unsafe-stellar-core:21.0.1-1917.52a449ff3.focal-testing-asan-disabled-perftests` | | SQLite in-memory | 7 / 3 | m5d.4xlarge | 10 | 1137 | |
+* **Core Version.** The stellar core release tested.
+* **Core Image.** The exact docker image tested, from Docker Hub.
+* **Core Compiler Flags.** C/C++ compiler flags used in the stellar-core build.
+* **Core Configure Flags.** Arguments passed to stellar-core's `./configure` script.
+* **Supercluster Commit.** Supercluster commit hash used to run the test
+* **Extra Supercluster Options.** Additional Supercluster commands used beyond the ones specified in the template specified in the introduction of this document.
+* **Max TPS.** The result of the test.
+* **Notes.** Any additional information on the test result or methodology.
+
+| Core Version | Core Image | Core Compiler Flags | Core Configure Flags | Supercluster Commit | Extra Supercluster Options | Max TPS | Notes |
+|--------------|------------|---------------------|----------------------|---------------------|----------------------------|---------|-------|
+| 22.3.0 | `stellar/unsafe-stellar-core:22.3.1-2490.e643061a4.focal-tmtps-perftests` | `-ggdb -O3 -fstack-protector-strong` | | `d9df3be5ec3ea6d7f18262c601b05c793eb2c63b` | `--run-for-max-tps --enable-relaxed-auto-qset-config` | 2032 | Performance improvement due to a combination of new stellar-core performance focused features, and testing methodology changes due to pregenerating transactions for load generation. See [release notes](https://github.com/stellar/stellar-core/releases/tag/v22.3.0) for more info. |
+| 22.2.0 | `stellar/unsafe-stellar-core:22.2.0-2361.e6c1f3bfc.focal-perftests` | `-ggdb -O3 -fstack-protector-strong` | `--enable-tracy --enable-tracy-capture --enable-tracy-csvexport` | `b49c0810f159e0305328e127057e1f6fc08a0524` | | 1079 | Performance improvement due to BucketList caching changes |
+| 22.1.0rc1 | `stellar/unsafe-stellar-core:22.1.0-2189.rc1.fdd833d57.focal-perftests` | `-ggdb -O3 -fstack-protector-strong` | `--enable-tracy --enable-tracy-capture --enable-tracy-csvexport` | | | 989 | Performance improvement due to [networking changes](https://github.com/stellar/stellar-core/pull/4544) |
+| 22.0.0 | `stellar/unsafe-stellar-core:22.0.0-2138.721fd0a65.focal-perftests` | `-ggdb -O3 -fstack-protector-strong` | `--enable-tracy --enable-tracy-capture --enable-tracy-csvexport` | | | 902 | |
+| 22.0.0rc2 | `stellar/unsafe-stellar-core:22.0.0-2095.rc2.1bccbc921.focal-perftests` | `-ggdb -O3 -fstack-protector-strong` | `--enable-tracy --enable-tracy-capture --enable-tracy-csvexport` | | | 958 | First version with mandatory BucketListDB backend |
+| 21.3.1 | `stellar/unsafe-stellar-core:21.3.1-2007.4ede19620.focal-perftests` | `-ggdb -O3 -fstack-protector-strong` | `--enable-tracy --enable-tracy-capture --enable-tracy-csvexport` | | | 1110 | Used BucketListDB database backend |
+| 21.3.1 | `stellar/unsafe-stellar-core:21.3.1-2007.4ede19620.focal-perftests` | `-ggdb -O3 -fstack-protector-strong` | `--enable-tracy --enable-tracy-capture --enable-tracy-csvexport` | | | 1170 | Used SQLite in-memory database backend |
+| 21.2.0 | `stellar/unsafe-stellar-core:21.2.0-1953.d78f48eac.focal-perftests` | `-ggdb -O3 -fstack-protector-strong` | `--enable-tracy --enable-tracy-capture --enable-tracy-csvexport` | | | 1059 | Used BucketListDB database backend |
+| 21.2.0 | `stellar/unsafe-stellar-core:21.2.0-1953.d78f48eac.focal-perftests` | `-ggdb -O3 -fstack-protector-strong` | `--enable-tracy --enable-tracy-capture --enable-tracy-csvexport` | | | 1053 | Used SQLite in-memory database backend |
+| 21.1.0 | `stellar/unsafe-stellar-core:21.0.1-1917.52a449ff3.focal-testing-asan-disabled-perftests` | `-ggdb -O3 -fstack-protector-strong` | `--enable-tracy --enable-tracy-capture --enable-tracy-csvexport` | | | 1137 | Used SQLite in-memory database backend |


### PR DESCRIPTION
This change adds results for the v22.3.0 release and also updates the table to:
* Include additional build info to improve reproducibility of our results
* Remove unchanging columns. Integrate the details within them into the introduction instead.