### PR TITLE
Plumb asan-options to parallel catchup v2

### DIFF
--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -161,6 +161,11 @@ let installProject (context: MissionContext) =
     setOptions.Add(sprintf "monitor.path=/%s/(.*)" context.namespaceProperty)
     setOptions.Add(sprintf "monitor.logging_interval_seconds=%d" jobMonitorLoggingIntervalSecs)
 
+    // Set ASAN_OPTIONS if provided
+    match context.asanOptions with
+    | Some asanOpts -> setOptions.Add(sprintf "worker.asanOptions=%s" asanOpts)
+    | None -> ()
+
     // Convert labels and taints to Helm array format
     if not (List.isEmpty context.requireNodeLabelsPcV2) then
         let requireLabelsHelm =

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ASAN_OPTIONS
-          value: quarantine_size_mb=1:malloc_context_size=5
+          value: {{ .Values.worker.asanOptions | quote }}
         envFrom:
         - configMapRef:
             name: worker-config

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -17,6 +17,7 @@ worker:
   requireNodeLabels: []
   avoidNodeLabels: []
   tolerateNodeTaints: []
+  asanOptions: "quarantine_size_mb=1:malloc_context_size=5"
   resources: # resources below are left empty on purpose, they are read and overridden from `StellarKubeCfg.fs`
     requests:
       cpu: ""


### PR DESCRIPTION
Setting `--asan-options quarantine_size_mb=1:malloc_context_size=5:alloc_dealloc_mismatch=0` in the commandline now gets reflected in the core worker cfg.

<img width="912" height="564" alt="Screenshot 2025-10-08 at 15 49 17" src="https://github.com/user-attachments/assets/333df3d9-b01c-44a3-bbe1-eb5e7f51b558" />
