### PR TITLE
Added network benchmarking feature

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -118,7 +118,10 @@ type MissionOptions
         enableRelaxedAutoQsetConfig: bool,
         jobMonitorExternalHost: string option,
         txBatchMaxSize: int option,
-        runForMaxTps: string option
+        runForMaxTps: string option,
+        benchmarkInfrastructure: bool option,
+        benchmarkOnly: bool option,
+        benchmarkDurationSeconds: int option
     ) =
 
     [<Option('k', "kubeconfig", HelpText = "Kubernetes config file", Required = false, Default = "~/.kube/config")>]
@@ -515,6 +518,22 @@ type MissionOptions
              Required = false)>]
     member self.RunForMaxTps = runForMaxTps
 
+    [<Option("benchmark-infra",
+             HelpText = "Run network infrastructure benchmark in addition to stellar-core tests",
+             Required = false)>]
+    member self.BenchmarkInfrastructure = benchmarkInfrastructure
+
+    [<Option("benchmark-only",
+             HelpText = "Run ONLY the network infrastructure benchmark, skip stellar-core tests (requires --benchmark-infra)",
+             Required = false)>]
+    member self.BenchmarkOnly = benchmarkOnly
+
+    [<Option("benchmark-duration-seconds",
+             HelpText = "Duration of network benchmark tests in seconds",
+             Required = false,
+             Default = 30)>]
+    member self.BenchmarkDurationSeconds = benchmarkDurationSeconds
+
 let splitLabel (lab: string) : (string * string option) =
     match lab.Split ':' with
     | [| x |] -> (x, None)
@@ -638,7 +657,10 @@ let main argv =
                   enableRelaxedAutoQsetConfig = false
                   jobMonitorExternalHost = None
                   txBatchMaxSize = None
-                  runForMaxTps = None }
+                  runForMaxTps = None
+                  benchmarkInfrastructure = None
+                  benchmarkInfrastructureOnly = None
+                  benchmarkDurationSeconds = None }
 
             let nCfg = MakeNetworkCfg ctx [] None
             use formation = kube.MakeEmptyFormation nCfg
@@ -689,6 +711,11 @@ let main argv =
                      let processInputSeq s = if Seq.isEmpty s then None else Some((Seq.map int) s)
 
                      try
+                         // Validate benchmark flag combinations
+                         if mission.BenchmarkOnly = Some true
+                            && mission.BenchmarkInfrastructure <> Some true then
+                             failwith "Error: --benchmark-only requires --benchmark-infra to be set"
+
                          let missionContext =
                              { MissionContext.kube = kube
                                kubeCfg = mission.KubeConfig
@@ -784,7 +811,10 @@ let main argv =
                                enableRelaxedAutoQsetConfig = mission.EnableRelaxedAutoQsetConfig
                                jobMonitorExternalHost = mission.JobMonitorExternalHost
                                txBatchMaxSize = mission.TxBatchMaxSize
-                               runForMaxTps = mission.RunForMaxTps }
+                               runForMaxTps = mission.RunForMaxTps
+                               benchmarkInfrastructure = mission.BenchmarkInfrastructure
+                               benchmarkInfrastructureOnly = mission.BenchmarkOnly
+                               benchmarkDurationSeconds = mission.BenchmarkDurationSeconds }
 
                          allMissions.[m] missionContext
 

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -128,7 +128,10 @@ let ctx : MissionContext =
       enableRelaxedAutoQsetConfig = false
       jobMonitorExternalHost = None
       txBatchMaxSize = None
-      runForMaxTps = None }
+      runForMaxTps = None
+      benchmarkInfrastructure = None
+      benchmarkInfrastructureOnly = None
+      benchmarkDurationSeconds = None }
 
 let netdata = __SOURCE_DIRECTORY__ + "/../../../data/public-network-data-2024-08-01.json"
 let pubkeys = __SOURCE_DIRECTORY__ + "/../../../data/tier1keys.json"

--- a/src/FSLibrary/BenchmarkDaemonSet.fs
+++ b/src/FSLibrary/BenchmarkDaemonSet.fs
@@ -1,0 +1,280 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+module BenchmarkDaemonSet
+
+open k8s
+open k8s.Models
+open System
+open System.Collections.Generic
+open Logging
+open StellarKubeSpecs
+open StellarNetworkCfg
+open StellarNetworkDelays
+open StellarCoreCfg
+
+// Docker image for iperf3 - a tool for measuring network throughput and latency
+// We use it to run bidirectional P2P network performance tests between stellar-core nodes
+let benchmarkImage = "networkstatic/iperf3:latest"
+
+let benchmarkLabels = Map.ofSeq [ "app", "network-benchmark" ]
+
+// Extract short name from stellar-core DNS patterns for use in benchmark pod names
+// We keep the full name including "node-" prefix to ensure DNS resolution works
+// Examples: "node-0-0" -> "node-0-0", "sdf-0" -> "sdf-0", "pn-0" -> "pn-0"
+let extractShortNameFromStellarCoreDns (fullName: string) : string =
+    // Keep the full name to ensure DNS resolution works correctly
+    // The benchmark pods use the same naming pattern as stellar-core pods
+    fullName
+
+// Extract node name from benchmark pod name by finding match in topology
+// Pod names are like: ssc-1234z-benchmark-bd-0-0 (last -0 is StatefulSet replica index)
+let extractNodeNameFromBenchmarkPod (podName: string) (topology: Map<string, string array>) : string =
+    // Remove the StatefulSet replica suffix (-0) if present
+    let podNameWithoutReplica =
+        let parts = podName.Split('-')
+
+        if parts.Length > 0 && parts.[parts.Length - 1] = "0" then
+            // Remove the last "-0" (replica index)
+            String.Join("-", parts.[0..parts.Length - 2])
+        else
+            podName
+
+    // Extract the short name from the benchmark StatefulSet name
+    // Format after removing replica: {runId}-benchmark-{shortName}
+    if podNameWithoutReplica.Contains("-benchmark-") then
+        let benchmarkIndex = podNameWithoutReplica.IndexOf("-benchmark-")
+        let shortName = podNameWithoutReplica.Substring(benchmarkIndex + 11) // Length of "-benchmark-"
+
+        // Find the matching full node name in topology using the short name
+        topology
+        |> Map.toArray
+        |> Array.tryFind
+            (fun (fullName, _) ->
+                let nodeShortName = extractShortNameFromStellarCoreDns fullName
+                nodeShortName = shortName)
+        |> Option.map fst
+        |> Option.defaultValue podName
+    else
+        podName
+
+// Create a single headless service for all benchmark pods for DNS resolution
+let createBenchmarkHeadlessService (nCfg: NetworkCfg) (runId: string) : V1Service =
+    let metadata =
+        V1ObjectMeta(
+            name = sprintf "%s-benchmark" runId,
+            labels = benchmarkLabels,
+            namespaceProperty = nCfg.NamespaceProperty
+        )
+
+    let serviceSpec =
+        V1ServiceSpec(
+            clusterIP = "None",
+            selector = benchmarkLabels,
+            ports = [| V1ServicePort(name = "iperf3", port = 5201, protocol = "TCP") |]
+        )
+
+    V1Service(metadata = metadata, spec = serviceSpec)
+
+// Create StatefulSet for benchmark with the same topology as stellar-core sts
+//
+// Network Topology and Port Management:
+// ======================================
+// There is a benchmark pod per stellar-core pod, which contains a server and client
+// container. Since the network is p2p, each test will generate bidirectional load,
+// but there is still a "server" that need to do all the accounting work. To distribute this,
+// for each peer connection we randomize which node will be the server vs. client. This means
+// that for each peer connection, a pod will have either a server or client instance.
+//
+// Each pod has one server container and one client container, but they hold several
+// instances of each. To avoid port conflicts, we give each pod a unique index
+// and manage connections as follows:
+//
+// 1. SERVER CONTAINER:
+//    - Exposes ports for all nodes (otherwise DNS won't work)
+//    - Only starts iperf3 servers for peers that will connect to us
+//    - Server on port (5201 + i) accepts connections from the client peer with index i
+//    - All servers run concurrently in the background
+//
+// 2. CLIENT CONTAINER:
+//    - Starts a client instance per server peer
+//    - Each node's client uses its own pod index to connect to peer's server
+//
+// CONNECTION LOGIC:
+// - Each pod has a unique global index
+// - Each client connects to port (5201 + its_own_index) on all servers
+// - Only one node in each connection initiates a test as the server (determined by hash)
+//
+// NETWORK DELAYS AND DNS:
+// - Network delay container applies tc rules based on destination IPs
+// - All ports must be exposed in container spec for proper DNS/endpoint creation
+let createBenchmarkStatefulSet
+    (nCfg: NetworkCfg)
+    (runId: string)
+    (coreSetName: string)
+    (nodeName: string)
+    (peers: string array)
+    (sourcePeers: string array)
+    (globalNodeIndex: Map<string, int>)
+    (duration: int)
+    (coreSet: StellarCoreSet.CoreSet)
+    (nodeIndex: int)
+    : V1StatefulSet =
+
+    let shortName = extractShortNameFromStellarCoreDns nodeName
+    let stsName = sprintf "%s-benchmark-%s" runId shortName
+
+    // Pod template - contains:
+    // 1. Server container: multiple instances of iperf3 servers
+    // 2. Client container: multiple instances of iperf3 clients
+    //    - Note: number of Server + Client instances = number of peers
+    // 3. Network delay container (optional): applies geographic latency simulation via tc
+    let podTemplate =
+        let podMetadata =
+            V1ObjectMeta(
+                labels = Map.add "coreset" coreSetName benchmarkLabels,
+                annotations = Map.ofSeq [ "nodeIndex", nodeIndex.ToString() ]
+            )
+
+        // Server container
+        let serverContainer =
+            // We must expose all ports for Kubernetes service endpoint creation
+            let allPorts =
+                globalNodeIndex
+                |> Map.toArray
+                |> Array.map (fun (_, idx) -> V1ContainerPort(containerPort = 5201 + idx, protocol = "TCP"))
+
+            // Only start servers for peers that will actually connect to us
+            let serverCommands =
+                sourcePeers
+                |> Array.choose (fun peerName -> Map.tryFind peerName globalNodeIndex)
+                |> Array.map (fun idx -> sprintf "iperf3 -s -p %d &" (5201 + idx))
+                |> String.concat "\n"
+
+            V1Container(
+                name = "server",
+                image = benchmarkImage,
+                command = [| "/bin/sh" |],
+                args = [| "-c"; serverCommands + "\nwait" |],
+                ports = allPorts,
+                resources = SmallTestCoreResourceRequirements
+            )
+
+        // Client container
+        let clientContainer =
+            let nodeIdx = Map.find nodeName globalNodeIndex
+
+            // Transform stellar-core DNS names to benchmark pod short names
+            let benchmarkPeers =
+                peers
+                |> Array.map
+                    (fun peerDns ->
+                        // Extract the pod name from the DNS (everything before first dot)
+                        let podName = peerDns.Split('.').[0]
+                        extractShortNameFromStellarCoreDns podName)
+
+            let peerList = String.Join(",", benchmarkPeers)
+
+            let clientScriptTemplate =
+                let scriptPath =
+                    System.IO.Path.Combine(__SOURCE_DIRECTORY__, "..", "scripts", "start-benchmark-client.sh")
+
+                System.IO.File.ReadAllText(scriptPath)
+
+            let clientScript =
+                clientScriptTemplate
+                    .Replace("NODE_PLACEHOLDER", nodeName)
+                    .Replace("PEERS_PLACEHOLDER", peerList)
+                    .Replace("NAMESPACE_PLACEHOLDER", nCfg.NamespaceProperty)
+                    .Replace("DURATION_PLACEHOLDER", duration.ToString())
+                    .Replace("INDEX_PLACEHOLDER", nodeIdx.ToString())
+                    .Replace("RUN_ID_PLACEHOLDER", runId)
+                    .Replace("HEADLESS_SERVICE_PLACEHOLDER", sprintf "%s-benchmark" runId)
+
+            // Client script spins up instance per peer server
+            V1Container(
+                name = "client",
+                image = benchmarkImage,
+                command = [| "/bin/bash" |],
+                args = [| "-c"; clientScript |],
+                volumeMounts = [| V1VolumeMount(name = "results", mountPath = "/results") |],
+                resources = SmallTestCoreResourceRequirements
+            )
+
+        // Network delay container if needed
+        let containers =
+            if nCfg.NeedNetworkDelayScript then
+                let baseDelayScript = (nCfg.NetworkDelayScript coreSet nodeIndex).ToString()
+
+                // Use the same script to install delays as we do for stellar-core pods, but swap out the DNS patterns
+                // for the benchmark pods' DNS names.
+                let delayScript =
+                    let mutable modifiedScript = baseDelayScript
+
+                    // Pattern captures both the coreset name and the node name
+                    let pattern =
+                        @"(ssc-[a-z0-9]+-[a-z0-9]+-sts)-([a-z0-9\-]+)\.ssc-[a-z0-9]+-[a-z0-9]+-stellar-core\.[a-z0-9\-]+\.svc\.cluster\.local"
+
+                    // Replace stellar-core DNS names with benchmark pod DNS names
+                    // From: ssc-2128z-941b4e-sts-node-3-0.ssc-2128z-941b4e-stellar-core.namespace.svc.cluster.local
+                    // To:   ssc-613dz-benchmark-ssc-2128z-941b4e-sts-node-3-0-0.ssc-613dz-benchmark.namespace.svc.cluster.local
+                    modifiedScript <-
+                        System.Text.RegularExpressions.Regex.Replace(
+                            modifiedScript,
+                            pattern,
+                            fun m ->
+                                let coreSetPrefix = m.Groups.[1].Value
+                                let nodeName = m.Groups.[2].Value
+
+                                // Create the full benchmark pod DNS name
+                                sprintf
+                                    "%s-benchmark-%s-%s-0.%s-benchmark.%s.svc.cluster.local"
+                                    runId
+                                    coreSetPrefix
+                                    nodeName
+                                    runId
+                                    nCfg.NamespaceProperty
+                        )
+
+                    modifiedScript
+
+                let netdelayContainer =
+                    V1Container(
+                        name = "netdelay",
+                        image = nCfg.missionContext.netdelayImage,
+                        command = [| "sh" |],
+                        args = [| "-c"; delayScript |],
+                        resources = SmallTestCoreResourceRequirements,
+                        securityContext = V1SecurityContext(capabilities = V1Capabilities(add = [| "NET_ADMIN" |]))
+                    )
+
+                [| serverContainer; clientContainer; netdelayContainer |]
+            else
+                [| serverContainer; clientContainer |]
+
+        let volumes = [| V1Volume(name = "results", emptyDir = V1EmptyDirVolumeSource()) |]
+
+        V1PodTemplateSpec(
+            metadata = podMetadata,
+            spec =
+                V1PodSpec(
+                    containers = containers,
+                    volumes = volumes,
+                    shareProcessNamespace = System.Nullable<bool>(true)
+                )
+        )
+
+    let statefulSetSpec =
+        V1StatefulSetSpec(
+            selector = V1LabelSelector(matchLabels = Map.add "coreset" coreSetName benchmarkLabels),
+            serviceName = sprintf "%s-benchmark" runId, // Points to the headless service
+            podManagementPolicy = "Parallel",
+            template = podTemplate,
+            replicas = System.Nullable<int>(1)
+        )
+
+    V1StatefulSet(
+        metadata = V1ObjectMeta(name = stsName, labels = benchmarkLabels, namespaceProperty = nCfg.NamespaceProperty),
+        spec = statefulSetSpec
+    )

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="StellarFormation.fs" />
     <Compile Include="StellarRemoteCommandExec.fs" />
     <Compile Include="StellarDataDump.fs" />
+    <Compile Include="BenchmarkDaemonSet.fs" />
     <Compile Include="StellarStatefulSets.fs" />
     <Compile Include="StellarJobExec.fs" />
     <Compile Include="StellarSupercluster.fs" />

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -247,6 +247,8 @@ type StellarCoreCfg =
         if self.network.missionContext.enableBackgroundSigValidation then
             t.Add("EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION", true) |> ignore
 
+        t.Add("EXPERIMENTAL_TRIGGER_TIMER", true) |> ignore
+
         match self.network.missionContext.peerReadingCapacity, self.network.missionContext.peerFloodCapacity with
         | None, None -> ()
         | Some read, Some flood ->

--- a/src/FSLibrary/StellarDestination.fs
+++ b/src/FSLibrary/StellarDestination.fs
@@ -17,6 +17,8 @@ type Destination(path: string) =
         else
             Directory.CreateDirectory(path) |> ignore
 
+    member public self.GetFullPath(name: string) : string = Path.Combine [| path; name |]
+
     member public self.RemoveIfExists name =
         let fullPath = Path.Combine [| path; name |]
 

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -118,4 +118,7 @@ type MissionContext =
       enableRelaxedAutoQsetConfig: bool
       jobMonitorExternalHost: string option
       txBatchMaxSize: int option
-      runForMaxTps: string option }
+      runForMaxTps: string option
+      benchmarkInfrastructure: bool option
+      benchmarkInfrastructureOnly: bool option
+      benchmarkDurationSeconds: int option }

--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -248,18 +248,44 @@ type MissionContext with
         (checkConsistency: bool)
         (run: StellarFormation -> unit)
         : unit =
-        use formation = self.MakeFormation coreSetList passphrase
 
-        try
+        // If benchmark-only mode, run benchmark without creating stellar-core pods
+        if self.benchmarkInfrastructureOnly.IsSome
+           && self.benchmarkInfrastructureOnly.Value then
+            LogInfo "Running benchmark only"
+            // Create an empty formation just for the benchmark
+            let nCfg = MakeNetworkCfg self coreSetList passphrase
+            use formation = self.kube.MakeEmptyFormation nCfg
+            formation.RunP2PNetworkBenchmark()
+            LogInfo "Network benchmark complete. Exiting without running mission"
+            ()
+        else
+            // Run benchmark first if requested (before creating stellar-core pods)
+            if self.benchmarkInfrastructure.IsSome && self.benchmarkInfrastructure.Value then
+                LogInfo "Running network benchmark before creating stellar-core pods..."
+                let nCfg = MakeNetworkCfg self coreSetList passphrase
+                use benchFormation = self.kube.MakeEmptyFormation nCfg
+                benchFormation.RunP2PNetworkBenchmark()
+                LogInfo "Network benchmark complete. Waiting for system to stabilize..."
+
+                // Give the cluster 20 seconds to clean up and stabilize before spinning
+                // up core pods
+                System.Threading.Thread.Sleep(20000)
+                LogInfo "Now creating stellar-core pods..."
+
+            // Now create stellar-core formation and run the actual tests
+            use formation = self.MakeFormation coreSetList passphrase
+
             try
-                formation.WaitUntilReady()
-                run formation
-                if checkConsistency then formation.CheckNoErrorsAndPairwiseConsistency()
-            finally
-                formation.DumpData()
-        with x ->
-            (if self.keepData then formation.KeepData()
-             reraise ())
+                try
+                    formation.WaitUntilReady()
+                    run formation
+                    if checkConsistency then formation.CheckNoErrorsAndPairwiseConsistency()
+                finally
+                    formation.DumpData()
+            with x ->
+                (if self.keepData then formation.KeepData()
+                 reraise ())
 
     member self.Execute
         (coreSetList: CoreSet list)

--- a/src/scripts/parse_benchmark_results.py
+++ b/src/scripts/parse_benchmark_results.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""
+Parse iperf3 benchmark results from Kubernetes pods and generate network performance report.
+
+This script processes raw benchmark data collected from the P2P network infrastructure test
+using coordinated bidirectional iperf3 tests.
+
+Bidirectional Testing Architecture:
+- Each node pair tests only once using iperf3's --bidir flag (simultaneous bidirectional)
+- Test coordination uses hash-based distribution to determine which peer initiates test
+- Only the initiating node runs the iperf3 client; the peer runs the server
+- A single bidirectional test measures:
+  - Forward direction: initiator → peer (client to server)
+  - Reverse direction: peer → initiator (server to client)
+- Both nodes' metrics are updated from this single test result
+
+Input Format (via stdin):
+- JSON object containing:
+  - test_id: Unique identifier for this benchmark run
+  - pods: Array of pod data, each containing:
+    - name: Pod name
+    - node_name: Stellar-core node name
+    - logs: Pod logs (used to extract node name)
+    - kubectl_output: Raw concatenated iperf3 JSON results from /results/*.json
+  - topology: Map of node names to lists of peer FQDNs
+  - network_delay_enabled: Boolean indicating if network delays are configured
+
+iperf3 Bidirectional JSON Structure:
+Each bidirectional test produces a JSON object with:
+- "start": Test configuration and start time
+- "intervals": Per-second measurements for both directions
+- "end": Summary statistics including:
+  - "sum_sent": Forward direction bytes sent (initiator → peer)
+  - "sum_received": Forward direction bytes received at peer
+  - "sum_sent_bidir_reverse": Reverse direction bytes sent (peer → initiator)
+  - "sum_received_bidir_reverse": Reverse direction bytes received at initiator
+  - "streams": Array with per-stream statistics including RTT latency
+
+Processing Steps:
+1. Determine which peer would have initiated (hash-based distribution)
+2. Parse each pod's bidirectional iperf3 JSON results
+3. Aggregate metrics properly:
+   - Forward traffic: Add to initiator's send and peer's receive
+   - Reverse traffic: Add to peer's send and initiator's receive
+   - RTT measurements: Share between both nodes (bidirectional measurement)
+4. Calculate aggregate statistics:
+   - Per-node totals and per-peer averages
+   - Network-wide RTT statistics
+   - Validate network balance (total send ≈ total receive)
+5. Generate formatted report and save JSON results
+
+Output:
+- Formatted text report to stdout (displayed in logs)
+- JSON results file saved to destination/{test_id}.json
+- Network balance warnings if imbalance between total send and total receive exceeds 5%
+"""
+
+import json
+import sys
+import re
+import statistics
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+
+def parse_iperf3_json(json_str: str) -> Dict:
+    """Parse a single iperf3 JSON result from bidirectional test.
+
+    iperf3 bidirectional test output contains:
+    - sum_sent: Data sent in the forward direction (client to server)
+    - sum_received: Data received in the forward direction (at server)
+    - sum_sent_bidir_reverse: Data sent in reverse direction (server to client)
+    - sum_received_bidir_reverse: Data received in reverse (at client)
+    """
+    result = {
+        'send_mbps': 0.0,
+        'recv_mbps': 0.0,
+        'retransmits': 0,
+        'min_rtt_ms': None,
+        'mean_rtt_ms': None,
+        'max_rtt_ms': None,
+        'reverse_send_mbps': 0.0,
+        'reverse_recv_mbps': 0.0,
+        'error': None
+    }
+
+    try:
+        data = json.loads(json_str)
+
+        if 'error' in data and data['error']:
+            result['error'] = data['error']
+            return result
+
+        # Extract data from the 'end' section
+        if 'end' in data:
+            end = data['end']
+
+            # Forward direction throughput
+            if 'sum_sent' in end and end['sum_sent']:
+                if 'bits_per_second' in end['sum_sent']:
+                    result['send_mbps'] = end['sum_sent']['bits_per_second'] / 1_000_000
+                if 'retransmits' in end['sum_sent']:
+                    result['retransmits'] = end['sum_sent']['retransmits']
+
+            if 'sum_received' in end and end['sum_received']:
+                if 'bits_per_second' in end['sum_received']:
+                    result['recv_mbps'] = end['sum_received']['bits_per_second'] / 1_000_000
+
+            # Reverse direction throughput
+            if 'sum_sent_bidir_reverse' in end and end['sum_sent_bidir_reverse']:
+                if 'bits_per_second' in end['sum_sent_bidir_reverse']:
+                    result['reverse_send_mbps'] = end['sum_sent_bidir_reverse']['bits_per_second'] / 1_000_000
+
+            if 'sum_received_bidir_reverse' in end and end['sum_received_bidir_reverse']:
+                if 'bits_per_second' in end['sum_received_bidir_reverse']:
+                    result['reverse_recv_mbps'] = end['sum_received_bidir_reverse']['bits_per_second'] / 1_000_000
+
+            # Extract RTT statistics from streams
+            result.update(extract_rtt_from_streams(end.get('streams', [])))
+
+    except json.JSONDecodeError as e:
+        result['error'] = f"JSON parse error: {e}"
+    except Exception as e:
+        result['error'] = f"Unexpected error: {e}"
+
+    return result
+
+
+def extract_rtt_from_streams(streams: List[Dict]) -> Dict:
+    rtt_stats = {'min_rtt_ms': None, 'mean_rtt_ms': None, 'max_rtt_ms': None}
+
+    rtts = {'min': [], 'mean': [], 'max': []}
+    for stream in streams:
+        if 'sender' in stream and stream['sender']:
+            sender = stream['sender']
+            if 'min_rtt' in sender and sender['min_rtt'] is not None:
+                rtts['min'].append(sender['min_rtt'] / 1000.0)
+            if 'mean_rtt' in sender and sender['mean_rtt'] is not None:
+                rtts['mean'].append(sender['mean_rtt'] / 1000.0)
+            if 'max_rtt' in sender and sender['max_rtt'] is not None:
+                rtts['max'].append(sender['max_rtt'] / 1000.0)
+
+    # Aggregate RTT stats: min of mins, mean of means, max of maxs
+    if rtts['min']:
+        rtt_stats['min_rtt_ms'] = min(rtts['min'])
+    if rtts['mean']:
+        rtt_stats['mean_rtt_ms'] = statistics.mean(rtts['mean'])
+    if rtts['max']:
+        rtt_stats['max_rtt_ms'] = max(rtts['max'])
+
+    return rtt_stats
+
+
+def should_node_initiate_test(node1: str, node2: str) -> bool:
+    """Determine which node should initiate the test using hash-based distribution.
+
+    This provides better load balancing so we have a roughly equal number of servers per node.
+    """
+    # Calculate hash values for both nodes
+    node1_hash = sum(ord(c) for c in node1)
+    node2_hash = sum(ord(c) for c in node2)
+    combined = node1_hash ^ node2_hash
+
+    # Use XOR to determine initiator for balanced distribution
+    if combined % 2 == 0:
+        # Even: lower hash initiates
+        should_initiate = node1_hash < node2_hash
+    else:
+        # Odd: higher hash initiates
+        should_initiate = node1_hash > node2_hash
+
+    # Fallback to lexicographic if hashes are equal since we're just summing string chars
+    if node1_hash == node2_hash:
+        should_initiate = node1 < node2
+
+    return should_initiate
+
+
+def aggregate_bidirectional_results(all_pods_data: List[Dict], topology: Dict[str, List[str]]) -> Dict[str, Dict]:
+    """Aggregate bidirectional test results.
+
+    When node A runs a bidirectional test to node B:
+    - Forward (A→B): Counts as A's send and B's receive
+    - Reverse (B→A): Counts as B's send and A's receive
+    """
+    # Initialize metrics for all nodes
+    node_metrics = {}
+    for pod_data in all_pods_data:
+        node_name = pod_data.get('node_name', pod_data.get('name', 'unknown'))
+        if node_name not in node_metrics:
+            node_metrics[node_name] = {
+                'total_send_mbps': 0.0,
+                'total_recv_mbps': 0.0,
+                'peer_count': 0,
+                'min_rtt_ms': None,
+                'mean_rtt_ms': [],
+                'max_rtt_ms': None,
+                'total_retransmits': 0,
+                'connection_failures': 0
+            }
+
+    # Process test results from each pod
+    for pod_data in all_pods_data:
+        initiator_node = pod_data.get('node_name', pod_data.get('name', 'unknown'))
+        kubectl_output = pod_data.get('kubectl_output', '')
+
+        if not kubectl_output or '"end"' not in kubectl_output:
+            continue
+
+        # Get peers for this node and determine which tests it would initiate
+        node_peers = topology.get(initiator_node, [])
+        tested_peers = []
+
+        for peer_fqdn in node_peers:
+            peer_node = peer_fqdn.split('.')[0] if '.' in peer_fqdn else peer_fqdn
+            if should_node_initiate_test(initiator_node, peer_node):
+                tested_peers.append(peer_fqdn)
+
+        # Parse all test results from this node's output
+        parts = kubectl_output.replace('}\n{', '}###SPLIT###{').split('###SPLIT###')
+        test_results = []
+
+        for part in parts:
+            if '"end"' in part and '"start"' in part:
+                result = parse_iperf3_json(part)
+                if not result['error']:
+                    test_results.append(result)
+
+        # Match results to peers and aggregate metrics
+        for i, result in enumerate(test_results):
+            if i < len(tested_peers):
+                peer_fqdn = tested_peers[i]
+                peer_node = peer_fqdn.split('.')[0] if '.' in peer_fqdn else peer_fqdn
+
+                # Forward direction: initiator → peer
+                node_metrics[initiator_node]['total_send_mbps'] += result['send_mbps']
+                if peer_node in node_metrics:
+                    node_metrics[peer_node]['total_recv_mbps'] += result['send_mbps']
+
+                # Reverse direction: peer → initiator
+                reverse_throughput = result.get('reverse_recv_mbps', 0) or result.get('reverse_send_mbps', 0)
+                if peer_node in node_metrics and reverse_throughput > 0:
+                    node_metrics[peer_node]['total_send_mbps'] += reverse_throughput
+                    node_metrics[initiator_node]['total_recv_mbps'] += reverse_throughput
+
+                # RTT measurements (bidirectional, so both nodes get the same values)
+                update_rtt_metrics(node_metrics[initiator_node], result)
+                if peer_node in node_metrics:
+                    update_rtt_metrics(node_metrics[peer_node], result)
+
+                # Retransmits are counted only for the initiator
+                node_metrics[initiator_node]['total_retransmits'] += result['retransmits']
+
+    # Finalize metrics and calculate aggregates
+    finalize_node_metrics(node_metrics, topology)
+    validate_network_balance(node_metrics)
+
+    return node_metrics
+
+
+def update_rtt_metrics(node_metrics: Dict, result: Dict):
+    """Update RTT metrics for a node based on test results."""
+    if result['mean_rtt_ms'] is not None:
+        node_metrics['mean_rtt_ms'].append(result['mean_rtt_ms'])
+
+    if result['min_rtt_ms'] is not None:
+        if node_metrics['min_rtt_ms'] is None:
+            node_metrics['min_rtt_ms'] = result['min_rtt_ms']
+        else:
+            node_metrics['min_rtt_ms'] = min(node_metrics['min_rtt_ms'], result['min_rtt_ms'])
+
+    if result['max_rtt_ms'] is not None:
+        if node_metrics['max_rtt_ms'] is None:
+            node_metrics['max_rtt_ms'] = result['max_rtt_ms']
+        else:
+            node_metrics['max_rtt_ms'] = max(node_metrics['max_rtt_ms'], result['max_rtt_ms'])
+
+
+def finalize_node_metrics(node_metrics: Dict[str, Dict], topology: Dict[str, List[str]]):
+    """Finalize node metrics by calculating aggregates and setting peer counts."""
+    for node_name, node in node_metrics.items():
+        # Set actual peer count from topology
+        if node['total_send_mbps'] > 0 or node['total_recv_mbps'] > 0:
+            node['peer_count'] = len(topology.get(node_name, []))
+
+        # Calculate mean RTT from collected samples
+        if node['mean_rtt_ms']:
+            rtts = node['mean_rtt_ms']
+            node['mean_rtt_ms'] = statistics.mean(rtts) if rtts else None
+        else:
+            node['mean_rtt_ms'] = None
+
+
+def validate_network_balance(node_metrics: Dict[str, Dict]):
+    """Validate that total network send approximately equals total receive."""
+    total_network_send = sum(node['total_send_mbps'] for node in node_metrics.values())
+    total_network_recv = sum(node['total_recv_mbps'] for node in node_metrics.values())
+
+    if total_network_send > 0:
+        imbalance_percent = abs(total_network_send - total_network_recv) / total_network_send * 100
+        if imbalance_percent > 5.0:  # Alert if more than 5% imbalance
+            print(f"WARNING: Network imbalance detected! Total send: {total_network_send:.1f} Mbps, "
+                  f"Total recv: {total_network_recv:.1f} Mbps ({imbalance_percent:.2f}% imbalance)", 
+                  file=sys.stderr)
+            print("This may indicate a bug in the benchmark coordination or severe packet loss.", 
+                  file=sys.stderr)
+
+
+def format_benchmark_results(results: List[Dict], test_id: str, network_delay_enabled: bool, duration_seconds: int = None) -> str:
+    """Format benchmark results for display."""
+    # Calculate aggregate metrics
+    total_nodes = len(results)
+    total_connections = sum(r['peer_count'] for r in results)
+    avg_peers = statistics.mean([r['peer_count'] for r in results]) if results else 0
+
+    # Filter valid results, we use -1 as the placeholder for no data
+    valid_results = [r for r in results if r['total_send_mbps'] > 0 or r['total_recv_mbps'] > 0]
+
+    # Calculate performance averages
+    if valid_results:
+        avg_send_total = statistics.mean([r['total_send_mbps'] for r in valid_results])
+        avg_recv_total = statistics.mean([r['total_recv_mbps'] for r in valid_results])
+
+        # Per-peer averages
+        per_peer_sends = [r['total_send_mbps'] / r['peer_count'] 
+                          for r in valid_results if r['peer_count'] > 0]
+        per_peer_recvs = [r['total_recv_mbps'] / r['peer_count'] 
+                          for r in valid_results if r['peer_count'] > 0]
+
+        avg_send_per_peer = statistics.mean(per_peer_sends) if per_peer_sends else 0
+        avg_recv_per_peer = statistics.mean(per_peer_recvs) if per_peer_recvs else 0
+
+        # RTT statistics
+        min_rtts = [r['min_rtt_ms'] for r in valid_results if r.get('min_rtt_ms') is not None]
+        mean_rtts = [r['mean_rtt_ms'] for r in valid_results if r.get('mean_rtt_ms') is not None]
+        max_rtts = [r['max_rtt_ms'] for r in valid_results if r.get('max_rtt_ms') is not None]
+
+        overall_min_rtt = min(min_rtts) if min_rtts else 0
+        overall_mean_rtt = statistics.mean(mean_rtts) if mean_rtts else 0
+        overall_max_rtt = max(max_rtts) if max_rtts else 0
+    else:
+        avg_send_total = avg_recv_total = 0
+        avg_send_per_peer = avg_recv_per_peer = 0
+        overall_min_rtt = overall_mean_rtt = overall_max_rtt = 0
+
+    # Format individual node results
+    node_lines = []
+    for r in results:
+        if r['total_send_mbps'] < 0 and r['total_recv_mbps'] < 0:
+            # No data for this node
+            node_lines.append(f"  {r['node_name']}: N/A send, N/A recv, N/A RTT, N/A retransmits")
+        else:
+            # Format per-peer throughput info
+            per_peer_info = ""
+            if r['peer_count'] > 0 and (r['total_send_mbps'] > 0 or r['total_recv_mbps'] > 0):
+                per_peer_send = r['total_send_mbps'] / r['peer_count']
+                per_peer_recv = r['total_recv_mbps'] / r['peer_count']
+                per_peer_info = f" ({per_peer_send:.1f}/{per_peer_recv:.1f} Mbps per peer)"
+
+            # Format RTT info
+            rtt_info = (f"{r['mean_rtt_ms']:.2f} ms mean RTT" 
+                       if r.get('mean_rtt_ms') is not None else "N/A RTT")
+
+            node_lines.append(
+                f"  {r['node_name']}: {r['total_send_mbps']:.1f} Mbps send, "
+                f"{r['total_recv_mbps']:.1f} Mbps recv{per_peer_info}, "
+                f"{rtt_info}, "
+                f"{r['total_retransmits']} retransmits"
+            )
+
+    total_failures = sum(r['connection_failures'] for r in results)
+    timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+
+    return f"""
+===============================================
+Network Infrastructure Benchmark Results
+===============================================
+Test ID: {test_id}
+Timestamp: {timestamp}
+
+Infrastructure Configuration:
+- Nodes: {total_nodes}
+- Average peers per node: {avg_peers:.1f}
+- Total connections: {total_connections}
+- Test duration: {duration_seconds if duration_seconds else 'N/A'} seconds
+- Network delays: {'enabled' if network_delay_enabled else 'disabled'}
+
+Aggregate Performance Metrics:
+- Connection failures: {total_failures}
+- Average total throughput per node: {avg_send_total:.1f} Mbps send, {avg_recv_total:.1f} Mbps recv
+- Average per-peer throughput: {avg_send_per_peer:.1f} Mbps send, {avg_recv_per_peer:.1f} Mbps recv
+
+RTT Latency Statistics (across all nodes):
+- Minimum: {overall_min_rtt:.2f} ms
+- Mean: {overall_mean_rtt:.2f} ms
+- Maximum: {overall_max_rtt:.2f} ms
+
+Individual Node Results:
+{chr(10).join(node_lines)}
+===============================================
+"""
+
+
+def main():
+    # Read input JSON from stdin
+    try:
+        input_json = sys.stdin.read()
+        input_data = json.loads(input_json)
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse input JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Failed to read input: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Extract node names from pod logs
+    for pod_data in input_data['pods']:
+        logs = pod_data.get('logs', '')
+        node_match = re.search(r'Node (\S+) running', logs)
+        if node_match:
+            pod_data['node_name'] = node_match.group(1)
+        else:
+            pod_data['node_name'] = pod_data['name']
+
+    # Aggregate test results
+    node_metrics = aggregate_bidirectional_results(
+        input_data['pods'],
+        input_data['topology']
+    )
+
+    # Convert to results format
+    results = []
+    for node_name, metrics in node_metrics.items():
+        results.append({
+            'node_name': node_name,
+            'peer_count': metrics['peer_count'],
+            'total_send_mbps': metrics['total_send_mbps'] if metrics['total_send_mbps'] > 0 else -1,
+            'total_recv_mbps': metrics['total_recv_mbps'] if metrics['total_recv_mbps'] > 0 else -1,
+            'total_retransmits': metrics['total_retransmits'],
+            'min_rtt_ms': metrics['min_rtt_ms'],
+            'mean_rtt_ms': metrics['mean_rtt_ms'],
+            'max_rtt_ms': metrics['max_rtt_ms'],
+            'connection_failures': metrics['connection_failures']
+        })
+
+    # Format and print results
+    formatted = format_benchmark_results(
+        results,
+        input_data['test_id'],
+        input_data.get('network_delay_enabled', False),
+        input_data.get('duration_seconds')
+    )
+
+    print(formatted)
+
+    # Also output JSON for saving to destination folder
+    output = {
+        'test_id': input_data['test_id'],
+        'results': results,
+        'formatted_output': formatted
+    }
+
+    # Write JSON to a file if destination is provided
+    import os
+    dest_file = os.path.join('destination', f"{input_data['test_id']}.json")
+    os.makedirs('destination', exist_ok=True)
+    with open(dest_file, 'w') as f:
+        json.dump(output, f, indent=2)
+
+    # Print destination file path to stderr so F# can log it
+    print(f"RESULTS_FILE: {dest_file}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/scripts/start-benchmark-client.sh
+++ b/src/scripts/start-benchmark-client.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Benchmark Client Pod Script
+# ============================
+# Starts iperf3 clients in a pod, one for each peer who is running an iperf3 server.
+#
+# Template Variables (replaced by F# before deployment):
+#   NODE_PLACEHOLDER - The name of this node
+#   PEERS_PLACEHOLDER - Comma-separated list of peer short names
+#   NAMESPACE_PLACEHOLDER - Kubernetes namespace
+#   DURATION_PLACEHOLDER - Test duration in seconds
+#   INDEX_PLACEHOLDER - Global node index for port selection
+#   RUN_ID_PLACEHOLDER - Unique run identifier
+#   HEADLESS_SERVICE_PLACEHOLDER - Name of the headless service (without namespace)
+
+NODE='NODE_PLACEHOLDER'
+PEERS='PEERS_PLACEHOLDER'
+NAMESPACE='NAMESPACE_PLACEHOLDER'
+DURATION=DURATION_PLACEHOLDER
+INDEX=INDEX_PLACEHOLDER
+RUN_ID='RUN_ID_PLACEHOLDER'
+HEADLESS_SERVICE='HEADLESS_SERVICE_PLACEHOLDER'
+
+echo "Node $NODE running benchmark to peers: $PEERS"
+mkdir -p /results
+
+# Wait for servers to be ready and DNS to propagate
+echo "Waiting 10 seconds for all servers to start and DNS to propagate..."
+sleep 10
+
+# Parse peer list
+IFS=',' read -ra PEER_ARRAY <<< "$PEERS"
+
+# Run iperf3 clients for each peer
+for PEER_DNS in "${PEER_ARRAY[@]}"; do
+    if [ -z "$PEER_DNS" ]; then continue; fi
+
+    PEER_SHORT="$PEER_DNS"
+
+    # Skip self-connections
+    NODE_SHORT=$(echo "$NODE" | rev | cut -d'-' -f1-2 | rev)
+    if [ "$PEER_SHORT" = "$NODE_SHORT" ]; then
+        echo "Skipping self-connection to $PEER_SHORT"
+        continue
+    fi
+
+    echo "Processing peer: $PEER_SHORT"
+
+    # Unique port based on our global index
+    SEND_PORT=$((5201 + INDEX))
+
+    # Use StatefulSet DNS pattern
+    PEER_DNS_NAME="$RUN_ID-benchmark-${PEER_SHORT}-0.$HEADLESS_SERVICE.$NAMESPACE.svc.cluster.local"
+
+    echo "Testing to $PEER_DNS_NAME on port $SEND_PORT"
+
+    # Run bidirectional test
+    iperf3 -c $PEER_DNS_NAME \
+           -p $SEND_PORT \
+           -t $DURATION \
+           --bidir \
+           -J > /results/result-$PEER_SHORT-bidir.json 2>&1
+
+    echo "Completed test to $PEER_SHORT"
+done
+
+echo "All tests completed"
+sleep infinity


### PR DESCRIPTION
## Overview

This PR introduces a network infrastructure benchmark that measures network performance of supercluster without actually running stellar-core. It installs an identical network topology, with the same peer to peer overlay, ingress, DNS, and artificial delay, but instead of running stellar-core containers, it runs iperf3 containers for a network stress test. All nodes flood as much bandwidth as possible to all their peers at the same time bidirectionally to simulate p2p networking. We then report bandwidth and latency as reported by iperf3. This test can be run standalone, or immediately before any ssc mission. We might want to add this to our MaxTPS flow for example to have a better idea of cluster variance run to run.

## Usage

`--benchmark-infra true` flag will enable the network test prior to the superclsuter mission. if ` --benchmark-only` is set, the test will exit after running just the network load test. `--benchmark-duration-seconds` determines how long to generate load for the stress tests and defaults to 30 seconds.

Example output:
```
Infrastructure Configuration:
- Nodes: 7
- Average peers per node: 6.0
- Total connections: 42
- Test duration: 30 seconds
- Network delays: enabled

Aggregate Performance Metrics:
- Connection failures: 0
- Average total throughput per node: 818.5 Mbps send, 818.5 Mbps recv
- Average per-peer throughput: 136.4 Mbps send, 136.4 Mbps recv

RTT Latency Statistics (across all nodes):
- Minimum: 12.34 ms
- Mean: 131.99 ms
- Maximum: 182.24 ms

Individual Node Results:
  ssc-2203z-138f5d-sts-lo-0: 101.5 Mbps send, 89.7 Mbps recv (16.9/15.0 Mbps per peer), 235.03 ms mean RTT, 2 retransmits
  ssc-2203z-138f5d-sts-node-0-0: 366.4 Mbps send, 365.3 Mbps recv (61.1/60.9 Mbps per peer), 164.57 ms mean RTT, 0 retransmits
  ssc-2203z-138f5d-sts-node-1-0: 659.5 Mbps send, 660.4 Mbps recv (109.9/110.1 Mbps per peer), 122.68 ms mean RTT, 37 retransmits
  ...
```

## Design

### Bidirectional Performance Testing via iper3
- Uses **iperf3's `--bidir` flag** to run simultaneous bidirectional tests between node pairs
- All pods submit maximum load to all peers at the same time to stress network
- Each connection has it's own server/client

### Topology Mirroring
- Creates one benchmark pod for each stellar-core node
- Maintains identical peer connections as defined in the stellar-core configuration
- Applies same network delays as stellar-core pods
- Uses same ingress and DNS service as stellar-core pods

### Pod Structure
Each benchmark pod contains three containers:

1. **Server Container**
   - Runs multiple iperf3 server instances (one per incoming peer connection)
   - Each server listens on port `5201 + source_node_index`, where each node has a unique index

2. **Client Container**
   - Runs client for all peers running a server
   -  Attempts to connect to server it's own node id as port

3. **Network Delay Container** (optional)
   - Applies geographic latency simulation via `tc` rules
   - Mirrors the exact delay configuration from stellar-core pods
   - Transforms DNS names from stellar-core pattern to benchmark pod pattern

Since there is some overhead in running a server vs. a client, we use a hash of
each pod name in a given connection to randomly decide who will be the client vs.
server for that particular connection. 

### Results Parsing
- Python script (`parse_benchmark_results.py`) processes raw iperf3 JSON output
- Aggregates metrics across all nodes and connections
- Calculates statistics including:
  - Per-node and per-peer throughput (send/receive)
  - RTT latency (min/mean/max)
  - TCP retransmit counts
  - Connection failure detection
- Outputs both human-readable summary and writes more detailed stats to JSON


## Observations from EKS cluster:

Here are a few samples I collected from a few different topologies, all with 5 minute runs each:

Small, 7 node topology: theoretical-max-tps.json 

```
Test ID: benchmark-20250829-220025
Timestamp: 2025-08-29 22:00:29

Infrastructure Configuration:
- Nodes: 7
- Average peers per node: 6.0
- Total connections: 42
- Test duration: 300 seconds
- Network delays: enabled

Aggregate Performance Metrics:
- Connection failures: 0
- Average total throughput per node: 1326.8 Mbps send, 1326.8 Mbps recv
- Average per-peer throughput: 221.1 Mbps send, 221.1 Mbps recv

RTT Latency Statistics (across all nodes):
- Minimum: 12.36 ms
- Mean: 127.90 ms
- Maximum: 189.08 ms

Individual Node Results:
  ssc-2155z-ca4b08-sts-lo-0: 195.4 Mbps send, 195.0 Mbps recv (32.6/32.5 Mbps per peer), 124.95 ms mean RTT, 0 retransmits
  ssc-2155z-ca4b08-sts-node-0-0: 2288.0 Mbps send, 2331.4 Mbps recv (381.3/388.6 Mbps per peer), 82.67 ms mean RTT, 0 retransmits
  ssc-2155z-ca4b08-sts-node-1-0: 150.2 Mbps send, 150.2 Mbps recv (25.0/25.0 Mbps per peer), 162.38 ms mean RTT, 0 retransmits
  ssc-2155z-ca4b08-sts-node-2-0: 133.0 Mbps send, 133.3 Mbps recv (22.2/22.2 Mbps per peer), 182.92 ms mean RTT, 0 retransmits
  ssc-2155z-ca4b08-sts-node-3-0: 3981.8 Mbps send, 3908.1 Mbps recv (663.6/651.3 Mbps per peer), 62.55 ms mean RTT, 116 retransmits
  ssc-2155z-ca4b08-sts-pn-0: 2389.4 Mbps send, 2419.9 Mbps recv (398.2/403.3 Mbps per peer), 117.20 ms mean RTT, 209 retransmits
  ssc-2155z-ca4b08-sts-sdf-0: 149.8 Mbps send, 149.9 Mbps recv (25.0/25.0 Mbps per peer), 162.62 ms mean RTT, 3 retransmits
```

Default, 22 node topology:

```
Test ID: benchmark-20250829-221505
Timestamp: 2025-08-29 22:15:17

Infrastructure Configuration:
- Nodes: 23
- Average peers per node: 22.0
- Total connections: 506
- Test duration: 300 seconds
- Network delays: enabled

Aggregate Performance Metrics:
- Connection failures: 0
- Average total throughput per node: 706.6 Mbps send, 706.6 Mbps recv
- Average per-peer throughput: 32.1 Mbps send, 32.1 Mbps recv

RTT Latency Statistics (across all nodes):
- Minimum: 6.55 ms
- Mean: 114.80 ms
- Maximum: 235.05 ms

Individual Node Results:
  ssc-2209z-ebe1ea-sts-bd-0: 3664.7 Mbps send, 2449.5 Mbps recv (166.6/111.3 Mbps per peer), 140.58 ms mean RTT, 76 retransmits
  ssc-2209z-ebe1ea-sts-bd-1: 6322.6 Mbps send, 4089.7 Mbps recv (287.4/185.9 Mbps per peer), 91.09 ms mean RTT, 45 retransmits
  ssc-2209z-ebe1ea-sts-bd-2: 234.9 Mbps send, 255.7 Mbps recv (10.7/11.6 Mbps per peer), 171.12 ms mean RTT, 42 retransmits
  ssc-2209z-ebe1ea-sts-cq-0: 543.7 Mbps send, 1032.1 Mbps recv (24.7/46.9 Mbps per peer), 15.90 ms mean RTT, 312 retransmits
  ssc-2209z-ebe1ea-sts-cq-1: 363.1 Mbps send, 592.3 Mbps recv (16.5/26.9 Mbps per peer), 36.14 ms mean RTT, 121 retransmits
  ssc-2209z-ebe1ea-sts-cq-2: 104.0 Mbps send, 123.2 Mbps recv (4.7/5.6 Mbps per peer), 189.21 ms mean RTT, 42 retransmits
  ssc-2209z-ebe1ea-sts-kb-0: 143.7 Mbps send, 174.3 Mbps recv (6.5/7.9 Mbps per peer), 128.64 ms mean RTT, 69 retransmits
  ssc-2209z-ebe1ea-sts-kb-1: 789.1 Mbps send, 1384.6 Mbps recv (35.9/62.9 Mbps per peer), 9.38 ms mean RTT, 597 retransmits
  ssc-2209z-ebe1ea-sts-kb-2: 113.9 Mbps send, 141.1 Mbps recv (5.2/6.4 Mbps per peer), 163.05 ms mean RTT, 53 retransmits
  ssc-2209z-ebe1ea-sts-lo-0: 175.7 Mbps send, 181.5 Mbps recv (8.0/8.2 Mbps per peer), 124.91 ms mean RTT, 44 retransmits
  ssc-2209z-ebe1ea-sts-lo-1: 116.8 Mbps send, 147.0 Mbps recv (5.3/6.7 Mbps per peer), 159.73 ms mean RTT, 59 retransmits
  ssc-2209z-ebe1ea-sts-lo-2: 555.0 Mbps send, 1300.8 Mbps recv (25.2/59.1 Mbps per peer), 16.00 ms mean RTT, 309 retransmits
  ssc-2209z-ebe1ea-sts-lo-3: 293.3 Mbps send, 614.1 Mbps recv (13.3/27.9 Mbps per peer), 38.65 ms mean RTT, 102 retransmits
  ssc-2209z-ebe1ea-sts-lo-4: 89.4 Mbps send, 108.0 Mbps recv (4.1/4.9 Mbps per peer), 218.20 ms mean RTT, 69 retransmits
  ssc-2209z-ebe1ea-sts-sdf-0: 140.8 Mbps send, 183.3 Mbps recv (6.4/8.3 Mbps per peer), 130.97 ms mean RTT, 73 retransmits
  ssc-2209z-ebe1ea-sts-sdf-1: 152.8 Mbps send, 177.1 Mbps recv (6.9/8.1 Mbps per peer), 132.72 ms mean RTT, 48 retransmits
  ssc-2209z-ebe1ea-sts-sdf-2: 158.3 Mbps send, 185.6 Mbps recv (7.2/8.4 Mbps per peer), 131.62 ms mean RTT, 64 retransmits
  ssc-2209z-ebe1ea-sts-sp-0: 133.1 Mbps send, 143.8 Mbps recv (6.0/6.5 Mbps per peer), 147.18 ms mean RTT, 31 retransmits
  ssc-2209z-ebe1ea-sts-sp-1: 786.0 Mbps send, 1219.1 Mbps recv (35.7/55.4 Mbps per peer), 9.28 ms mean RTT, 542 retransmits
  ssc-2209z-ebe1ea-sts-sp-2: 94.1 Mbps send, 106.9 Mbps recv (4.3/4.9 Mbps per peer), 215.48 ms mean RTT, 39 retransmits
  ssc-2209z-ebe1ea-sts-wx-0: 129.1 Mbps send, 149.3 Mbps recv (5.9/6.8 Mbps per peer), 145.90 ms mean RTT, 55 retransmits
  ssc-2209z-ebe1ea-sts-wx-1: 1058.4 Mbps send, 1389.4 Mbps recv (48.1/63.2 Mbps per peer), 10.14 ms mean RTT, 447 retransmits
  ssc-2209z-ebe1ea-sts-wx-2: 89.2 Mbps send, 103.4 Mbps recv (4.1/4.7 Mbps per peer), 214.52 ms mean RTT, 62 retransmits
```

Larger, 100 node topology:

```
Test ID: benchmark-20250829-222154
Timestamp: 2025-08-29 22:22:47

Infrastructure Configuration:
- Nodes: 100
- Average peers per node: 9.0
- Total connections: 898
- Test duration: 300 seconds
- Network delays: enabled

Aggregate Performance Metrics:
- Connection failures: 0
- Average total throughput per node: 1323.8 Mbps send, 1323.8 Mbps recv
- Average per-peer throughput: 155.9 Mbps send, 155.8 Mbps recv

RTT Latency Statistics (across all nodes):
- Minimum: 0.02 ms
- Mean: 122.33 ms
- Maximum: 383.83 ms

Individual Node Results:
  ssc-2216z-f2eecd-sts-bd-0: 284.1 Mbps send, 287.8 Mbps recv (31.6/32.0 Mbps per peer), 178.45 ms mean RTT, 4 retransmits
  ssc-2216z-f2eecd-sts-bd-1: 2915.4 Mbps send, 2408.7 Mbps recv (971.8/802.9 Mbps per peer), 4.03 ms mean RTT, 606 retransmits
  ssc-2216z-f2eecd-sts-bd-2: 132.9 Mbps send, 161.8 Mbps recv (19.0/23.1 Mbps per peer), 113.19 ms mean RTT, 118 retransmits
  ssc-2216z-f2eecd-sts-cq-0: 125.4 Mbps send, 97.0 Mbps recv (12.5/9.7 Mbps per peer), 183.87 ms mean RTT, 88 retransmits
  ssc-2216z-f2eecd-sts-cq-1: 173.3 Mbps send, 192.0 Mbps recv (24.8/27.4 Mbps per peer), 113.52 ms mean RTT, 54 retransmits
  ssc-2216z-f2eecd-sts-cq-2: 214.3 Mbps send, 195.5 Mbps recv (35.7/32.6 Mbps per peer), 75.15 ms mean RTT, 106 retransmits
  ssc-2216z-f2eecd-sts-lo-0: 202.0 Mbps send, 202.2 Mbps recv (67.3/67.4 Mbps per peer), 91.90 ms mean RTT, 17 retransmits
  ssc-2216z-f2eecd-sts-lo-1: 1149.8 Mbps send, 1354.5 Mbps recv (115.0/135.5 Mbps per peer), 87.40 ms mean RTT, 71 retransmits
  ssc-2216z-f2eecd-sts-lo-2: 130.9 Mbps send, 123.9 Mbps recv (21.8/20.6 Mbps per peer), 119.96 ms mean RTT, 46 retransmits
  ssc-2216z-f2eecd-sts-lo-3: 169.2 Mbps send, 168.8 Mbps recv (33.8/33.8 Mbps per peer), 126.65 ms mean RTT, 8 retransmits
  ssc-2216z-f2eecd-sts-lo-4: 1547.8 Mbps send, 1705.3 Mbps recv (386.9/426.3 Mbps per peer), 35.91 ms mean RTT, 150 retransmits
  ssc-2216z-f2eecd-sts-node-0-0: 2897.9 Mbps send, 3385.5 Mbps recv (414.0/483.6 Mbps per peer), 80.58 ms mean RTT, 26 retransmits
  ssc-2216z-f2eecd-sts-node-1-0: 2587.1 Mbps send, 2599.7 Mbps recv (199.0/200.0 Mbps per peer), 112.59 ms mean RTT, 26 retransmits
  ssc-2216z-f2eecd-sts-node-10-0: 1241.1 Mbps send, 1231.5 Mbps recv (103.4/102.6 Mbps per peer), 119.64 ms mean RTT, 36 retransmits
  ssc-2216z-f2eecd-sts-node-11-0: 148.5 Mbps send, 130.9 Mbps recv (14.8/13.1 Mbps per peer), 114.16 ms mean RTT, 42 retransmits
  ssc-2216z-f2eecd-sts-node-12-0: 170.2 Mbps send, 177.5 Mbps recv (24.3/25.4 Mbps per peer), 76.75 ms mean RTT, 48 retransmits
  ssc-2216z-f2eecd-sts-node-13-0: 135.2 Mbps send, 122.2 Mbps recv (19.3/17.5 Mbps per peer), 93.27 ms mean RTT, 42 retransmits
  ssc-2216z-f2eecd-sts-node-14-0: 136.7 Mbps send, 134.2 Mbps recv (17.1/16.8 Mbps per peer), 158.04 ms mean RTT, 9 retransmits
  ssc-2216z-f2eecd-sts-node-15-0: 136.0 Mbps send, 126.6 Mbps recv (12.4/11.5 Mbps per peer), 105.56 ms mean RTT, 8 retransmits
  ssc-2216z-f2eecd-sts-node-16-0: 243.9 Mbps send, 254.3 Mbps recv (17.4/18.2 Mbps per peer), 168.79 ms mean RTT, 39 retransmits
  ssc-2216z-f2eecd-sts-node-17-0: 102.5 Mbps send, 95.4 Mbps recv (11.4/10.6 Mbps per peer), 149.20 ms mean RTT, 88 retransmits
  ssc-2216z-f2eecd-sts-node-18-0: 179.0 Mbps send, 187.2 Mbps recv (29.8/31.2 Mbps per peer), 67.64 ms mean RTT, 42 retransmits
  ssc-2216z-f2eecd-sts-node-19-0: 160.6 Mbps send, 169.4 Mbps recv (22.9/24.2 Mbps per peer), 107.70 ms mean RTT, 5 retransmits
  ssc-2216z-f2eecd-sts-node-2-0: 2521.3 Mbps send, 2097.7 Mbps recv (252.1/209.8 Mbps per peer), 65.67 ms mean RTT, 53 retransmits
  ssc-2216z-f2eecd-sts-node-20-0: 369.0 Mbps send, 391.3 Mbps recv (26.4/27.9 Mbps per peer), 80.67 ms mean RTT, 24 retransmits
  ssc-2216z-f2eecd-sts-node-21-0: 163.2 Mbps send, 161.2 Mbps recv (18.1/17.9 Mbps per peer), 78.92 ms mean RTT, 13 retransmits
  ssc-2216z-f2eecd-sts-node-22-0: 277.2 Mbps send, 277.1 Mbps recv (30.8/30.8 Mbps per peer), 191.86 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-23-0: 3822.5 Mbps send, 3807.0 Mbps recv (347.5/346.1 Mbps per peer), 89.98 ms mean RTT, 66 retransmits
  ssc-2216z-f2eecd-sts-node-24-0: 227.6 Mbps send, 229.9 Mbps recv (15.2/15.3 Mbps per peer), 172.15 ms mean RTT, 38 retransmits
  ssc-2216z-f2eecd-sts-node-25-0: 1862.9 Mbps send, 1860.0 Mbps recv (155.2/155.0 Mbps per peer), 6.88 ms mean RTT, 18 retransmits
  ssc-2216z-f2eecd-sts-node-26-0: 510.1 Mbps send, 501.3 Mbps recv (51.0/50.1 Mbps per peer), 120.42 ms mean RTT, 50 retransmits
  ssc-2216z-f2eecd-sts-node-27-0: 387.2 Mbps send, 466.9 Mbps recv (38.7/46.7 Mbps per peer), 179.54 ms mean RTT, 1 retransmits
  ssc-2216z-f2eecd-sts-node-28-0: 8096.7 Mbps send, 8370.3 Mbps recv (736.1/760.9 Mbps per peer), 5.28 ms mean RTT, 64 retransmits
  ssc-2216z-f2eecd-sts-node-29-0: 5195.8 Mbps send, 4904.8 Mbps recv (399.7/377.3 Mbps per peer), 41.35 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-3-0: 4674.5 Mbps send, 4965.5 Mbps recv (584.3/620.7 Mbps per peer), 2.58 ms mean RTT, 1189 retransmits
  ssc-2216z-f2eecd-sts-node-30-0: 254.2 Mbps send, 266.6 Mbps recv (12.7/13.3 Mbps per peer), 172.90 ms mean RTT, 1 retransmits
  ssc-2216z-f2eecd-sts-node-31-0: 177.0 Mbps send, 174.8 Mbps recv (19.7/19.4 Mbps per peer), 73.43 ms mean RTT, 1 retransmits
  ssc-2216z-f2eecd-sts-node-32-0: 96.2 Mbps send, 96.1 Mbps recv (8.0/8.0 Mbps per peer), 253.25 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-33-0: 102.6 Mbps send, 89.8 Mbps recv (11.4/10.0 Mbps per peer), 122.83 ms mean RTT, 3 retransmits
  ssc-2216z-f2eecd-sts-node-34-0: 5214.8 Mbps send, 4972.9 Mbps recv (869.1/828.8 Mbps per peer), 97.69 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-35-0: 55.3 Mbps send, 65.5 Mbps recv (4.3/5.0 Mbps per peer), 290.36 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-36-0: 6991.1 Mbps send, 7124.4 Mbps recv (582.6/593.7 Mbps per peer), 109.36 ms mean RTT, 89 retransmits
  ssc-2216z-f2eecd-sts-node-37-0: 1914.7 Mbps send, 1899.8 Mbps recv (273.5/271.4 Mbps per peer), 148.73 ms mean RTT, 7 retransmits
  ssc-2216z-f2eecd-sts-node-38-0: 8047.4 Mbps send, 6550.1 Mbps recv (731.6/595.5 Mbps per peer), 89.94 ms mean RTT, 68 retransmits
  ssc-2216z-f2eecd-sts-node-39-0: 1154.0 Mbps send, 1147.7 Mbps recv (144.2/143.5 Mbps per peer), 13.91 ms mean RTT, 210 retransmits
  ssc-2216z-f2eecd-sts-node-4-0: 287.4 Mbps send, 276.2 Mbps recv (57.5/55.2 Mbps per peer), 152.90 ms mean RTT, 15 retransmits
  ssc-2216z-f2eecd-sts-node-40-0: 459.9 Mbps send, 480.9 Mbps recv (30.7/32.1 Mbps per peer), 179.45 ms mean RTT, 7 retransmits
  ssc-2216z-f2eecd-sts-node-41-0: 1312.2 Mbps send, 1310.5 Mbps recv (164.0/163.8 Mbps per peer), 13.99 ms mean RTT, 1 retransmits
  ssc-2216z-f2eecd-sts-node-42-0: 168.5 Mbps send, 168.3 Mbps recv (21.1/21.0 Mbps per peer), 107.30 ms mean RTT, 1 retransmits
  ssc-2216z-f2eecd-sts-node-43-0: 2307.2 Mbps send, 2444.0 Mbps recv (329.6/349.1 Mbps per peer), 9.42 ms mean RTT, 943 retransmits
  ssc-2216z-f2eecd-sts-node-44-0: 2755.8 Mbps send, 2756.1 Mbps recv (306.2/306.2 Mbps per peer), 125.58 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-45-0: 267.7 Mbps send, 268.0 Mbps recv (44.6/44.7 Mbps per peer), 186.53 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-46-0: 605.1 Mbps send, 622.2 Mbps recv (67.2/69.1 Mbps per peer), 185.93 ms mean RTT, 2 retransmits
  ssc-2216z-f2eecd-sts-node-47-0: 2664.3 Mbps send, 2642.1 Mbps recv (266.4/264.2 Mbps per peer), 25.12 ms mean RTT, 124 retransmits
  ssc-2216z-f2eecd-sts-node-48-0: 818.5 Mbps send, 1067.5 Mbps recv (81.8/106.8 Mbps per peer), 96.08 ms mean RTT, 155 retransmits
  ssc-2216z-f2eecd-sts-node-49-0: 610.4 Mbps send, 383.6 Mbps recv (55.5/34.9 Mbps per peer), 167.48 ms mean RTT, 2 retransmits
  ssc-2216z-f2eecd-sts-node-5-0: 168.7 Mbps send, 171.9 Mbps recv (15.3/15.6 Mbps per peer), 106.84 ms mean RTT, 2 retransmits
  ssc-2216z-f2eecd-sts-node-50-0: 130.0 Mbps send, 141.2 Mbps recv (10.0/10.9 Mbps per peer), 171.86 ms mean RTT, 4 retransmits
  ssc-2216z-f2eecd-sts-node-51-0: 166.2 Mbps send, 166.2 Mbps recv (15.1/15.1 Mbps per peer), 293.88 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-52-0: 319.9 Mbps send, 324.2 Mbps recv (16.8/17.1 Mbps per peer), 57.04 ms mean RTT, 9 retransmits
  ssc-2216z-f2eecd-sts-node-53-0: 131.8 Mbps send, 138.3 Mbps recv (16.5/17.3 Mbps per peer), 171.81 ms mean RTT, 27 retransmits
  ssc-2216z-f2eecd-sts-node-54-0: 126.6 Mbps send, 119.3 Mbps recv (12.7/11.9 Mbps per peer), 190.76 ms mean RTT, 1 retransmits
  ssc-2216z-f2eecd-sts-node-55-0: 1454.8 Mbps send, 1461.5 Mbps recv (161.6/162.4 Mbps per peer), 16.49 ms mean RTT, 62 retransmits
  ssc-2216z-f2eecd-sts-node-56-0: 127.4 Mbps send, 127.5 Mbps recv (21.2/21.2 Mbps per peer), 191.05 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-57-0: 64.4 Mbps send, 64.4 Mbps recv (6.4/6.4 Mbps per peer), 377.31 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-58-0: 2057.4 Mbps send, 2060.3 Mbps recv (342.9/343.4 Mbps per peer), 166.74 ms mean RTT, 2 retransmits
  ssc-2216z-f2eecd-sts-node-59-0: 4184.6 Mbps send, 3924.9 Mbps recv (418.5/392.5 Mbps per peer), 12.27 ms mean RTT, 88 retransmits
  ssc-2216z-f2eecd-sts-node-6-0: 422.0 Mbps send, 329.7 Mbps recv (60.3/47.1 Mbps per peer), 116.04 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-60-0: 515.9 Mbps send, 516.2 Mbps recv (129.0/129.0 Mbps per peer), 152.99 ms mean RTT, 1 retransmits
  ssc-2216z-f2eecd-sts-node-61-0: 138.1 Mbps send, 138.2 Mbps recv (13.8/13.8 Mbps per peer), 176.59 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-62-0: 116.8 Mbps send, 132.5 Mbps recv (16.7/18.9 Mbps per peer), 184.27 ms mean RTT, 8 retransmits
  ssc-2216z-f2eecd-sts-node-63-0: 195.2 Mbps send, 195.2 Mbps recv (15.0/15.0 Mbps per peer), 125.00 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-64-0: 223.5 Mbps send, 219.6 Mbps recv (37.2/36.6 Mbps per peer), 224.49 ms mean RTT, 2 retransmits
  ssc-2216z-f2eecd-sts-node-65-0: 131.7 Mbps send, 141.7 Mbps recv (22.0/23.6 Mbps per peer), 171.57 ms mean RTT, 5 retransmits
  ssc-2216z-f2eecd-sts-node-66-0: 1415.5 Mbps send, 1611.8 Mbps recv (202.2/230.3 Mbps per peer), 80.18 ms mean RTT, 28 retransmits
  ssc-2216z-f2eecd-sts-node-67-0: 2332.4 Mbps send, 2334.4 Mbps recv (333.2/333.5 Mbps per peer), 10.30 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-68-0: 217.0 Mbps send, 199.7 Mbps recv (21.7/20.0 Mbps per peer), 111.75 ms mean RTT, 1 retransmits
  ssc-2216z-f2eecd-sts-node-69-0: 82.9 Mbps send, 89.3 Mbps recv (6.4/6.9 Mbps per peer), 271.34 ms mean RTT, 8 retransmits
  ssc-2216z-f2eecd-sts-node-7-0: 90.6 Mbps send, 90.7 Mbps recv (12.9/13.0 Mbps per peer), 268.63 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-70-0: 5459.4 Mbps send, 5909.8 Mbps recv (496.3/537.3 Mbps per peer), 58.96 ms mean RTT, 19 retransmits
  ssc-2216z-f2eecd-sts-node-71-0: 2443.9 Mbps send, 2428.7 Mbps recv (349.1/347.0 Mbps per peer), 158.19 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-72-0: 98.1 Mbps send, 102.6 Mbps recv (8.2/8.6 Mbps per peer), 237.64 ms mean RTT, 4 retransmits
  ssc-2216z-f2eecd-sts-node-73-0: 1285.0 Mbps send, 1115.1 Mbps recv (160.6/139.4 Mbps per peer), 17.99 ms mean RTT, 11 retransmits
  ssc-2216z-f2eecd-sts-node-74-0: 3493.9 Mbps send, 3379.9 Mbps recv (349.4/338.0 Mbps per peer), 112.78 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-75-0: 1615.3 Mbps send, 1838.6 Mbps recv (201.9/229.8 Mbps per peer), 99.13 ms mean RTT, 581 retransmits
  ssc-2216z-f2eecd-sts-node-76-0: 6095.6 Mbps send, 7419.9 Mbps recv (609.6/742.0 Mbps per peer), 31.48 ms mean RTT, 356 retransmits
  ssc-2216z-f2eecd-sts-node-8-0: 4813.2 Mbps send, 4986.7 Mbps recv (343.8/356.2 Mbps per peer), 88.17 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-node-9-0: 226.6 Mbps send, 226.0 Mbps recv (22.7/22.6 Mbps per peer), 107.81 ms mean RTT, 1 retransmits
  ssc-2216z-f2eecd-sts-pn-0: 124.4 Mbps send, 134.5 Mbps recv (20.7/22.4 Mbps per peer), 181.95 ms mean RTT, 6 retransmits
  ssc-2216z-f2eecd-sts-pn-1: 3443.2 Mbps send, 3428.9 Mbps recv (491.9/489.8 Mbps per peer), 7.77 ms mean RTT, 19 retransmits
  ssc-2216z-f2eecd-sts-pn-2: 109.0 Mbps send, 122.0 Mbps recv (15.6/17.4 Mbps per peer), 194.93 ms mean RTT, 26 retransmits
  ssc-2216z-f2eecd-sts-sdf-0: 88.5 Mbps send, 88.4 Mbps recv (14.8/14.7 Mbps per peer), 275.08 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-sdf-1: 1486.0 Mbps send, 2453.4 Mbps recv (297.2/490.7 Mbps per peer), 11.46 ms mean RTT, 588 retransmits
  ssc-2216z-f2eecd-sts-sdf-2: 788.6 Mbps send, 787.7 Mbps recv (98.6/98.5 Mbps per peer), 30.88 ms mean RTT, 5 retransmits
  ssc-2216z-f2eecd-sts-sp-0: 155.7 Mbps send, 155.7 Mbps recv (17.3/17.3 Mbps per peer), 156.63 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-sp-1: 221.1 Mbps send, 234.1 Mbps recv (55.3/58.5 Mbps per peer), 169.80 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-sp-2: 154.2 Mbps send, 136.2 Mbps recv (22.0/19.5 Mbps per peer), 157.02 ms mean RTT, 4 retransmits
  ssc-2216z-f2eecd-sts-wx-0: 222.0 Mbps send, 224.5 Mbps recv (37.0/37.4 Mbps per peer), 217.55 ms mean RTT, 0 retransmits
  ssc-2216z-f2eecd-sts-wx-1: 4803.4 Mbps send, 3285.8 Mbps recv (600.4/410.7 Mbps per peer), 4.53 ms mean RTT, 681 retransmits
  ssc-2216z-f2eecd-sts-wx-2: 884.5 Mbps send, 872.0 Mbps recv (126.4/124.6 Mbps per peer), 122.79 ms mean RTT, 0 retransmits
```

It seems like the total bandwidth of each node is pretty variable, and lower than I expected. There we several runs I saw where even the small, 7 node max TPS topology has nodes with < 100 Mbps total bandwidth, which seems like this would negatively affect MaxTPS test. I think we need to do a little more digging to figure out what's causing this variance.