### PR TITLE
Misc fixes

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -116,6 +116,7 @@ type MissionOptions
         numPregeneratedTxs: int option,
         genesisTestAccountCount: int option,
         asanOptions: string option,
+        coreEnv: string option,
         catchupSkipKnownResultsForTesting: bool option,
         checkEventsAreConsistentWithEntryDiffs: bool option,
         enableRelaxedAutoQsetConfig: bool,
@@ -516,6 +517,9 @@ type MissionOptions
     [<Option("asan-options", HelpText = "Value for ASAN_OPTIONS environment variable", Required = false)>]
     member self.asanOptions = asanOptions
 
+    [<Option("core-env", HelpText = "Comma-separated environment variables to set on stellar-core containers, formatted as NAME=VALUE,NAME2=VALUE2.", Required = false)>]
+    member self.CoreEnv = coreEnv
+
     [<Option("catchup-skip-known-results-for-testing",
              HelpText = "when this flag is provided, pubnet parallel catchup workers will run with CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = true, resulting in skipping application of failed transaction and signature verification",
              Required = false)>]
@@ -635,6 +639,23 @@ let splitLabel (lab: string) : (string * string option) =
     | [ x ] -> x, None
     | head :: tail -> head, Some(System.String.Join(":", tail))
     | _ -> failwith ("unexpected label '" + lab + "', need string of form 'key' or 'key:value'")
+
+let splitEnvVar (envVar: string) : (string * string) =
+    let separatorIndex = envVar.IndexOf('=')
+
+    if separatorIndex <= 0 then
+        failwithf "Could not parse environment variable '%s'. Expected NAME=VALUE." envVar
+
+    envVar.Substring(0, separatorIndex), envVar.Substring(separatorIndex + 1)
+
+let splitEnvVars (envVars: string option) : (string * string) list =
+    match envVars with
+    | None -> []
+    | Some value ->
+        value.Split(',', System.StringSplitOptions.RemoveEmptyEntries)
+        |> Array.map (fun envVar -> envVar.Trim())
+        |> Array.map splitEnvVar
+        |> Array.toList
 
 // Given a (key, value option) output form `splitLabel`, return (key, value) or
 // fail if value is None
@@ -756,6 +777,7 @@ let main argv =
                   numPregeneratedTxs = None
                   genesisTestAccountCount = None
                   asanOptions = None
+                  coreEnv = []
                   enableTailLogging = true
                   catchupSkipKnownResultsForTesting = None
                   checkEventsAreConsistentWithEntryDiffs = None
@@ -931,6 +953,7 @@ let main argv =
                                updateSorobanCosts = None
                                genesisTestAccountCount = mission.GenesisTestAccountCount
                                asanOptions = mission.asanOptions
+                               coreEnv = splitEnvVars mission.CoreEnv
                                enableRelaxedAutoQsetConfig = mission.EnableRelaxedAutoQsetConfig
                                jobMonitorExternalHost = mission.JobMonitorExternalHost
                                txBatchMaxSize = mission.TxBatchMaxSize

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -124,6 +124,7 @@ let ctx : MissionContext =
       updateSorobanCosts = None
       genesisTestAccountCount = None
       asanOptions = None
+      coreEnv = []
       enableRelaxedAutoQsetConfig = false
       jobMonitorExternalHost = None
       txBatchMaxSize = None

--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -110,6 +110,9 @@ let tolerateTaintToHelmIndexed (index: int) ((key: string), (effect: string opti
 let serviceAccountAnnotationsToHelmIndexed (index: int) (key: string, value: string) =
     sprintf "service_account.annotations[%d].key=%s,service_account.annotations[%d].value=%s" index key index value
 
+let coreEnvToHelmIndexed (index: int) (name: string, value: string) =
+    sprintf "worker.coreEnv[%d].name=%s,worker.coreEnv[%d].value=\"%s\"" index name index value
+
 let installProject (context: MissionContext) =
     LogInfo "Installing Helm chart with release name: %s" helmReleaseName
 
@@ -201,6 +204,14 @@ let installProject (context: MissionContext) =
     match context.asanOptions with
     | Some asanOpts -> setOptions.Add(sprintf "worker.asanOptions=%s" asanOpts)
     | None -> ()
+
+    if not (List.isEmpty context.coreEnv) then
+        let coreEnvHelm =
+            context.coreEnv
+            |> List.mapi coreEnvToHelmIndexed
+            |> String.concat ","
+
+        setOptions.Add(coreEnvHelm)
 
     // Convert labels and taints to Helm array format
     if not (List.isEmpty context.requireNodeLabelsPcV2) then

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -822,7 +822,7 @@ type NetworkCfg with
     // hook the per-Pod Services and Ingress up to). Getting all this to work
     // requires that you install the DNS server component on your k8s cluster.
     member self.ToService() : V1Service =
-        let serviceSpec = V1ServiceSpec(clusterIP = "None", selector = CfgVal.labels)
+        let serviceSpec = V1ServiceSpec(clusterIP = "None", selector = CfgVal.labels, publishNotReadyAddresses = true)
         V1Service(spec = serviceSpec, metadata = self.NamespacedMeta self.ServiceName)
 
 

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -281,6 +281,7 @@ let CoreContainerForCommand
     (imageName: string)
     (configOpt: ConfigOption)
     (asanOptions: string option)
+    (coreEnv: (string * string) list)
     (cr: CoreResources)
     (command: string array)
     (initCommands: ShCmd array)
@@ -296,6 +297,11 @@ let CoreContainerForCommand
             name = CfgVal.asanOptionsEnvVarName,
             value = defaultArg asanOptions CfgVal.asanOptionsEnvVarDefaultValue
         )
+
+    let coreEnvVars =
+        coreEnv
+        |> List.map (fun (name, value) -> V1EnvVar(name = name, value = value))
+        |> Array.ofList
 
     let cfgWords = cfgFileArgs configOpt MainCoreContainer
     let containerName = CfgVal.stellarCoreContainerName (Array.get command 0)
@@ -335,7 +341,7 @@ let CoreContainerForCommand
         image = imageName,
         command = [| "/bin/sh" |],
         args = [| "-x"; "-c"; allCmdsAndCleanup.ToString() |],
-        env = [| peerNameEnvVar; asanOptionsEnvVar |],
+        env = Array.concat [ [| peerNameEnvVar; asanOptionsEnvVar |]; coreEnvVars ],
         resources = res,
         securityContext = V1SecurityContext(capabilities = V1Capabilities(add = [| "NET_ADMIN" |])),
         volumeMounts = CoreContainerVolumeMounts peerOrJobNames configOpt
@@ -662,13 +668,14 @@ type NetworkCfg with
 
         let res = self.missionContext.coreResources
         let asan = self.missionContext.asanOptions
+        let coreEnv = self.missionContext.coreEnv
 
         let containers =
             match self.jobCoreSetOptions with
-            | None -> [| CoreContainerForCommand image cfgOpt asan res command [||] [| jobName |] |]
+            | None -> [| CoreContainerForCommand image cfgOpt asan coreEnv res command [||] [| jobName |] |]
             | Some (opts) ->
                 let initCmds = self.getInitCommands cfgOpt opts
-                let coreContainer = CoreContainerForCommand image cfgOpt asan res command initCmds [| jobName |]
+                let coreContainer = CoreContainerForCommand image cfgOpt asan coreEnv res command initCmds [| jobName |]
 
                 match opts.dbType with
                 | Postgres -> [| coreContainer; PostgresContainer self.missionContext.postgresImage |]
@@ -764,10 +771,11 @@ type NetworkCfg with
 
         let res = self.missionContext.coreResources
         let asan = self.missionContext.asanOptions
+        let coreEnv = self.missionContext.coreEnv
 
         let containers =
             [| WithProbes
-                (CoreContainerForCommand imageName cfgOpt asan res runCmd initCommands peerNames)
+                (CoreContainerForCommand imageName cfgOpt asan coreEnv res runCmd initCommands peerNames)
                 self.missionContext.probeTimeout
                HistoryContainer self.missionContext.nginxImage |]
 

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -108,8 +108,8 @@ type MissionContext =
       pubnetParallelCatchupLedgersPerJob: int
       pubnetParallelCatchupNumWorkers: int
       genesisTestAccountCount: int option
-
       asanOptions: string option
+      coreEnv: (string * string) list
 
       // Tail logging can cause the pubnet simulation missions like SorobanLoadGeneration
       // and SimulatePubnet to fail on the heartbeat handler due to what looks like a

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/catchup_workers.yaml
@@ -91,6 +91,10 @@ spec:
               fieldPath: metadata.name
         - name: ASAN_OPTIONS
           value: {{ .Values.worker.asanOptions | quote }}
+        {{- range .Values.worker.coreEnv }}
+        - name: {{ .name }}
+          value: {{ .value | quote }}
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Release.Name }}-worker-config

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -19,6 +19,7 @@ worker:
   avoidNodeLabels: []
   tolerateNodeTaints: []
   asanOptions: "quarantine_size_mb=1:malloc_context_size=5:alloc_dealloc_mismatch=0"
+  coreEnv: []
   resources: # resources below are left empty on purpose, they are read and overridden from `StellarKubeCfg.fs`
     requests:
       cpu: ""


### PR DESCRIPTION
Two separate fixes here:

  1. Add support for passing env vars through from ssc command line all the way to the core instances, in case you want to adjust a configuration setting on a run-by-run basis, this is a very lightweight way to do it.
  2. Add `publishNotReadyAddresses=true` to the headless service configuration for each statefulset that wires it into DNS. this will get DNS entries into k8s' managed DNS as soon as possible -- before k8s has successfully completed a readiness probe -- which in turn means that other core nodes that try to resolve their names are going to at least get _DNS answers_ regardless of the pod being ready. I _believe_ (though it's hard to test) that this narrows startup races that _might_ cause failed connection-establishments due to cached negative DNS lookups. Fairly hypothetical change, but it doesn't seem to do any harm in my testing and I think it might improve things a bit.