### PR TITLE
Add prometheus scrape annotations to job monitor

### DIFF
--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -44,6 +44,12 @@ spec:
     metadata:
       labels:
         app: job-monitor
+      annotations:
+        # Add annotations to tell prometheus service discovery to scrape metrics.
+        # In k8s clusters without prometheus the annotations will be dormant
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/prometheus"
     spec:
       containers:
       - name: job-monitor


### PR DESCRIPTION
### What

This PR adds standard prometheus scrape annotations to the job monitor pod.

### Why

This will make prometheus scrape job monitor metrics.