### PR TITLE
Bump maxSkew for the parallel catchup V2 mission

### DIFF
--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -115,6 +115,8 @@ spec:
       - labelSelector:
           matchLabels:
             app: stellar-core
+        # Note: maxSkew affects dynamic node scheduling with karpenter
+        # See https://github.com/stellar/supercluster/issues/330
         maxSkew: 2
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: DoNotSchedule


### PR DESCRIPTION
### What

Bump maxSkew for the parallel catchup V2 mission.

### Why

maxSkew of 1 interfers slightly with dynamic scheduler (karpenter). This leads to workers being underutilised and extra cost. I tried it out and setting it to higher value still give us almost ideal pod spread but results in fewer dynamic workers being provisioned.

### Testing

I tried it out by running the mission from my laptop. Other than that the change is really simple, worst case scenario I can think if is that some workers end up doing slighlty more work than others.