### PR TITLE
Use automatic quorum set configuration by default

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -119,7 +119,6 @@ type MissionOptions
         asanOptions: string option,
         catchupSkipKnownResultsForTesting: bool option,
         checkEventsAreConsistentWithEntryDiffs: bool option,
-        enableRelaxedAutoQsetConfig: bool,
         jobMonitorExternalHost: string option,
         txBatchMaxSize: int option,
         runForMaxTps: string option,
@@ -527,12 +526,6 @@ type MissionOptions
              Required = false)>]
     member self.CheckEventsAreConsistentWithEntryDiffs = checkEventsAreConsistentWithEntryDiffs
 
-    [<Option("enable-relaxed-auto-qset-config",
-             HelpText = "Enables the use of automatic quorum set configuration on missions that may create core sets that do not satisfy the redundancy and history requirements placed on pubnet validators.  Requires a stellar-core version that supports the SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING config option.",
-             Required = false,
-             Default = false)>]
-    member self.EnableRelaxedAutoQsetConfig = enableRelaxedAutoQsetConfig
-
     [<Option("job-monitor-external-host",
              HelpText = "Cluster-external hostname to connect to for access to job monitor",
              Required = false)>]
@@ -847,7 +840,6 @@ let main argv =
                                updateSorobanCosts = None
                                genesisTestAccountCount = mission.GenesisTestAccountCount
                                asanOptions = mission.asanOptions
-                               enableRelaxedAutoQsetConfig = mission.EnableRelaxedAutoQsetConfig
                                jobMonitorExternalHost = mission.JobMonitorExternalHost
                                txBatchMaxSize = mission.TxBatchMaxSize
                                runForMaxTps = mission.RunForMaxTps

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -124,7 +124,6 @@ let ctx : MissionContext =
       updateSorobanCosts = None
       genesisTestAccountCount = None
       asanOptions = None
-      enableRelaxedAutoQsetConfig = false
       jobMonitorExternalHost = None
       txBatchMaxSize = None
       runForMaxTps = None

--- a/src/FSLibrary/MissionCatchupHelpers.fs
+++ b/src/FSLibrary/MissionCatchupHelpers.fs
@@ -60,11 +60,7 @@ let MakeCatchupSets (options: CatchupMissionOptions) =
         { CoreSetOptions.GetDefault options.generatorImage with
               nodeCount = 1
               quorumSet = CoreSetQuorum(CoreSetName "generator")
-              accelerateTime = true
-              // FIXME: Remove these options once the stable (old) image in
-              // CI supports skipping validator quality checks
-              skipHighCriticalValidatorChecks = false
-              quorumSetConfigType = RequireExplicitQset }
+              accelerateTime = true }
 
 
     let generatorSet = MakeLiveCoreSet "generator" generatorOptions
@@ -74,11 +70,7 @@ let MakeCatchupSets (options: CatchupMissionOptions) =
               nodeCount = 1
               quorumSet = CoreSetQuorum(CoreSetName "generator")
               accelerateTime = true
-              initialization = CoreSetInitialization.DefaultNoForceSCP
-              // FIXME: Remove these options once the stable (old) image in
-              // CI supports skipping validator quality checks
-              skipHighCriticalValidatorChecks = false
-              quorumSetConfigType = RequireExplicitQset }
+              initialization = CoreSetInitialization.DefaultNoForceSCP }
 
     let minimal1Options = { newNodeOptions with catchupMode = CatchupRecent(0) }
     let minimal1Set = MakeDeferredCoreSet "minimal1" minimal1Options
@@ -133,11 +125,7 @@ let MakeCatchupSets (options: CatchupMissionOptions) =
         { CoreSetOptions.GetDefault options.versionImage with
               nodeCount = 1
               quorumSet = CoreSetQuorum(CoreSetName "version")
-              accelerateTime = true
-              // FIXME: Remove these options once the stable (old) image in
-              // CI supports skipping validator quality checks
-              skipHighCriticalValidatorChecks = false
-              quorumSetConfigType = RequireExplicitQset }
+              accelerateTime = true }
 
     let versionSet = MakeLiveCoreSet "version" versionOptions
 

--- a/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
+++ b/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
@@ -37,11 +37,7 @@ let databaseInplaceUpgrade (context: MissionContext) =
                   // force-SCP) keeps it from falsely reporting "Synced!" at
                   // ledger 1 when pod scheduling delays let the core nodes get
                   // ahead of it.
-                  initialization = CoreSetInitialization.DefaultNoForceSCP
-                  // FIXME: Remove these options once the stable (old) image in
-                  // CI supports skipping validator quality checks
-                  skipHighCriticalValidatorChecks = false
-                  quorumSetConfigType = RequireExplicitQset }
+                  initialization = CoreSetInitialization.DefaultNoForceSCP }
 
     let fetchFromPeer = Some(CoreSetName("before-upgrade"), 0)
 

--- a/src/FSLibrary/MissionMixedImageLoadGeneration.fs
+++ b/src/FSLibrary/MissionMixedImageLoadGeneration.fs
@@ -46,11 +46,7 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
                   invariantChecks = AllInvariantsExceptEvents
                   accelerateTime = false
                   dumpDatabase = false
-                  quorumSet = qSet
-                  // FIXME: Remove these options once the stable (old) image in
-                  // CI supports skipping validator quality checks
-                  skipHighCriticalValidatorChecks = false
-                  quorumSetConfigType = RequireExplicitQset }
+                  quorumSet = qSet }
 
     let newCoreSet =
         MakeLiveCoreSet

--- a/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
+++ b/src/FSLibrary/MissionMixedImageNetworkSurvey.fs
@@ -119,11 +119,7 @@ let mixedImageNetworkSurvey (context: MissionContext) =
               { CoreSetOptions.GetDefault oldImage with
                     nodeCount = oldKeys.Length
                     accelerateTime = false
-                    surveyPhaseDuration = Some surveyPhaseDurationMinutes
-                    // FIXME: Remove these options once the stable (old) image
-                    // in CI supports skipping validator quality checks
-                    skipHighCriticalValidatorChecks = false
-                    quorumSetConfigType = RequireExplicitQset } }
+                    surveyPhaseDuration = Some surveyPhaseDurationMinutes } }
 
     let newCoreSet =
         { name = CoreSetName newName

--- a/src/FSLibrary/MissionVersionMixConsensus.fs
+++ b/src/FSLibrary/MissionVersionMixConsensus.fs
@@ -27,11 +27,7 @@ let versionMixConsensus (context: MissionContext) =
             "before"
             { CoreSetOptions.GetDefault oldImage with
                   nodeCount = 2
-                  quorumSet = CoreSetQuorum(CoreSetName "before")
-                  // FIXME: Remove these options once the stable (old) image in
-                  // CI supports skipping validator quality checks
-                  skipHighCriticalValidatorChecks = false
-                  quorumSetConfigType = RequireExplicitQset }
+                  quorumSet = CoreSetQuorum(CoreSetName "before") }
 
     let fetchFromPeer = Some(CoreSetName("before"), 0)
 
@@ -42,7 +38,6 @@ let versionMixConsensus (context: MissionContext) =
                   nodeCount = 2
                   historyNodes = Some([])
                   quorumSet = CoreSetQuorumListWithThreshold([ CoreSetName "new-core"; CoreSetName "old-core" ], 100)
-                  quorumSetConfigType = RequireExplicitQset
                   initialization =
                       { newDb = true
                         newHist = true
@@ -58,10 +53,6 @@ let versionMixConsensus (context: MissionContext) =
                   nodeCount = 2
                   historyNodes = Some([])
                   quorumSet = CoreSetQuorumListWithThreshold([ CoreSetName "new-core"; CoreSetName "old-core" ], 100)
-                  // FIXME: Remove these options once the stable (old) image in
-                  // CI supports skipping validator quality checks
-                  skipHighCriticalValidatorChecks = false
-                  quorumSetConfigType = RequireExplicitQset
                   initialization =
                       { newDb = true
                         newHist = true

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -170,8 +170,7 @@ type StellarCoreCfg =
       emitMeta: bool
       addArtificialDelayUsec: int option // optional delay for testing in microseconds
       surveyPhaseDuration: int option
-      containerType: CoreContainerType
-      skipHighCriticalValidatorChecks: bool }
+      containerType: CoreContainerType }
 
     member self.ToTOML() : TomlTable =
         let t = Toml.Create()
@@ -241,9 +240,7 @@ type StellarCoreCfg =
         | Some _ -> failwith "run-for-max-tps must be either classic, classic-prev-version, or soroban"
         | None -> ()
 
-        if self.skipHighCriticalValidatorChecks
-           && self.network.missionContext.enableRelaxedAutoQsetConfig then
-            t.Add("SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING", true) |> ignore
+        t.Add("SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING", true) |> ignore
 
         match self.homeDomain with
         | None -> ()
@@ -555,13 +552,12 @@ type NetworkCfg with
         // Produces a simple flat qset of nodes. Uses auto quorum set
         // configuration if possible.
         let simpleQuorum (nks: (PeerShortName * KeyPair) array) =
-            match o.quorumSetConfigType, o.homeDomain, self.missionContext.enableRelaxedAutoQsetConfig with
-            | RequireAutoQset, Some hd, _
-            | PreferAutoQset, Some hd, true -> toAutoQSet (List.ofArray nks) hd
-            | PreferAutoQset, None, _
-            | PreferAutoQset, _, false
-            | RequireExplicitQset, _, _ -> toExplicitQSet nks None
-            | RequireAutoQset, None, _ -> failwith "Auto quorum set configuration requires a home domain"
+            match o.quorumSetConfigType, o.homeDomain with
+            | RequireAutoQset, Some hd
+            | PreferAutoQset, Some hd -> toAutoQSet (List.ofArray nks) hd
+            | PreferAutoQset, None
+            | RequireExplicitQset, _ -> toExplicitQSet nks None
+            | RequireAutoQset, None -> failwith "Auto quorum set configuration requires a home domain"
 
         let checkAutoQSetIncompatability (mode: string) =
             if o.quorumSetConfigType = RequireAutoQset then
@@ -645,8 +641,7 @@ type NetworkCfg with
           emitMeta = opts.emitMeta
           addArtificialDelayUsec = opts.addArtificialDelayUsec
           surveyPhaseDuration = opts.surveyPhaseDuration
-          containerType = MainCoreContainer
-          skipHighCriticalValidatorChecks = opts.skipHighCriticalValidatorChecks }
+          containerType = MainCoreContainer }
 
     member self.StellarCoreCfg(c: CoreSet, i: int, ctype: CoreContainerType) : StellarCoreCfg =
         { network = self
@@ -686,5 +681,4 @@ type NetworkCfg with
           emitMeta = c.options.emitMeta
           addArtificialDelayUsec = c.options.addArtificialDelayUsec
           surveyPhaseDuration = c.options.surveyPhaseDuration
-          containerType = ctype
-          skipHighCriticalValidatorChecks = c.options.skipHighCriticalValidatorChecks }
+          containerType = ctype }

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -177,14 +177,10 @@ type InvariantChecksSpec =
 // Determines how quorum set configurations should be generated
 type QuorumSetConfiguration =
     // Prefer automatic quorum set configuration. Fall back on explicit quorum
-    // set configuration if automatic configuration is not possible, or if
-    // --enable-relaxed-auto-qset-config is not set.
+    // set configuration if automatic configuration is not possible
     | PreferAutoQset
     // Require automatic quorum set configuration. Fail if automatic
-    // configuration is not possible. Uses automatic configuration even if
-    // --enable-relaxed-auto-qset-config is not set, so missions using this
-    // option *must* satisfy the HIGH quality validator checks present in
-    // stellar-core.
+    // configuration is not possible.
     | RequireAutoQset
     // Require explicit quorum set configuration.
     | RequireExplicitQset
@@ -221,11 +217,7 @@ type CoreSetOptions =
       emitMeta: bool
       addArtificialDelayUsec: int option
       surveyPhaseDuration: int option
-      updateSorobanCosts: bool option
-      // `skipHighCriticalValidatorChecks` exists to allow supercluster to
-      // remain compatible with older stellar-core images that do not have the
-      // ability to turn of validator checks for HIGH and CRITICAL validators
-      skipHighCriticalValidatorChecks: bool }
+      updateSorobanCosts: bool option }
 
     member self.WithWaitForConsensus(w: bool) =
         { self with initialization = { self.initialization with waitForConsensus = w } }
@@ -262,8 +254,7 @@ type CoreSetOptions =
           emitMeta = false
           addArtificialDelayUsec = None
           surveyPhaseDuration = None
-          updateSorobanCosts = None
-          skipHighCriticalValidatorChecks = true }
+          updateSorobanCosts = None }
 
 type CoreSet =
     { name: CoreSetName

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -119,7 +119,6 @@ type MissionContext =
       catchupSkipKnownResultsForTesting: bool option
       checkEventsAreConsistentWithEntryDiffs: bool option
       updateSorobanCosts: bool option
-      enableRelaxedAutoQsetConfig: bool
       jobMonitorExternalHost: string option
       txBatchMaxSize: int option
       runForMaxTps: string option

--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -547,11 +547,6 @@ let FullPubnetCoreSets (context: MissionContext) (manualclose: bool) (enforceMin
             |> Array.map
                 (fun (_, nodes: PubnetNode.Root []) -> Array.map (fun (n: PubnetNode.Root) -> n.PublicKey) nodes)
 
-        let orgToExplicitQSet (org: string array) : ExplicitQuorumSet =
-            { thresholdPercent = Some(51) // Simple majority
-              validators = pubKeysToValidators org
-              innerQuorumSets = Array.empty }
-
         let tier1Orgs =
             tier1Nodes
             |> Array.map
@@ -565,14 +560,9 @@ let FullPubnetCoreSets (context: MissionContext) (manualclose: bool) (enforceMin
 
         if context.flatQuorum.IsSome && context.flatQuorum.Value then
             ExplicitQuorum flatQset
-        else if context.enableRelaxedAutoQsetConfig then
+        else
             let validators = Array.map pubKeysToAutoValidators tier1NodesGroupedByHomeDomain |> Array.toList
             AutoQuorum { homeDomains = Set.toList tier1Orgs; validators = List.fold (@) [] validators }
-        else
-            ExplicitQuorum
-                { thresholdPercent = Some(67) // 3f + 1
-                  validators = Map.empty
-                  innerQuorumSets = Array.map orgToExplicitQSet tier1NodesGroupedByHomeDomain }
 
     let pubnetOpts =
         { CoreSetOptions.GetDefault context.image with


### PR DESCRIPTION
Closes #271

This change enables automatic quorum set configuration on all missions that previously had it disabled until the old stable image supported the `SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING` configuration option. That option was introduced in stellar-core v22.3.0, so this is beyond overdue.

The change also removes the `--enable-relaxed-auto-qset-config` option and uncondtionally sets
`SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING=true`.  This ensures that we use automatic quorum set configuration (and therefore the "new" nomination algorithm) wherever possible.