### PR TITLE
Upgrade KubernetesClient and supporting libraries

### DIFF
--- a/scripts/eks-init.py
+++ b/scripts/eks-init.py
@@ -13,7 +13,7 @@ DEFAULT_REGION = "us-west-2"
 # topology plus 3 to cover the ingress controller and two coredns instances.
 DEFAULT_NUM_NODES = 10
 DEFAULT_NODE_TYPE = "m5d.4xlarge"
-KUBERNETES_VERSION = "1.30"
+KUBERNETES_VERSION = "1.31"
 SSH_USERNAME = "ec2-user"
 NVME_MOUNT_SCRIPT = "https://raw.githubusercontent.com/awslabs/amazon-eks-ami/86105105a83fdc80e682b850aac6f626119a6951/templates/shared/runtime/bin/setup-local-disks"
 DNS_RETRY_INTERVAL_SECONDS = 60

--- a/src/CSLibrary/CSLibrary.csproj
+++ b/src/CSLibrary/CSLibrary.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
-    <PackageReference Include="KubernetesClient" Version="14.0.2" />
+    <PackageReference Include="KubernetesClient" Version="15.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="stellar-dotnet-sdk" Version="10.0.0" />

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -79,14 +79,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="FSharp.Data" Version="4.1.1" />
-    <PackageReference Include="KubernetesClient" Version="14.0.2" />
+    <PackageReference Include="KubernetesClient" Version="15.0.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="stellar-dotnet-sdk" Version="10.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="YamlDotNet" Version="15.3.0" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CSLibrary\CSLibrary.csproj" />


### PR DESCRIPTION
Closes stellar/stellar-supercluster#342

This change updates our `KubernetesClient` library to 15.0.1 in preparation for upgrading SSC's kubernetes version to 1.31. This version of KubernetesClient supports both kubernetes 1.30 (our currently supported version) and 1.31. I've tested this change by manually running a few missions, all of which passed without issues.

In order to upgrade KubernetesClient, I also had to upgrade our yaml library. Again, I didn't run into any issues with this.