### PR TITLE
fix job-monitor Dockerfile by installing packages via apt

### DIFF
--- a/src/MissionParallelCatchup/Dockerfile.jobmonitor
+++ b/src/MissionParallelCatchup/Dockerfile.jobmonitor
@@ -5,16 +5,15 @@ VOLUME /data
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
     python3 \
-    python3-pip && \
+    python3-redis \
+    python3-requests \
+    python3-prometheus-client && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 COPY ./job_monitor.py /app
-
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install --no-cache-dir redis requests prometheus_client
 
 EXPOSE 8080
 


### PR DESCRIPTION
Ubuntu 24.04 ships Python 3.12 which enforces PEP 668. The docker build was failing due to it. The fix is to install the packages via apt instead of pip.

This PR removes pip entirely and installs the three Python libraries as Debian packages (python3-redis, python3-requests, python3-prometheus-client), which are all available in Ubuntu 24.04. Also added `--no-install-recommends` to keep the image smaller.

Tested it by running `docker build -f src/MissionParallelCatchup/Dockerfile.jobmonitor -t stellar/ssc-job-monitor:test src/MissionParallelCatchup/` and it succeeds.