### PR TITLE
Add v22 compatibility mode to `--run-for-max-tps`

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -511,7 +511,7 @@ type MissionOptions
     member self.TxBatchMaxSize = txBatchMaxSize
 
     [<Option("run-for-max-tps",
-             HelpText = "Sets core configuration to optimal for high throughput tests. Values: 'classic' or 'soroban'",
+             HelpText = "Sets core configuration to optimal for high throughput tests. Values: 'classic', 'classic-v22-compat', or 'soroban'",
              Required = false)>]
     member self.RunForMaxTps = runForMaxTps
 

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -233,7 +233,8 @@ type StellarCoreCfg =
         | Some "soroban" ->
             t.Add("TESTING_MAX_CLASSIC_BYTE_ALLOWANCE", 1024 * 1024 * 1) |> ignore
             t.Add("TESTING_MAX_SOROBAN_BYTE_ALLOWANCE", 1024 * 1024 * 9) |> ignore
-        | Some _ -> failwith "run-for-max-tps must be either classic or soroban"
+        | Some "classic-v22-compat" -> ()
+        | Some _ -> failwith "run-for-max-tps must be either classic, classic-v22-compat, or soroban"
         | None -> ()
 
         if self.skipHighCriticalValidatorChecks
@@ -353,7 +354,7 @@ type StellarCoreCfg =
             t.Add("FORCE_OLD_STYLE_LEADER_ELECTION", true) |> ignore
 
         match self.network.missionContext.runForMaxTps with
-        | Some _ ->
+        | Some mode ->
             if not self.network.missionContext.enableInMemoryBuckets then
                 t.Add("BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT", 0) |> ignore
 
@@ -370,8 +371,10 @@ type StellarCoreCfg =
             t.Add("FLOOD_DEMAND_BACKOFF_DELAY_MS", 1000) |> ignore
             t.Add("BUCKETLIST_DB_PERSIST_INDEX", false) |> ignore
             t.Add("FLOOD_DEMAND_PERIOD_MS", 100) |> ignore
-            t.Add("TRANSACTION_QUEUE_SIZE_MULTIPLIER_FOR_TESTING", 3) |> ignore
-            t.Add("SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER_FOR_TESTING", 3) |> ignore
+
+            if mode <> "classic-v22-compat" then
+                t.Add("TRANSACTION_QUEUE_SIZE_MULTIPLIER_FOR_TESTING", 3) |> ignore
+                t.Add("SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER_FOR_TESTING", 3) |> ignore
         | None -> ()
 
         let invList =


### PR DESCRIPTION
This change adds a new option `classic-v22-compat` to the `--run-for-max-tps` flag. This option omits some testing-only configuration options that were added in v23.0.0 so that supercluster remains compatible with at least stellar-core v22.3.0. This is important for theoretical max TPS testing where we like to retest old versions to establish a baseline before testing new versions.