### PR TITLE
Allow setting of asan options

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -114,6 +114,7 @@ type MissionOptions
         tag: string option,
         numPregeneratedTxs: int option,
         genesisTestAccountCount: int option,
+        asanOptions: string option,
         catchupSkipKnownResultsForTesting: bool option,
         checkEventsAreConsistentWithEntryDiffs: bool option,
         enableRelaxedAutoQsetConfig: bool,
@@ -490,6 +491,9 @@ type MissionOptions
              Required = false)>]
     member self.GenesisTestAccountCount = genesisTestAccountCount
 
+    [<Option("asan-options", HelpText = "Value for ASAN_OPTIONS environment variable", Required = false)>]
+    member self.asanOptions = asanOptions
+
     [<Option("catchup-skip-known-results-for-testing",
              HelpText = "when this flag is provided, pubnet parallel catchup workers will run with CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = true, resulting in skipping application of failed transaction and signature verification",
              Required = false)>]
@@ -637,6 +641,7 @@ let main argv =
                   tag = None
                   numPregeneratedTxs = None
                   genesisTestAccountCount = None
+                  asanOptions = None
                   enableTailLogging = true
                   catchupSkipKnownResultsForTesting = None
                   checkEventsAreConsistentWithEntryDiffs = None
@@ -788,6 +793,7 @@ let main argv =
                                checkEventsAreConsistentWithEntryDiffs = mission.CheckEventsAreConsistentWithEntryDiffs
                                updateSorobanCosts = None
                                genesisTestAccountCount = mission.GenesisTestAccountCount
+                               asanOptions = mission.asanOptions
                                enableRelaxedAutoQsetConfig = mission.EnableRelaxedAutoQsetConfig
                                jobMonitorExternalHost = mission.JobMonitorExternalHost
                                txBatchMaxSize = mission.TxBatchMaxSize

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -121,6 +121,7 @@ let ctx : MissionContext =
       checkEventsAreConsistentWithEntryDiffs = None
       updateSorobanCosts = None
       genesisTestAccountCount = None
+      asanOptions = None
       enableRelaxedAutoQsetConfig = false
       jobMonitorExternalHost = None
       txBatchMaxSize = None

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -38,7 +38,7 @@ module CfgVal =
     let localHistName = "local"
     let peerNameEnvVarName = "STELLAR_CORE_PEER_SHORT_NAME"
     let asanOptionsEnvVarName = "ASAN_OPTIONS"
-    let asanOptionsEnvVarValue = "quarantine_size_mb=1:malloc_context_size=5"
+    let asanOptionsEnvVarDefaultValue = "quarantine_size_mb=1:malloc_context_size=5"
     let peerCfgFileName = "stellar-core.cfg"
     let peerInitCfgFileName = "stellar-core-init.cfg"
     let peerDelayCfgFileName = "install-delays.sh"

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -107,6 +107,8 @@ type MissionContext =
       pubnetParallelCatchupNumWorkers: int
       genesisTestAccountCount: int option
 
+      asanOptions: string option
+
       // Tail logging can cause the pubnet simulation missions like SorobanLoadGeneration
       // and SimulatePubnet to fail on the heartbeat handler due to what looks like a
       // server disconnection. Our solution for now is to just disable tail logging on


### PR DESCRIPTION
Ubuntu 24.04 standard packaged `libc++` has an issue where ASAN reports an error for exceptions (because they get created with the ASAN `new` but removed with the standard `free`). So, conditionally, we want to be able to set `alloc_dealloc_mismatch=0` in the `ASAN_OPTIONS` environment variable.