### PR TITLE
Fix and update `MissionSimulatePubnetMixedLoad`.

### DIFF
--- a/src/FSLibrary/MissionSimulatePubnetMixedLoad.fs
+++ b/src/FSLibrary/MissionSimulatePubnetMixedLoad.fs
@@ -39,7 +39,8 @@ let simulatePubnetMixedLoad (baseContext: MissionContext) =
               // performance.
               maxConnections = Some(baseContext.maxConnections |> Option.defaultValue 65)
 
-              enableBackggroundOverlay = true }
+              enableBackggroundOverlay = true
+              updateSorobanCosts = Some(true) }
 
     let fullCoreSet = FullPubnetCoreSets context true false
 
@@ -52,9 +53,9 @@ let simulatePubnetMixedLoad (baseContext: MissionContext) =
     let numLoadGenerators = 20
     let loadGenerators = List.take (min numLoadGenerators (List.length nonTier1)) nonTier1
 
-    // Transactions per second. ~1000 per ledger. 200 payment TPS and 2 invoke
-    // TPS.
-    let txrate = 202
+    // Transactions per second. ~1050 per ledger. ~200 payment TPS and ~10
+    // invoke TPS.
+    let txrate = 210
 
     let loadGen =
         { LoadGen.GetDefault() with
@@ -107,12 +108,7 @@ let simulatePubnetMixedLoad (baseContext: MissionContext) =
 
             for lg in loadGenerators do
                 // Run setup on nodes one at a time
-                formation.RunLoadgen
-                    lg
-                    { loadGen with
-                          mode = SorobanInvokeSetup
-                          txrate = 2
-                          minSorobanPercentSuccess = Some 100 }
+                formation.RunLoadgen lg context.SetupSorobanInvoke
 
             formation.RunMultiLoadgen loadGenerators loadGen
             formation.EnsureAllNodesInSync fullCoreSet)

--- a/src/FSLibrary/PubnetData.fs
+++ b/src/FSLibrary/PubnetData.fs
@@ -85,6 +85,6 @@ let pubnetWasmBytes =
 // fixed as part of stellar-core issue #4231.
 let pubnetDataEntries = [ (1, 667); (2, 333) ]
 
-let pubnetPayWeight = 99
-let pubnetInvokeWeight = 1
+let pubnetPayWeight = 95
+let pubnetInvokeWeight = 5
 let pubnetUploadWeight = 0


### PR DESCRIPTION
This change accomplishes a couple things:
1. `simulatePubnetMixedLoad` was experiencing issues with loadgen failing during invoke setup. It seems like this is a known issue that #234 resolved for the other soroban missions, but this mission was missed. This change applies the same fix from that PR to this mission.
2. This change increases the default percentage of soroban transactions for mixed modes from 1% to 5%. It also increases the TPS rate for the test from 202 to 210. This distribution more closely matches what we see on pubnet.