### PR TITLE
Bump parallel catchup RAM requests

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -126,8 +126,8 @@ let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
 
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
-    // 0.25 vCPUs, 2GB RAM and 35 GB of disk bursting to 2vCPU, 16GB and 40 GB
-    makeResourceRequirementsWithStorageLimit 250 2048 35 2000 16384 40
+    // 0.25 vCPUs, 8GB RAM and 35 GB of disk bursting to 2vCPU, 16GB and 40 GB
+    makeResourceRequirementsWithStorageLimit 250 8192 35 2000 16384 40
 
 let NonParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing non-parallel catchup, we give each container


### PR DESCRIPTION
This PR bumps parallel catchup worker pod RAM requests from 2 to 8G.

I noticed that the pods burst quite a lot and having requests so low when compared to 16G limit means k8s may need to kill pods sometimes due to memory contention.