### PR TITLE
Stability fixes and overlay evaluation script

### DIFF
--- a/scripts/slp_eval.sh
+++ b/scripts/slp_eval.sh
@@ -1,5 +1,41 @@
 #!/bin/sh
 
+# SLP mixed-load evaluation wrapper.
+#
+# This script runs the MinBlockTimeMixed mission against a stellar-core image
+# using the 2025-06-24 pubnet topology data and the fixed benchmark parameters
+# below. It is intended to answer: "does this image sustain the selected mixed
+# classic/Soroban load at the normal 5s ledger close target?"
+#
+# Benchmark setup:
+# - One mission run is started for each selected Soroban load flag:
+#   --sac, --oz, and/or --soroswap. Passing multiple flags runs them
+#   sequentially, not as one combined Soroban workload.
+# - Every run includes CLASSIC_TX_RATE pre-generated classic payment TPS to
+#   match current network conditions. The flag value supplies only the Soroban
+#   TPS for that run, so total TPS is CLASSIC_TX_RATE + selected Soroban TPS.
+# - The mission uses MinBlockTimeMixed's MIXED_PREGEN_* overlay-only loadgen
+#   mode, simulated pubnet network delay, with NETWORK_SIZE_LIMIT nodes.
+# - The block-time search range is intentionally narrow:
+#   [MIN_BLOCK_TIME_MS, MAX_BLOCK_TIME_MS] = [4900, 5100]. With the mission's
+#   100ms binary-search threshold, this effectively evaluates the 5s target
+#   to match the current network close time.
+# - simulate-apply-duration is derived from SIMULATE_APPLY_BUDGET_MS and the
+#   total TPS so the synthetic apply sleep budget remains roughly constant as
+#   the requested Soroban rate changes.
+#
+# Result interpretation:
+# - A zero exit and a "Minimum sustainable block time: ..." log line means the
+#   run passed the mission SLA for the tested target: on every node,
+#   ledger.age.closed-histogram P75 was within the configured band around T and
+#   P99 was <= 2*T, and the network stayed synced/consistent.
+# - Because this wrapper uses a narrow range around 5s, interpret a successful
+#   result as "the image passed this workload at the normal 5s close time", not
+#   as a precise minimum block-time measurement.
+# - A non-zero exit, "No block time ... satisfied the SLA", loadgen failure, or
+#   sync/consistency failure means the image/setup did not pass this benchmark
+#   configuration.
+
 DATA_ROOT="$(pwd)"
 STELLAR_CORE_IMAGE=
 SAC_TX_RATE=
@@ -23,7 +59,7 @@ AVOID_NODE_LABELS="purpose:ssc"
 CLASSIC_TX_RATE=200
 MIN_BLOCK_TIME_MS=4900
 MAX_BLOCK_TIME_MS=5100
-BLOCK_TIME_MS=$(( (MIN_BLOCK_TIME_MS + MAX_BLOCK_TIME_MS) / 2 ))
+BLOCK_TIME_MS=$(((MIN_BLOCK_TIME_MS + MAX_BLOCK_TIME_MS) / 2))
 NUM_PREGENERATED_TXS=1000000
 GENESIS_TEST_ACCOUNT_COUNT=1000000
 SIMULATE_APPLY_WEIGHT=100
@@ -34,13 +70,34 @@ usage() {
 	cat <<EOF
 Usage: $0 --stellar-core-image IMAGE [--data-root PATH] [--sac RATE] [--oz RATE] [--soroswap RATE]
 
+Runs one MinBlockTimeMixed mission per selected load flag against IMAGE.
+Each run always generates ${CLASSIC_TX_RATE} classic payment TPS plus the
+selected Soroban TPS. For example, "--sac 50" tests ${CLASSIC_TX_RATE} classic
+TPS + 50 SAC Soroban TPS; "--sac 50 --oz 25" runs two separate benchmarks.
+
 Options:
   --stellar-core-image, --image IMAGE   Stellar Core image to evaluate. Required.
   --data-root, --supercluster-root PATH Root containing data/. Defaults to pwd.
   --sac RATE                            Run SAC load with the given Soroban tx rate.
+                                        Can be supplied with other load flags to run benchmarks sequentially.
   --oz RATE                             Run OZ load with the given Soroban tx rate.
+                                        Can be supplied with other load flags to run benchmarks sequentially.
   --soroswap RATE                       Run Soroswap load with the given Soroban tx rate.
+                                        Can be supplied with other load flags to run benchmarks sequentially.
   -h, --help                            Show this help.
+
+Benchmark constants:
+  Classic TPS:        ${CLASSIC_TX_RATE}
+  Target close time:  ${BLOCK_TIME_MS}ms, evaluated via [${MIN_BLOCK_TIME_MS}, ${MAX_BLOCK_TIME_MS}]
+  Network size limit: ${NETWORK_SIZE_LIMIT}
+  Data set:           data/public-network-data-2025-06-24.json
+
+Results:
+  PASS: command exits 0 and logs "Minimum sustainable block time: ...".
+        With this wrapper, treat that as passing the workload at the normal
+        5s target close time.
+  FAIL: command exits non-zero, reports no satisfying block time, or reports
+        loadgen/sync/consistency failures.
 EOF
 }
 

--- a/scripts/slp_eval.sh
+++ b/scripts/slp_eval.sh
@@ -1,0 +1,261 @@
+#!/bin/sh
+
+DATA_ROOT="$(pwd)"
+STELLAR_CORE_IMAGE=
+SAC_TX_RATE=
+OZ_TX_RATE=
+SOROSWAP_TX_RATE=
+
+IMAGE_REPOSITORY="746476062914.dkr.ecr.us-east-1.amazonaws.com/dev"
+
+PROJECT="src/App/App.fsproj"
+MISSION="MinBlockTimeMixed"
+DESTINATION="evaluation"
+
+NETDELAY_IMAGE="$IMAGE_REPOSITORY/sdf-netdelay:latest"
+POSTGRES_IMAGE="$IMAGE_REPOSITORY/postgres:9.5.22"
+NGINX_IMAGE="$IMAGE_REPOSITORY/nginx:latest"
+PROMETHEUS_EXPORTER_IMAGE="$IMAGE_REPOSITORY/stellar-core-prometheus-exporter:latest"
+
+INGRESS_INTERNAL_DOMAIN="stellar-supercluster.kube001-ssc-eks.services.stellar-ops.com"
+AVOID_NODE_LABELS="purpose:ssc"
+
+CLASSIC_TX_RATE=200
+MIN_BLOCK_TIME_MS=4900
+MAX_BLOCK_TIME_MS=5100
+BLOCK_TIME_MS=$(( (MIN_BLOCK_TIME_MS + MAX_BLOCK_TIME_MS) / 2 ))
+NUM_PREGENERATED_TXS=1000000
+GENESIS_TEST_ACCOUNT_COUNT=1000000
+SIMULATE_APPLY_WEIGHT=100
+SIMULATE_APPLY_BUDGET_MS=600
+NETWORK_SIZE_LIMIT=277
+
+usage() {
+	cat <<EOF
+Usage: $0 --stellar-core-image IMAGE [--data-root PATH] [--sac RATE] [--oz RATE] [--soroswap RATE]
+
+Options:
+  --stellar-core-image, --image IMAGE   Stellar Core image to evaluate. Required.
+  --data-root, --supercluster-root PATH Root containing data/. Defaults to pwd.
+  --sac RATE                            Run SAC load with the given Soroban tx rate.
+  --oz RATE                             Run OZ load with the given Soroban tx rate.
+  --soroswap RATE                       Run Soroswap load with the given Soroban tx rate.
+  -h, --help                            Show this help.
+EOF
+}
+
+is_nonnegative_integer() {
+	case "$1" in
+	"" | *[!0-9]*)
+		return 1
+		;;
+	*)
+		return 0
+		;;
+	esac
+}
+
+parse_args() {
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+		--stellar-core-image | --image)
+			if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+				printf '%s\n' "$1 requires an image." >&2
+				usage >&2
+				exit 1
+			fi
+			STELLAR_CORE_IMAGE="$2"
+			shift 2
+			;;
+		--stellar-core-image=* | --image=*)
+			STELLAR_CORE_IMAGE="${1#*=}"
+			shift
+			;;
+		--data-root | --supercluster-root)
+			if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+				printf '%s\n' "$1 requires a path." >&2
+				usage >&2
+				exit 1
+			fi
+			DATA_ROOT="$2"
+			shift 2
+			;;
+		--data-root=* | --supercluster-root=*)
+			DATA_ROOT="${1#*=}"
+			shift
+			;;
+		--sac)
+			if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+				printf '%s\n' "--sac requires a Soroban tx rate." >&2
+				usage >&2
+				exit 1
+			fi
+			SAC_TX_RATE="$2"
+			shift 2
+			;;
+		--sac=*)
+			SAC_TX_RATE="${1#*=}"
+			shift
+			;;
+		--oz)
+			if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+				printf '%s\n' "--oz requires a Soroban tx rate." >&2
+				usage >&2
+				exit 1
+			fi
+			OZ_TX_RATE="$2"
+			shift 2
+			;;
+		--oz=*)
+			OZ_TX_RATE="${1#*=}"
+			shift
+			;;
+		--soroswap)
+			if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+				printf '%s\n' "--soroswap requires a Soroban tx rate." >&2
+				usage >&2
+				exit 1
+			fi
+			SOROSWAP_TX_RATE="$2"
+			shift 2
+			;;
+		--soroswap=*)
+			SOROSWAP_TX_RATE="${1#*=}"
+			shift
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			printf 'Unknown argument: %s\n' "$1" >&2
+			usage >&2
+			exit 1
+			;;
+		esac
+	done
+}
+
+validate_tx_rate() {
+	flag="${1:?usage: validate_tx_rate FLAG RATE}"
+	tx_rate="${2:?usage: validate_tx_rate FLAG RATE}"
+
+	if ! is_nonnegative_integer "$tx_rate"; then
+		printf '%s\n' "$flag rate must be a non-negative integer." >&2
+		exit 1
+	fi
+}
+
+validate_args() {
+	if [ -z "$STELLAR_CORE_IMAGE" ]; then
+		printf '%s\n' "A Stellar Core image is required." >&2
+		usage >&2
+		exit 1
+	fi
+
+	if [ -z "$SAC_TX_RATE" ] && [ -z "$OZ_TX_RATE" ] && [ -z "$SOROSWAP_TX_RATE" ]; then
+		printf '%s\n' "At least one load flag is required: --sac, --oz, or --soroswap." >&2
+		usage >&2
+		exit 1
+	fi
+
+	if [ -n "$SAC_TX_RATE" ]; then
+		validate_tx_rate "--sac" "$SAC_TX_RATE"
+	fi
+
+	if [ -n "$OZ_TX_RATE" ]; then
+		validate_tx_rate "--oz" "$OZ_TX_RATE"
+	fi
+
+	if [ -n "$SOROSWAP_TX_RATE" ]; then
+		validate_tx_rate "--soroswap" "$SOROSWAP_TX_RATE"
+	fi
+}
+
+calculate_simulate_apply_duration() {
+	classic_tx_rate="${1:?usage: calculate_simulate_apply_duration CLASSIC_TX_RATE SOROBAN_TX_RATE}"
+	soroban_tx_rate="${2:?usage: calculate_simulate_apply_duration CLASSIC_TX_RATE SOROBAN_TX_RATE}"
+
+	if ! is_nonnegative_integer "$classic_tx_rate" || ! is_nonnegative_integer "$soroban_tx_rate"; then
+		printf '%s\n' "Tx rates must be non-negative integers." >&2
+		return 1
+	fi
+
+	total_tx_rate=$((classic_tx_rate + soroban_tx_rate))
+	if [ "$total_tx_rate" -eq 0 ]; then
+		printf '%s\n' "Total tx rate must be greater than zero." >&2
+		return 1
+	fi
+
+	printf '%s\n' "$((SIMULATE_APPLY_BUDGET_MS * 1000000 / (total_tx_rate * BLOCK_TIME_MS)))"
+}
+
+resolve_min_block_time_mixed_mode() {
+	case "$1" in
+	sac | mixed_pregen_sac_payment)
+		printf '%s\n' "mixed_pregen_sac_payment"
+		;;
+	oz | mixed_pregen_oz_token_transfer)
+		printf '%s\n' "mixed_pregen_oz_token_transfer"
+		;;
+	soroswap | mixed_pregen_soroswap_swap)
+		printf '%s\n' "mixed_pregen_soroswap_swap"
+		;;
+	*)
+		printf '%s\n' "Unsupported mode '$1'. Use one of: sac, oz, soroswap." >&2
+		return 1
+		;;
+	esac
+}
+
+run_min_block_time_mixed() {
+	mode_alias="${1:?usage: run_min_block_time_mixed MODE SOROBAN_TX_RATE}"
+	soroban_tx_rate="${2:?usage: run_min_block_time_mixed MODE SOROBAN_TX_RATE}"
+	min_block_time_mixed_mode="$(resolve_min_block_time_mixed_mode "$mode_alias")"
+	simulate_apply_duration="$(calculate_simulate_apply_duration "$CLASSIC_TX_RATE" "$soroban_tx_rate")"
+
+	dotnet run \
+		--project "$PROJECT" \
+		mission "$MISSION" \
+		--destination "$DESTINATION" \
+		--image="$STELLAR_CORE_IMAGE" \
+		--netdelay-image="$NETDELAY_IMAGE" \
+		--postgres-image="$POSTGRES_IMAGE" \
+		--nginx-image="$NGINX_IMAGE" \
+		--prometheus-exporter-image="$PROMETHEUS_EXPORTER_IMAGE" \
+		--ingress-internal-domain="$INGRESS_INTERNAL_DOMAIN" \
+		--avoid-node-labels="$AVOID_NODE_LABELS" \
+		--export-to-prometheus \
+		--classic-tx-rate="$CLASSIC_TX_RATE" \
+		--soroban-tx-rate="$soroban_tx_rate" \
+		--min-block-time-mixed-mode="$min_block_time_mixed_mode" \
+		--min-block-time-ms="$MIN_BLOCK_TIME_MS" \
+		--max-block-time-ms="$MAX_BLOCK_TIME_MS" \
+		--num-pregenerated-txs="$NUM_PREGENERATED_TXS" \
+		--genesis-test-account-count="$GENESIS_TEST_ACCOUNT_COUNT" \
+		--simulate-apply-weight "$SIMULATE_APPLY_WEIGHT" \
+		--simulate-apply-duration "$simulate_apply_duration" \
+		--pubnet-data "$PUBNET_DATA" \
+		--tier1-keys "$TIER1_KEYS" \
+		--network-size-limit "$NETWORK_SIZE_LIMIT" \
+		--require-node-labels=purpose:largetests \
+		--tolerate-node-taints=largetests
+}
+
+parse_args "$@"
+validate_args
+
+PUBNET_DATA="$DATA_ROOT/data/public-network-data-2025-06-24.json"
+TIER1_KEYS="$DATA_ROOT/data/tier1keys.json"
+
+if [ -n "$SAC_TX_RATE" ]; then
+	run_min_block_time_mixed sac "$SAC_TX_RATE"
+fi
+
+if [ -n "$OZ_TX_RATE" ]; then
+	run_min_block_time_mixed oz "$OZ_TX_RATE"
+fi
+
+if [ -n "$SOROSWAP_TX_RATE" ]; then
+	run_min_block_time_mixed soroswap "$SOROSWAP_TX_RATE"
+fi

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -206,7 +206,6 @@ type Tests(output: ITestOutputHelper) =
 
         let cmds = nCfg.getInitCommands PeerSpecificConfigFile coreSet.options
         let cmdStr = ShAnd(cmds).ToString()
-        let exp = "{ ; }"
         Assert.Equal(exp, cmdStr)
 
     [<Fact>]

--- a/src/FSLibrary/MaxTPSTest.fs
+++ b/src/FSLibrary/MaxTPSTest.fs
@@ -171,18 +171,18 @@ let maxTPSTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg: LoadG
 
             List.map
                 (fun (cs: CoreSet) ->
-                    if isLoadGenNode cs then
-                        let i = j
-                        j <- j + 1
+                    let pregenerateTxs =
+                        if isLoadGenNode cs then
+                            let i = j
+                            j <- j + 1
+                            Some(txs, accountsPerNode, accountsPerNode * i)
+                        else
+                            Some(0, 1, 0)
 
-                        { cs with
-                              options =
-                                  { cs.options with
-                                        initialization =
-                                            { cs.options.initialization with
-                                                  pregenerateTxs = Some(txs, accountsPerNode, accountsPerNode * i) } } }
-                    else
-                        cs)
+                    { cs with
+                          options =
+                              { cs.options with
+                                    initialization = { cs.options.initialization with pregenerateTxs = pregenerateTxs } } })
                 allNodes
         | _ -> allNodes
 

--- a/src/FSLibrary/MinBlockTimeTest.fs
+++ b/src/FSLibrary/MinBlockTimeTest.fs
@@ -25,7 +25,23 @@ let private searchThresholdMs = 100
 // For the purposes of min block test, use high value to avoid noise from SCP timeouts
 let private timeout = 2000
 
-let private mixedPregenLedgerMultiplier = 15
+let private txSetSizeBufferMultiplier = 2
+
+let private maxTxSetSizeForTarget (kind: string) (targetMs: int) (txRate: int) =
+    let scaled = int64 targetMs * int64 txRate * int64 txSetSizeBufferMultiplier
+
+    let txSetSize = (scaled + 999L) / 1000L
+
+    if txSetSize > int64 System.Int32.MaxValue then
+        failwithf "%s MaxTxSetSize %d exceeds supported int range" kind txSetSize
+
+    max (int txSetSize) 100
+
+let private classicMaxTxSetSizeForTarget (targetMs: int) (classicTxRate: int) =
+    maxTxSetSizeForTarget "Classic" targetMs classicTxRate
+
+let private sorobanMaxTxSetSizeForTarget (targetMs: int) (sorobanTxRate: int) =
+    maxTxSetSizeForTarget "Soroban" targetMs sorobanTxRate
 
 type private MixedPregenSorobanResources =
     { instructions: int64
@@ -46,7 +62,7 @@ let private mixedPregenSorobanResources (mode: LoadGenMode) =
           writeBytes = 800
           readOnlyEntries = 2
           readWriteEntries = 2
-          txSizeBytes = 350
+          txSizeBytes = 1000
           contractEventBytes = 200 }
     | MixedPregenOZTokenTransfer ->
         { instructions = 5000000L
@@ -66,8 +82,8 @@ let private mixedPregenSorobanResources (mode: LoadGenMode) =
           contractEventBytes = 200 }
     | _ -> failwithf "Mode %s is not a MIXED_PREGEN_* mode" (mode.ToString())
 
-let private scaleLedgerLimit (name: string) (value: int) (sorobanTxRate: int) =
-    let scaled = int64 value * int64 sorobanTxRate * int64 mixedPregenLedgerMultiplier
+let private scaleLedgerLimit (name: string) (value: int) (ledgerMaxTxCount: int) =
+    let scaled = int64 value * int64 ledgerMaxTxCount
 
     if scaled > int64 System.Int32.MaxValue then
         failwithf "Scaled %s limit %d exceeds supported int range" name scaled
@@ -78,47 +94,56 @@ let private upgradeMixedPregenSorobanLimits
     (formation: StellarFormation)
     (coreSets: CoreSet list)
     (baseLoadGen: LoadGen)
+    (targetMs: int)
     =
     let sorobanTxRate = baseLoadGen.sorobanTxRate |> Option.defaultValue 0
 
     if sorobanTxRate > 0 then
         let resources = mixedPregenSorobanResources baseLoadGen.mode
         let footprintEntries = resources.readOnlyEntries + resources.readWriteEntries
+        let targetMaxTxSetSize = sorobanMaxTxSetSizeForTarget targetMs sorobanTxRate
 
         LogInfo
-            "Upgrading MIXED_PREGEN_* Soroban limits for %s: soroban TPS=%d, ledger multiplier=%d"
+            "Upgrading MIXED_PREGEN_* Soroban limits for %s: Soroban MaxTxSetSize=%d for T=%dms, soroban TPS=%d, buffer=%dx"
             (baseLoadGen.mode.ToString())
+            targetMaxTxSetSize
+            targetMs
             sorobanTxRate
-            mixedPregenLedgerMultiplier
+            txSetSizeBufferMultiplier
 
+        formation.UpgradeSorobanMaxTxSetSize coreSets targetMaxTxSetSize
         formation.SetupUpgradeContract coreSets.Head
         let peer = formation.NetworkCfg.GetPeer coreSets.Head 0
 
-        let scaledLedgerMaxTxCount = sorobanTxRate * mixedPregenLedgerMultiplier
-
         let ledgerMaxInstructions =
-            max (peer.GetLedgerMaxInstructions()) (resources.instructions * int64 scaledLedgerMaxTxCount)
+            max (peer.GetLedgerMaxInstructions()) (resources.instructions * int64 targetMaxTxSetSize)
 
         let ledgerMaxReadBytes =
-            max (peer.GetLedgerReadBytes()) (scaleLedgerLimit "ledger read bytes" resources.readBytes sorobanTxRate)
+            max
+                (peer.GetLedgerReadBytes())
+                (scaleLedgerLimit "ledger read bytes" resources.readBytes targetMaxTxSetSize)
 
         let ledgerMaxWriteBytes =
-            max (peer.GetLedgerWriteBytes()) (scaleLedgerLimit "ledger write bytes" resources.writeBytes sorobanTxRate)
+            max
+                (peer.GetLedgerWriteBytes())
+                (scaleLedgerLimit "ledger write bytes" resources.writeBytes targetMaxTxSetSize)
 
         let ledgerMaxReadEntries =
-            max (peer.GetLedgerReadEntries()) (scaleLedgerLimit "ledger read entries" footprintEntries sorobanTxRate)
+            max
+                (peer.GetLedgerReadEntries())
+                (scaleLedgerLimit "ledger read entries" footprintEntries targetMaxTxSetSize)
 
         let ledgerMaxWriteEntries =
             max
                 (peer.GetLedgerWriteEntries())
-                (scaleLedgerLimit "ledger write entries" resources.readWriteEntries sorobanTxRate)
+                (scaleLedgerLimit "ledger write entries" resources.readWriteEntries targetMaxTxSetSize)
 
-        let ledgerMaxTxCount = max (peer.GetLedgerMaxTxCount()) scaledLedgerMaxTxCount
+        let ledgerMaxTxCount = max (peer.GetLedgerMaxTxCount()) targetMaxTxSetSize
 
         let ledgerMaxTransactionsSizeBytes =
             max
                 (peer.GetLedgerMaxTransactionsSizeBytes())
-                (scaleLedgerLimit "ledger tx bytes" resources.txSizeBytes sorobanTxRate)
+                (scaleLedgerLimit "ledger tx bytes" resources.txSizeBytes targetMaxTxSetSize)
 
         let txMaxInstructions = max (peer.GetTxMaxInstructions()) resources.instructions
         let txMaxReadBytes = max (peer.GetTxReadBytes()) resources.readBytes
@@ -272,19 +297,19 @@ let minBlockTimeTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg:
 
             List.map
                 (fun (cs: CoreSet) ->
-                    if isLoadGenNode cs then
-                        let i = if isMixedPregenMode mode then j % partitionCount else j
+                    let pregenerateTxs =
+                        if isLoadGenNode cs then
+                            let i = if isMixedPregenMode mode then j % partitionCount else j
 
-                        j <- j + 1
+                            j <- j + 1
+                            Some(txs, accountsPerNode, accountsPerNode * i)
+                        else
+                            Some(0, 1, 0)
 
-                        { cs with
-                              options =
-                                  { cs.options with
-                                        initialization =
-                                            { cs.options.initialization with
-                                                  pregenerateTxs = Some(txs, accountsPerNode, accountsPerNode * i) } } }
-                    else
-                        cs)
+                    { cs with
+                          options =
+                              { cs.options with
+                                    initialization = { cs.options.initialization with pregenerateTxs = pregenerateTxs } } })
                 allNodes
         | _ -> allNodes
 
@@ -298,15 +323,14 @@ let minBlockTimeTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg:
             let fixedTxRate = context.txRate
 
             let classicTxRateForLimits =
-                if isMixedPregenMode baseLoadGen.mode then
-                    baseLoadGen.classicTxRate |> Option.defaultValue 0
-                else
-                    fixedTxRate
+                match baseLoadGen.classicTxRate, context.minBlockTimeMixedClassicTxRate with
+                | Some rate, _ -> rate
+                | None, Some rate -> rate
+                | None, None -> fixedTxRate
 
-            // Headroom factor matches MaxTPSTest's `limitMultiplier = 5 * 2`:
-            // 5x for ledgers-per-second at the default 5s close time, 2x for
-            // spike margin. Applied at every (re)boot because pod restart
-            // resets the network to genesis defaults.
+            if classicTxRateForLimits < 0 then
+                failwith "--classic-tx-rate must be non-negative"
+
             let isPaymentOnly = baseLoadGen.mode = GeneratePaymentLoad || baseLoadGen.mode = PayPregenerated
 
             let setupCoreSets (coreSets: CoreSet list) =
@@ -314,11 +338,8 @@ let minBlockTimeTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg:
                 formation.ManualClose coreSets
                 formation.WaitUntilSynced coreSets
                 formation.UpgradeProtocolToLatest coreSets
-                formation.UpgradeMaxTxSetSize coreSets (max (classicTxRateForLimits * mixedPregenLedgerMultiplier) 100)
 
-                if isMixedPregenMode baseLoadGen.mode then
-                    upgradeMixedPregenSorobanLimits formation coreSets baseLoadGen
-                elif not isPaymentOnly then
+                if not (isMixedPregenMode baseLoadGen.mode) && not isPaymentOnly then
                     MaxTPSTest.upgradeSorobanLedgerLimits context formation coreSets fixedTxRate
                     MaxTPSTest.upgradeSorobanTxLimits context formation coreSets
 
@@ -350,6 +371,22 @@ let minBlockTimeTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg:
                 let peer = formation.NetworkCfg.GetPeer allNodes.Head 0
                 peer.WaitForScpLedgerCloseTime targetMs |> ignore
 
+            let upgradeClassicMaxTxSetSize (targetMs: int) =
+                let maxTxSetSize = classicMaxTxSetSizeForTarget targetMs classicTxRateForLimits
+
+                LogInfo
+                    "Upgrading classic MaxTxSetSize to %d for T=%dms, classic TPS=%d, buffer=%dx"
+                    maxTxSetSize
+                    targetMs
+                    classicTxRateForLimits
+                    txSetSizeBufferMultiplier
+
+                formation.UpgradeMaxTxSetSize allNodes maxTxSetSize
+
+            let upgradeSorobanMaxTxSetSize (targetMs: int) =
+                if isMixedPregenMode baseLoadGen.mode then
+                    upgradeMixedPregenSorobanLimits formation allNodes baseLoadGen targetMs
+
             let evaluateAt (targetMs: int) : bool =
                 let loadGen =
                     { baseLoadGen with
@@ -361,6 +398,8 @@ let minBlockTimeTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg:
                           txrate = fixedTxRate }
 
                 applySCPUpgrade targetMs
+                upgradeClassicMaxTxSetSize targetMs
+                upgradeSorobanMaxTxSetSize targetMs
                 formation.clearMetrics allNodes
 
                 // A loadgen failure is not an SLA signal — it usually means the

--- a/src/FSLibrary/MinBlockTimeTest.fs
+++ b/src/FSLibrary/MinBlockTimeTest.fs
@@ -195,40 +195,50 @@ let private withOverlayOnlyMode (formation: StellarFormation) (coreSets: CoreSet
         LogInfo "Disabling overlay-only mode"
         toggleOverlayOnlyMode formation coreSets
 
-let private readLedgerAgePercentiles (peer: Peer) : float * float =
+let private readLedgerAgePercentiles (peer: Peer) : Peer * float * float =
     let h = peer.GetMetrics().LedgerAgeClosedHistogram
-    float h.``75``, float h.``99``
+    peer, float h.``75``, float h.``99``
+
+let private collectLedgerAgePercentiles
+    (formation: StellarFormation)
+    (coreSets: CoreSet list)
+    : (Peer * float * float) list =
+    formation.NetworkCfg.PeersInSets(List.toArray coreSets)
+    |> List.map (fun peer -> async { return readLedgerAgePercentiles peer })
+    |> Async.Parallel
+    |> Async.RunSynchronously
+    |> Array.toList
 
 // Returns true iff every peer's ledger.age.closed-histogram satisfies:
 //   P75 in [0.80*T, 1.20*T)
 //   P99 <= 2*T
 //
+// Evaluate a pre-collected snapshot. Core keeps closing ledgers after loadgen
+// exits, so delaying metric collection skews SLA reads.
+//
 // FIXME: the P75 tolerance is temporarily widened to +/-20% because
 // stellar-core currently has perf regressions that prevent the intended
 // +/-5% band from being achievable. Tighten this back to 0.95/1.05 (or
 // lower) once those regressions are fixed.
-let private checkLedgerAgeSLA (formation: StellarFormation) (coreSets: CoreSet list) (targetMs: int) : bool =
+let private checkLedgerAgeSLA (percentiles: (Peer * float * float) list) (targetMs: int) : bool =
     let tf = float targetMs
     let tLo = tf * 0.80
     let tHi = tf * 1.20
     let p99Max = tf * 2.0
     let mutable ok = true
 
-    formation.NetworkCfg.EachPeerInSets
-        (List.toArray coreSets)
-        (fun peer ->
-            let p75, p99 = readLedgerAgePercentiles peer
-            let peerOk = p75 >= tLo && p75 < tHi && p99 <= p99Max
+    for peer, p75, p99 in percentiles do
+        let peerOk = p75 >= tLo && p75 < tHi && p99 <= p99Max
 
-            LogInfo
-                "peer=%s T=%dms p75=%.0f p99=%.0f -> %s"
-                peer.ShortName.StringName
-                targetMs
-                p75
-                p99
-                (if peerOk then "PASS" else "FAIL")
+        LogInfo
+            "peer=%s T=%dms p75=%.0f p99=%.0f -> %s"
+            peer.ShortName.StringName
+            targetMs
+            p75
+            p99
+            (if peerOk then "PASS" else "FAIL")
 
-            if not peerOk then ok <- false)
+        if not peerOk then ok <- false
 
     ok
 
@@ -416,9 +426,13 @@ let minBlockTimeTest (context: MissionContext) (baseLoadGen: LoadGen) (setupCfg:
                         formation.RunMultiLoadgen activeLoadGenNodes loadGen
                 with e -> failwithf "Loadgen failed at T=%dms; TPS might be too high (%s)" targetMs e.Message
 
+                // Snapshot SLA metrics before consistency checks; those can take
+                // long enough to skew the ledger age percentiles.
+                let ledgerAgePercentiles = collectLedgerAgePercentiles formation allNodes
+
                 formation.CheckNoErrorsAndPairwiseConsistency()
                 formation.EnsureAllNodesInSync allNodes
-                checkLedgerAgeSLA formation allNodes targetMs
+                checkLedgerAgeSLA ledgerAgePercentiles targetMs
 
             if context.minBlockTimeMs >= context.maxBlockTimeMs then
                 failwithf

--- a/src/FSLibrary/MinBlockTimeTest.fs
+++ b/src/FSLibrary/MinBlockTimeTest.fs
@@ -226,6 +226,13 @@ let private checkLedgerAgeSLA (percentiles: (Peer * float * float) list) (target
     let tHi = tf * 1.20
     let p99Max = tf * 2.0
     let mutable ok = true
+    let formatDeviation value =
+        let deviation = (value - tf) / tf * 100.0
+
+        if deviation >= 0.0 then
+            sprintf "+%.1f%%" deviation
+        else
+            sprintf "%.1f%%" deviation
 
     for peer, p75, p99 in percentiles do
         let peerOk = p75 >= tLo && p75 < tHi && p99 <= p99Max
@@ -239,6 +246,18 @@ let private checkLedgerAgeSLA (percentiles: (Peer * float * float) list) (target
             (if peerOk then "PASS" else "FAIL")
 
         if not peerOk then ok <- false
+
+    if not percentiles.IsEmpty then
+        let avgP75 = percentiles |> List.averageBy (fun (_, p75, _) -> p75)
+        let avgP99 = percentiles |> List.averageBy (fun (_, _, p99) -> p99)
+
+        LogInfo
+            "all peers T=%dms avg-p75=%.0f (%s vs target) avg-p99=%.0f (%s vs target)"
+            targetMs
+            avgP75
+            (formatDeviation avgP75)
+            avgP99
+            (formatDeviation avgP99)
 
     ok
 

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -316,15 +316,19 @@ type StellarCoreCfg =
         if self.emitMeta then
             t.Add("METADATA_OUTPUT_STREAM", CfgVal.metaStreamPath) |> ignore
 
-        match self.network.missionContext.simulateApplyWeight, self.network.missionContext.simulateApplyDuration with
-        | None, None -> ()
-        | Some weight, Some duration ->
-            t.Add("OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING", duration) |> ignore
-            t.Add("OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING", weight) |> ignore
-        | _, _ ->
-            raise (
-                System.ArgumentException "simulate-apply-weight and simulate-apply-duration must be defined together"
-            )
+        match self.containerType with
+        | InitCoreContainer -> ()
+        | MainCoreContainer ->
+            match self.network.missionContext.simulateApplyWeight, self.network.missionContext.simulateApplyDuration with
+            | None, None -> ()
+            | Some weight, Some duration ->
+                t.Add("OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING", duration) |> ignore
+                t.Add("OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING", weight) |> ignore
+            | _, _ ->
+                raise (
+                    System.ArgumentException
+                        "simulate-apply-weight and simulate-apply-duration must be defined together"
+                )
 
         distributionToToml self.network.missionContext.byteCountDistribution "BYTE_COUNT" t
         distributionToToml self.network.missionContext.wasmBytesDistribution "WASM_BYTES" t
@@ -451,13 +455,11 @@ type StellarCoreCfg =
             let validators = List.filter (fun (v: AutoValidator) -> v.keys <> self.nodeSeed) qs.validators
             List.iter (fun v -> validatorsTab.Add(autoValidatorToTable v) |> ignore) validators
 
-        // When simulateApplyWeight = Some _, stellar-core sets MODE_STORES_HISTORY
-        // which is used for simulations that only test consensus.
-        // In such cases, we should not pass put and mkdir commands.
         if self.localHistory then
             localTab.Add(
                 CfgVal.localHistName,
-                if self.network.missionContext.simulateApplyWeight.IsSome then
+                if self.containerType = MainCoreContainer
+                   && self.network.missionContext.simulateApplyWeight.IsSome then
                     histGetOnly
                 else
                     defaultHist

--- a/src/FSLibrary/StellarCorePeer.fs
+++ b/src/FSLibrary/StellarCorePeer.fs
@@ -27,7 +27,10 @@ type NetworkCfg with
             for i in 0 .. (coreSet.CurrentCount - 1) do
                 f (self.GetPeer coreSet i)
 
+    member self.PeersInSets(coreSetArray: CoreSet array) : Peer list =
+        [ for coreSet in coreSetArray do
+              for i in 0 .. (coreSet.CurrentCount - 1) do
+                  self.GetPeer coreSet i ]
+
     member self.EachPeerInSets (coreSetArray: CoreSet array) (f: Peer -> unit) : unit =
-        for coreSet in coreSetArray do
-            for i in 0 .. (coreSet.CurrentCount - 1) do
-                f (self.GetPeer coreSet i)
+        self.PeersInSets coreSetArray |> List.iter f

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -349,7 +349,7 @@ let WithProbes (container: V1Container) (probeTimeout: int) : V1Container =
             periodSeconds = System.Nullable<int>(1),
             failureThreshold = System.Nullable<int>(60),
             timeoutSeconds = System.Nullable<int>(probeTimeout),
-            initialDelaySeconds = System.Nullable<int>(60),
+            initialDelaySeconds = System.Nullable<int>(120),
             httpGet = V1HTTPGetAction(path = "/info", port = httpPortStr)
         )
 
@@ -517,8 +517,7 @@ type NetworkCfg with
             let cmdAndArgs = (Array.map ShWord.OfStr (Array.append [| CfgVal.stellarCoreBinPath |] args))
             ShCmd(Array.append cmdAndArgs cfgWords)
 
-        let nonSimulation = self.missionContext.simulateApplyWeight.IsNone
-        let runCoreIf flag args = if flag && nonSimulation then Some(runCore args) else None
+        let runCoreIf flag args = if flag then Some(runCore args) else None
 
         let ignoreError cmd : ShCmd Option =
             match cmd with

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -408,7 +408,11 @@ type StellarFormation with
         self.ArmUpgradeEntries coreSetList configUpgradeSetKey upgradeTime
 
     member self.clearMetrics(coreSets: CoreSet list) =
-        self.NetworkCfg.EachPeerInSets(coreSets |> List.toArray) (fun peer -> peer.ClearMetrics())
+        self.NetworkCfg.PeersInSets(coreSets |> List.toArray)
+        |> List.map (fun peer -> async { peer.ClearMetrics() })
+        |> Async.Parallel
+        |> Async.RunSynchronously
+        |> ignore
 
     // This is similar to RunLoadgen but runs a 1/N fractional portion of a
     // given LoadGen on node 0 of each of N CoreSets.


### PR DESCRIPTION
- Properly spin up watchers when in pregenerated txs mode
- Upgrades: harden network limit calculation by including target block time in the calculation
- Fix SAC txSize estimate for network limits
- Fix broken support for simulate apply config flags
- Bump init delay timer. Previously, the lower limit would cause some containers to get killed sporadically on startup