### PR TITLE
Use hardcoded name for parallel-catchup-v2 ServiceAccount

### DIFF
--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -13,7 +13,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-sa
+  name: stellar-supercluster
   {{- if .Values.service_account.annotations }}
   annotations:
     {{- range .Values.service_account.annotations }}
@@ -39,7 +39,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-stellar-core
     spec:
-      serviceAccountName: {{ .Release.Name }}-sa
+      serviceAccountName: stellar-supercluster
       {{- if or .Values.worker.requireNodeLabels .Values.worker.avoidNodeLabels }}
       affinity:
         nodeAffinity:


### PR DESCRIPTION
This change was made as part of https://github.com/stellar/supercluster/pull/344
However, the aws role policy currently assumes hard-coded value https://github.com/stellar/terraform/blob/c330fcd6daecfdfe23394c9b484e3730927a5c48/aws/sdf/iam/iam_roles.auto.tfvars.json#L1023
Rolling this back for now. When we need to support multiple runs in the future, we will need to update this, and the role policy to accept a wildcard. 