### PR TITLE
Revert "Add simple list call in NamespaceContent.AddAll() to fix OIDC issues"

### DIFF
--- a/src/FSLibrary/StellarNamespaceContent.fs
+++ b/src/FSLibrary/StellarNamespaceContent.fs
@@ -123,7 +123,6 @@ type NamespaceContent(kube: Kubernetes, apiRateLimit: int, namespaceProperty: st
     member self.AddAll() =
         ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (apiRateLimit)
 
-        kube.ListNamespacedRole(namespaceParameter = namespaceProperty) |> ignore
         for s in kube.ListNamespacedService(namespaceParameter = namespaceProperty).Items do
             self.Add(s)
 


### PR DESCRIPTION
PR #309 doesn't seem to have actually fixed the OIDC issue, and it causes some problems with our kubernetes cluster (certain runners don't have the proper permissions for it). While I am investigating the underlying issue, it seems best to revert the broken change.