### PR TITLE
Remove hardcoded node afinity labels in v1 missions

### DIFF
--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -119,7 +119,7 @@ spec:
         # See https://github.com/stellar/supercluster/issues/330
         maxSkew: 2
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       {{- end }}
 ---
 apiVersion: v1


### PR DESCRIPTION
Resolves https://github.com/stellar/supercluster/issues/335

This is necessary for simultaneously running parallel catchup v2 with other missions (config change done [here](https://github.com/stellar/stellar-supercluster/pull/356)).