### PR TITLE
Adding alloc_dealloc_mismatch=0 in default ASAN options to skip the check due to libc++19 bug

### DIFF
--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -38,7 +38,7 @@ module CfgVal =
     let localHistName = "local"
     let peerNameEnvVarName = "STELLAR_CORE_PEER_SHORT_NAME"
     let asanOptionsEnvVarName = "ASAN_OPTIONS"
-    let asanOptionsEnvVarDefaultValue = "quarantine_size_mb=1:malloc_context_size=5"
+    let asanOptionsEnvVarDefaultValue = "quarantine_size_mb=1:malloc_context_size=5:alloc_dealloc_mismatch=0"
     let peerCfgFileName = "stellar-core.cfg"
     let peerInitCfgFileName = "stellar-core-init.cfg"
     let peerDelayCfgFileName = "install-delays.sh"

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -17,7 +17,7 @@ worker:
   requireNodeLabels: []
   avoidNodeLabels: []
   tolerateNodeTaints: []
-  asanOptions: "quarantine_size_mb=1:malloc_context_size=5"
+  asanOptions: "quarantine_size_mb=1:malloc_context_size=5:alloc_dealloc_mismatch=0"
   resources: # resources below are left empty on purpose, they are read and overridden from `StellarKubeCfg.fs`
     requests:
       cpu: ""


### PR DESCRIPTION
Adding alloc_dealloc_mismatch=0 in default ASAN options to skip the check due to a known bug in libc++19,
https://github.com/llvm/llvm-project/issues/59432
