### PR TITLE
Set explicit threshold for pubnet and testnet quorums

### DIFF
--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -811,7 +811,7 @@ let PubnetGetCommands =
     |> Map.ofList
 
 let PubnetQuorum : ExplicitQuorumSet =
-    { thresholdPercent = None
+    { thresholdPercent = Some 51
       validators =
           [ PeerShortName "core_live_001",
             KeyPair.FromAccountId("GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH")
@@ -847,7 +847,7 @@ let TestnetGetCommands =
     |> Map.ofList
 
 let TestnetQuorum : ExplicitQuorumSet =
-    { thresholdPercent = None
+    { thresholdPercent = Some 51
       validators =
           [ PeerShortName "core_testnet_001",
             KeyPair.FromAccountId("GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y")


### PR DESCRIPTION
Before this PR, the thresholds for `PubnetQuorum` and `TestnetQuorum` are unset, so they get auto-calculated by stellar-core. The default ends up with requiring 3/3 nodes, which means, in the event of a one node failure, missions relying on these quorums can fail. The missions using `TestnetQuorum` are
* HistoryTestnetCompleteCatchup
* HistoryTestnetMinimumCatchup
* HistoryTestnetParallelCatchup
* HistoryTestnetPerformance
* HistoryTestnetRecentCatchup

The missions using `PubnetQuorum` are
* HistoryPubnetCompleteCatchup
* HistoryPubnetMinimumCatchup
* HistoryPubnetParallelCatchup
* HistoryPubnetParallelCatchupExtrawide
* HistoryPubnetPerformance
* HistoryPubnetRecentCatchup