### PR TITLE
Swallow SIGINT while running kubectl

### DIFF
--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -62,11 +62,20 @@ let ConnectToCluster (cfgFile: string) (nsOpt: string option) : (Kubernetes * st
                     with :? ComponentModel.Win32Exception -> false
 
                 if started then
-                    if proc.WaitForExit(TimeSpan(0, 1, 0)) then
-                        if proc.ExitCode = 0 then RanSuccess else RanWithError proc.ExitCode
-                    else
-                        proc.Kill()
-                        DidNotComplete(proc.WaitForExit(TimeSpan(0, 1, 0)))
+                    // Swallow Ctrl+C in the parent while kubectl is running, so the
+                    // SIGINT delivered to the foreground process group only stops
+                    // kubectl and lets us decide what to do next.
+                    let cancelHandler = ConsoleCancelEventHandler(fun _ e -> e.Cancel <- true)
+                    Console.CancelKeyPress.AddHandler cancelHandler
+
+                    try
+                        if proc.WaitForExit(TimeSpan(0, 1, 0)) then
+                            if proc.ExitCode = 0 then RanSuccess else RanWithError proc.ExitCode
+                        else
+                            proc.Kill()
+                            DidNotComplete(proc.WaitForExit(TimeSpan(0, 1, 0)))
+                    finally
+                        Console.CancelKeyPress.RemoveHandler cancelHandler
                 else
                     DidNotRun)
 


### PR DESCRIPTION
Sometimes I realize that my local network is set up wrong such that the authentication flow can't complete. While it is possible to just wait the minute for the pre-existing code to detect this, I'd prefer to be able to just `CTRL+C` cancel the `kubectl auth whoami` that does the token refresh. Before this PR, `CTRL+C` would also stop the running F# code, so we wouldn't run the command that attempts to restore the original id-token.