### PR TITLE
Split load across nodes more evenly, useful for low tps configs

### DIFF
--- a/src/FSLibrary/MinBlockTimeTest.fs
+++ b/src/FSLibrary/MinBlockTimeTest.fs
@@ -22,8 +22,6 @@ let private smallNetworkSize = 10
 
 let private searchThresholdMs = 100
 
-let private protocolMaxBlockTimeMs = 5000
-
 let private timeoutsFor (targetMs: int) : int = max 500 (targetMs / 5)
 
 let private mixedPregenLedgerMultiplier = 15
@@ -315,7 +313,7 @@ let minBlockTimeTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg:
                 formation.ManualClose coreSets
                 formation.WaitUntilSynced coreSets
                 formation.UpgradeProtocolToLatest coreSets
-                formation.UpgradeMaxTxSetSize coreSets (classicTxRateForLimits * 10)
+                formation.UpgradeMaxTxSetSize coreSets (max (classicTxRateForLimits * mixedPregenLedgerMultiplier) 100)
 
                 if isMixedPregenMode baseLoadGen.mode then
                     upgradeMixedPregenSorobanLimits formation coreSets baseLoadGen
@@ -363,14 +361,14 @@ let minBlockTimeTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg:
                           txs = fixedTxRate * 300
                           txrate = fixedTxRate }
 
-                // Both the SCP upgrade (which runs a small arming loadgen) and
-                // the measurement load can fail when the network is still
-                // degraded from a previous iteration; either case is an SLA
-                // miss, not a crash.
-                try
-                    applySCPUpgrade targetMs
-                    formation.clearMetrics allNodes
+                applySCPUpgrade targetMs
+                formation.clearMetrics allNodes
 
+                // A loadgen failure is not an SLA signal — it usually means the
+                // requested TPS is too high for the network, or that loadgen
+                // itself lost a tx in the pipeline. Treating it as "SLA missed"
+                // would mislead the binary search, so fail the mission loudly.
+                try
                     if isMixedPregenMode baseLoadGen.mode then
                         withOverlayOnlyMode
                             formation
@@ -378,19 +376,11 @@ let minBlockTimeTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg:
                             (fun () -> formation.RunMultiLoadgen activeLoadGenNodes loadGen)
                     else
                         formation.RunMultiLoadgen activeLoadGenNodes loadGen
+                with e -> failwithf "Loadgen failed at T=%dms; TPS might be too high (%s)" targetMs e.Message
 
-                    formation.CheckNoErrorsAndPairwiseConsistency()
-                    formation.EnsureAllNodesInSync allNodes
-                    checkLedgerAgeSLA formation allNodes targetMs
-                with e ->
-                    LogInfo "Run errored at T=%dms: %s" targetMs e.Message
-                    false
-
-            if context.maxBlockTimeMs > protocolMaxBlockTimeMs then
-                failwithf
-                    "--max-block-time-ms=%d exceeds the protocol cap (%d ms); validators will reject such upgrades"
-                    context.maxBlockTimeMs
-                    protocolMaxBlockTimeMs
+                formation.CheckNoErrorsAndPairwiseConsistency()
+                formation.EnsureAllNodesInSync allNodes
+                checkLedgerAgeSLA formation allNodes targetMs
 
             if context.minBlockTimeMs >= context.maxBlockTimeMs then
                 failwithf

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -409,16 +409,35 @@ type StellarFormation with
         let n = List.length coreSets
 
         let fractionalLoadGen (i: int) : LoadGen =
-            let getFraction attr = if i + 1 = n then (attr / n + attr % n) else attr / n
+            // Spread remainder across the first r nodes instead of dumping it
+            // entirely on the last one, so per-node load stays even.
+            let getFraction attr =
+                let q = attr / n
+                let r = attr % n
+                if i < r then q + 1 else q
+
             let getOptionalFraction attr = Option.map getFraction attr
+
+            let classicShare = getOptionalFraction fullLoadGen.classicTxRate
+            let sorobanShare = getOptionalFraction fullLoadGen.sorobanTxRate
+
+            // In mixed mode derive txrate from the component rates so that
+            // txrate, classicTxRate, and sorobanTxRate stay consistent on
+            // every peer (independent splits would diverge by 1 per slice).
+            let txrateShare =
+                match classicShare, sorobanShare with
+                | Some c, Some s -> c + s
+                | Some c, None -> c
+                | None, Some s -> s
+                | None, None -> getFraction fullLoadGen.txrate
 
             { fullLoadGen with
                   accounts = fullLoadGen.accounts / n
                   txs = fullLoadGen.txs / n
                   spikesize = getFraction fullLoadGen.spikesize
-                  txrate = getFraction fullLoadGen.txrate
-                  classicTxRate = getOptionalFraction fullLoadGen.classicTxRate
-                  sorobanTxRate = getOptionalFraction fullLoadGen.sorobanTxRate }
+                  txrate = txrateShare
+                  classicTxRate = classicShare
+                  sorobanTxRate = sorobanShare }
 
         let hasNonZeroRate (loadGen: LoadGen) =
             match loadGen.classicTxRate, loadGen.sorobanTxRate with


### PR DESCRIPTION
We've had this issue for a while, but this is a lot more relevant now that we're testing Soroban loads where tps is generally quite a bit lower than classic. the change spread the load more evenly across nodes