### PR TITLE
Add mission to test SCP timing upgrade

### DIFF
--- a/doc/missions.md
+++ b/doc/missions.md
@@ -131,6 +131,10 @@ Test heavy Soroban load on a large network of nodes. This mission mostly focuses
 
 Test various upgrade scenarios for Soroban network configs (maximum transaction size, maximum transaction count, etc).
 
+## MissionUpgradeSCPSettings
+
+Test SCP timing configuration upgrades as defined in CAP-70.
+
 ## MissionSorobanInvokeHostLoad
 
 Test resource-intensive InvokeHostFunction operations on a small network of nodes.

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -72,6 +72,7 @@
     <Compile Include="MissionDatabaseInplaceUpgrade.fs" />
     <Compile Include="MissionAcceptanceUnitTests.fs" />
     <Compile Include="MissionMaxTPSMixed.fs" />
+    <Compile Include="MissionUpgradeSCPSettings.fs" />
     <Compile Include="StellarMission.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FSLibrary/MissionUpgradeSCPSettings.fs
+++ b/src/FSLibrary/MissionUpgradeSCPSettings.fs
@@ -1,0 +1,102 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+module MissionUpgradeSCPSettings
+
+open StellarCorePeer
+open StellarCoreSet
+open StellarMissionContext
+open StellarFormation
+open StellarStatefulSets
+open StellarSupercluster
+open StellarCoreHTTP
+open StellarNetworkData
+open System.Threading
+open Logging
+
+let upgradeSCPSettings (context: MissionContext) =
+    let context =
+        { context with
+              coreResources = SimulatePubnetTier1PerfResources
+              installNetworkDelay = Some(context.installNetworkDelay |> Option.defaultValue true)
+              numAccounts = 1000
+              numTxs = 1000
+              txRate = 50 }
+
+    let fullCoreSet = StableApproximateTier1CoreSets context.image false
+
+    let sdf =
+        List.find (fun (cs: CoreSet) -> cs.name.StringName = "stellar" || cs.name.StringName = "sdf") fullCoreSet
+
+    let tier1 = List.filter (fun (cs: CoreSet) -> cs.options.tier1 = Some true) fullCoreSet
+
+    // This tests the following SCP timings and upgrades:
+    // Protocol 22 sanity check: make sure block times are 5 seconds
+    // Upgrade to protocol 23: block times stay the same after upgrade
+    // Upgrade to minimum SCP timing configuration: check for 4 second block times
+    context.Execute
+        fullCoreSet
+        None
+        (fun (formation: StellarFormation) ->
+            formation.WaitUntilConnected fullCoreSet
+            formation.ManualClose tier1
+            formation.WaitUntilSynced fullCoreSet
+
+            let peer = formation.NetworkCfg.GetPeer sdf 0
+
+            // Helper function to measure average block close time
+            let measureBlockTime (expectedSeconds: float) =
+                let beforeLedgerNum = peer.GetLedgerNum()
+                let beforeCloseTime = peer.GetInfo().Ledger.CloseTime
+
+                // Generate some load so we're not just closing empty ledgers
+                formation.RunLoadgen sdf context.GeneratePaymentLoad
+
+                let afterLedgerNum = peer.GetLedgerNum()
+                let afterCloseTime = peer.GetInfo().Ledger.CloseTime
+                let ledgersClosed = afterLedgerNum - beforeLedgerNum
+                let timeElapsed = afterCloseTime - beforeCloseTime
+                let avgCloseTime = float timeElapsed / float ledgersClosed
+
+                LogInfo
+                    "%d ledgers closed in %d seconds, average close time: %.2f seconds"
+                    ledgersClosed
+                    timeElapsed
+                    avgCloseTime
+
+                // Verify close time is approximately as expected
+                if avgCloseTime < expectedSeconds - 0.25 || avgCloseTime > expectedSeconds + 0.5 then
+                    failwithf "Expected ~%.0f second close time, but got %.2f seconds" expectedSeconds avgCloseTime
+
+            // Upgrade to protocol 22 and verify 5-second block times
+            LogInfo "Upgrading to protocol 22 and verifying 5-second block times"
+            let currentProtocol = peer.GetLedgerProtocolVersion()
+
+            if currentProtocol <> 22 then
+                formation.UpgradeProtocol tier1 22
+                peer.WaitForProtocol 22
+
+            formation.UpgradeMaxTxSetSize tier1 100000
+            peer.WaitForMaxTxSetSize 100000
+            formation.WaitUntilSynced fullCoreSet
+
+            // Create accounts for payment load later
+            formation.RunLoadgen sdf context.GenerateAccountCreationLoad
+
+            measureBlockTime 5.0
+
+            // Upgrade to protocol 23 and check that block times are still 5 seconds
+            LogInfo "Upgrading to protocol 23 and verifying 5-second block times"
+            formation.UpgradeProtocol tier1 23
+            peer.WaitForProtocol 23
+            measureBlockTime 5.0
+
+            // Upgrade to minimum SCP timing configuration and check for 4-second block times
+            LogInfo "Deploying SCP timing configuration upgrade to 4-second block times"
+            formation.UpgradeToMinimumSCPConfig tier1
+
+            LogInfo "Verifying 4-second block times after SCP timing upgrade"
+            measureBlockTime 4.0
+
+            formation.CheckNoErrorsAndPairwiseConsistency())

--- a/src/FSLibrary/MissionUpgradeSCPSettings.fs
+++ b/src/FSLibrary/MissionUpgradeSCPSettings.fs
@@ -12,7 +12,6 @@ open StellarStatefulSets
 open StellarSupercluster
 open StellarCoreHTTP
 open StellarNetworkData
-open System.Threading
 open Logging
 
 let upgradeSCPSettings (context: MissionContext) =
@@ -86,10 +85,9 @@ let upgradeSCPSettings (context: MissionContext) =
 
             measureBlockTime 5.0
 
-            // Upgrade to protocol 23 and check that block times are still 5 seconds
-            LogInfo "Upgrading to protocol 23 and verifying 5-second block times"
-            formation.UpgradeProtocol tier1 23
-            peer.WaitForProtocol 23
+            // Upgrade to latest protocol and check that block times are still 5 seconds
+            LogInfo "Upgrading to latest protocol and verifying 5-second block times"
+            formation.UpgradeProtocolToLatest tier1
             measureBlockTime 5.0
 
             // Upgrade to minimum SCP timing configuration and check for 4-second block times

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -110,7 +110,14 @@ type LoadGen =
       // Fields for BLEND_CLASSIC_SOROBAN mode
       payWeight: int option
       sorobanUploadWeight: int option
-      sorobanInvokeWeight: int option }
+      sorobanInvokeWeight: int option
+
+      // Fields for SCP timing configuration
+      ledgerTargetCloseTimeMilliseconds: int option
+      ballotTimeoutIncrementMilliseconds: int option
+      ballotTimeoutInitialMilliseconds: int option
+      nominationTimeoutInitialMilliseconds: int option
+      nominationTimeoutIncrementMilliseconds: int option }
 
     member self.ToQuery : (string * string) list =
         let mandatoryParams =
@@ -162,6 +169,21 @@ type LoadGen =
                                                                     "sorobaninvokeweight"
                                                                     self.sorobanInvokeWeight
                                                                   @ optionalParam "txmxftprnt" self.txMaxFootprintSize
+                                                                    @ optionalParam
+                                                                        "ldgrclse"
+                                                                        self.ledgerTargetCloseTimeMilliseconds
+                                                                      @ optionalParam
+                                                                          "balinc"
+                                                                          self.ballotTimeoutIncrementMilliseconds
+                                                                        @ optionalParam
+                                                                            "balinit"
+                                                                            self.ballotTimeoutInitialMilliseconds
+                                                                          @ optionalParam
+                                                                              "nominit"
+                                                                              self.nominationTimeoutInitialMilliseconds
+                                                                            @ optionalParam
+                                                                                "nominc"
+                                                                                self.nominationTimeoutIncrementMilliseconds
 
         mandatoryParams @ optionalParams
 
@@ -202,7 +224,12 @@ type LoadGen =
           txMaxFootprintSize = None
           payWeight = None
           sorobanUploadWeight = None
-          sorobanInvokeWeight = None }
+          sorobanInvokeWeight = None
+          ledgerTargetCloseTimeMilliseconds = None
+          ballotTimeoutIncrementMilliseconds = None
+          ballotTimeoutInitialMilliseconds = None
+          nominationTimeoutInitialMilliseconds = None
+          nominationTimeoutIncrementMilliseconds = None }
 
 // Takes a default value `v` and a list `l` and returns `v` if `l` is empty,
 // otherwise `l`.

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -484,6 +484,17 @@ type Peer with
         | Some jprop -> Some(jprop.AsInteger())
         | None -> None
 
+    // SCP configuration getters
+    member self.GetScpLedgerCloseTimeMs() : int = self.GetSorobanInfo().Scp.LedgerCloseTimeMs
+
+    member self.GetScpNominationTimeoutMs() : int = self.GetSorobanInfo().Scp.NominationTimeoutMs
+
+    member self.GetScpNominationTimeoutIncMs() : int = self.GetSorobanInfo().Scp.NominationTimeoutIncMs
+
+    member self.GetScpBallotTimeoutMs() : int = self.GetSorobanInfo().Scp.BallotTimeoutMs
+
+    member self.GetScpBallotTimeoutIncMs() : int = self.GetSorobanInfo().Scp.BallotTimeoutIncMs
+
     member self.GetLedgerProtocolVersion() : int = self.GetInfo().Ledger.Version
 
     member self.GetSupportedProtocolVersion() : int = self.GetInfo().ProtocolVersion
@@ -585,6 +596,11 @@ type Peer with
         RetryUntilTrue
             (fun _ -> self.GetTxMaxInstructions() = n)
             (fun _ -> LogInfo "Waiting for TxMaxInstructions=%d on %s" n self.ShortName.StringName)
+
+    member self.WaitForScpLedgerCloseTime(n: int) =
+        RetryUntilTrue
+            (fun _ -> self.GetScpLedgerCloseTimeMs() = n)
+            (fun _ -> LogInfo "Waiting for ScpLedgerCloseTimeMs=%d on %s" n self.ShortName.StringName)
 
     member self.WaitForMaxTxSize(n: int) =
         RetryUntilTrue

--- a/src/FSLibrary/StellarMission.fs
+++ b/src/FSLibrary/StellarMission.fs
@@ -45,6 +45,7 @@ open MissionMixedImageNetworkSurvey
 open MissionMaxTPSMixed
 open MissionSimulatePubnetMixedLoad
 open MissionMixedNominationLeaderElection
+open MissionUpgradeSCPSettings
 
 type Mission = (MissionContext -> unit)
 
@@ -91,4 +92,5 @@ let allMissions : Map<string, Mission> =
                  ("MaxTPSMixed", maxTPSMixed)
                  ("SimulatePubnetMixedLoad", simulatePubnetMixedLoad)
                  ("MixedNominationLeaderElectionWithOldMajority", mixedNominationLeaderElectionWithOldMajority)
-                 ("MixedNominationLeaderElectionWithNewMajority", mixedNominationLeaderElectionWithNewMajority) |]
+                 ("MixedNominationLeaderElectionWithNewMajority", mixedNominationLeaderElectionWithNewMajority)
+                 ("UpgradeSCPSettings", upgradeSCPSettings) |]

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -232,9 +232,7 @@ type StellarFormation with
                   nominationTimeoutIncrementMilliseconds = Some(750) }
             (System.DateTime.UtcNow.AddSeconds(20.0))
 
-        // Wait for the upgrade to take effect by waiting for a few ledgers
-        // TODO: Actually check for the config once sorobaninfo endpoint is updated
-        peer.WaitForFewLedgers 6 |> ignore
+        peer.WaitForScpLedgerCloseTime 4000 |> ignore
 
     member self.ReportStatus() = ReportAllPeerStatus self.NetworkCfg
 

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -234,6 +234,19 @@ type StellarFormation with
 
         peer.WaitForScpLedgerCloseTime 4000 |> ignore
 
+    member self.UpgradeSCPTargetLedgerCloseTime (coreSetList: CoreSet list) (closeTimeMs: int) =
+        self.SetupUpgradeContract coreSetList.[0]
+        let peer = self.NetworkCfg.GetPeer coreSetList.[0] 0
+
+        self.DeployUpgradeEntriesAndArm
+            coreSetList
+            { LoadGen.GetDefault() with
+                  mode = CreateSorobanUpgrade
+                  ledgerTargetCloseTimeMilliseconds = Some(closeTimeMs) }
+            (System.DateTime.UtcNow.AddSeconds(20.0))
+
+        peer.WaitForScpLedgerCloseTime closeTimeMs |> ignore
+
     member self.ReportStatus() = ReportAllPeerStatus self.NetworkCfg
 
     member self.CreateAccount (coreSet: CoreSet) (u: Username) =

--- a/src/FSLibrary/json-type-samples/sample-soroban-info.json
+++ b/src/FSLibrary/json-type-samples/sample-soroban-info.json
@@ -33,6 +33,13 @@
         "starting_eviction_scan_level" : 1,
         "temp_rent_rate_denominator" : 5356800
     },
+    "scp" : {
+        "ledger_close_time_ms" : 5000,
+        "nomination_timeout_ms" : 2000,
+        "nomination_timeout_inc_ms" : 1000,
+        "ballot_timeout_ms" : 3000,
+        "ballot_timeout_inc_ms" : 1000
+    },
     "tx" : {
         "max_contract_events_size_bytes" : 2048,
         "max_instructions" : 1000000000000000000,


### PR DESCRIPTION
Adds a test for CAP 70.

This test starts at protocol 22 and checks for 5 second ledgers, then upgrades to protocol 23 and ensures that ledgers are still 5 seconds. Finally, it upgrades to the minimum allowed SCP timing configuration and checks if ledgers are 4 seconds.

When we upgrade SCP timings, we don't have a good way of actually checking the upgrade went through, so I've opened this core PR: https://github.com/stellar/stellar-core/pull/4838.