### PR TITLE
Bump parallel catchup RAM limit - 2x to start

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -126,8 +126,8 @@ let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
 
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
-    // 0.25 vCPUs, 2GB RAM and 35 GB of disk bursting to 2vCPU, 8GB and 40 GB
-    makeResourceRequirementsWithStorageLimit 250 2048 35 2000 8192 40
+    // 0.25 vCPUs, 2GB RAM and 35 GB of disk bursting to 2vCPU, 16GB and 40 GB
+    makeResourceRequirementsWithStorageLimit 250 2048 35 2000 16384 40
 
 let NonParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing non-parallel catchup, we give each container


### PR DESCRIPTION
Parallel catchup has been failing due to recent RAM increase. 
This bumps the limit to 2x as a starting point, we may walk it back later once we figure out a stable point.