### PR TITLE
Remove outdated background overlay option

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -92,7 +92,6 @@ type MissionOptions
         installNetworkDelay: bool option,
         flatNetworkDelay: int option,
         peerReadingCapacity: int option,
-        enableBackgroundOverlay: bool,
         enableBackgroundSigValidation: bool,
         enableParallelApply: bool,
         enableInMemoryBuckets: bool,
@@ -385,9 +384,6 @@ type MissionOptions
              Required = false)>]
     member self.PeerReadingCapacity = peerReadingCapacity
 
-    [<Option("enable-background-overlay", HelpText = "background overlay")>]
-    member self.EnableBackgroundOverlay : bool = enableBackgroundOverlay
-
     [<Option("enable-background-sig-validation", HelpText = "enable background signature validation")>]
     member self.EnableBackgroundSigValidation : bool = enableBackgroundSigValidation
 
@@ -617,7 +613,6 @@ let main argv =
                   simulateApplyWeight = None
                   peerFloodCapacity = None
                   peerReadingCapacity = None
-                  enableBackggroundOverlay = false
                   enableBackgroundSigValidation = false
                   enableParallelApply = false
                   enableInMemoryBuckets = false
@@ -763,7 +758,6 @@ let main argv =
                                simulateApplyDuration = processInputSeq mission.SimulateApplyDuration
                                simulateApplyWeight = processInputSeq mission.SimulateApplyWeight
                                peerReadingCapacity = mission.PeerReadingCapacity
-                               enableBackggroundOverlay = mission.EnableBackgroundOverlay
                                enableBackgroundSigValidation = mission.EnableBackgroundSigValidation
                                enableParallelApply = mission.EnableParallelApply
                                enableInMemoryBuckets = mission.EnableInMemoryBuckets

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -73,7 +73,6 @@ let ctx : MissionContext =
       fullyConnectTier1 = false
       peerReadingCapacity = None
       peerFloodCapacity = None
-      enableBackggroundOverlay = false
       enableBackgroundSigValidation = false
       enableParallelApply = false
       enableInMemoryBuckets = false

--- a/src/FSLibrary/MissionSimulatePubnetMixedLoad.fs
+++ b/src/FSLibrary/MissionSimulatePubnetMixedLoad.fs
@@ -39,7 +39,6 @@ let simulatePubnetMixedLoad (baseContext: MissionContext) =
               // performance.
               maxConnections = Some(baseContext.maxConnections |> Option.defaultValue 65)
 
-              enableBackggroundOverlay = true
               updateSorobanCosts = Some(true) }
 
     let fullCoreSet = FullPubnetCoreSets context true false

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -240,9 +240,6 @@ type StellarCoreCfg =
            && self.network.missionContext.enableRelaxedAutoQsetConfig then
             t.Add("SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING", true) |> ignore
 
-        if self.network.missionContext.enableBackggroundOverlay then
-            t.Add("EXPERIMENTAL_BACKGROUND_OVERLAY_PROCESSING", true) |> ignore
-
         match self.homeDomain with
         | None -> ()
         | Some hd -> t.Add("NODE_HOME_DOMAIN", hd) |> ignore

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -87,7 +87,6 @@ type MissionContext =
       simulateApplyDuration: seq<int> option
       simulateApplyWeight: seq<int> option
       peerReadingCapacity: int option
-      enableBackggroundOverlay: bool
       enableBackgroundSigValidation: bool
       enableParallelApply: bool
       enableInMemoryBuckets: bool


### PR DESCRIPTION
The `--enable-background-overlay` flag sets
`EXPERIMENTAL_BACKGROUND_OVERLAY_PROCESSING=true` in stellar-core. However, stellar-core 23.0.0 renamed this option. Since the background overlay is enabled by default now, and the only use of the supercluster flag was to enable the stellar-core option, this PR removes the flag entirely (rather than renaming it) as the flag is now redundant.