### PR TITLE
Reach stellar-core HTTP via pod-exec when --core-http-via-pod-exec is set

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,6 +37,14 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
     - name: Run BootAndSync mission
       run: dotnet run --project src/App/App.fsproj --configuration Release -- mission BootAndSync --image stellar/stellar-core:stable --kubeconfig $KUBECONFIG --namespace default --ingress-class nginx --ingress-internal-domain local --ingress-external-host localhost --uneven-sched
+    # Exercise the pod-exec HTTP transport (--core-http-via-pod-exec) with no
+    # resolvable ingress host: the ingress host falls back to <nonce>.local,
+    # which does not resolve from the runner. If any core HTTP access leaked
+    # back to the ingress, this run would fail with a name-resolution error, so
+    # a green run proves all access goes through pod exec. This mirrors an
+    # out-of-cluster runner (e.g. Namespace/nsc k3s). See issue #399.
+    - name: Run BootAndSync mission via pod-exec
+      run: dotnet run --project src/App/App.fsproj --configuration Release -- mission BootAndSync --image stellar/stellar-core:stable --kubeconfig $KUBECONFIG --namespace default --ingress-class nginx --ingress-internal-domain local --core-http-via-pod-exec --uneven-sched
     - uses: actions/upload-artifact@v4
       with:
         name: destination

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -180,10 +180,7 @@ type MissionOptions
     member self.IngressExternalPort = ingressExternalPort
 
     [<Option("metrics-via-cluster-dns",
-             HelpText =
-                 "Scrape post-mission metrics directly from the per-pod svc.cluster.local DNS name "
-                 + "instead of through the ingress hostname. Use when the ingress hostname (e.g. "
-                 + "<nonce>.local) does not resolve from where SSC runs but cluster DNS does.",
+             HelpText = "Scrape post-mission metrics directly from the per-pod svc.cluster.local DNS name instead of through the ingress hostname. Use when the ingress hostname (e.g. <nonce>.local) does not resolve from where SSC runs but cluster DNS does.",
              Required = false,
              Default = false)>]
     member self.MetricsViaClusterDns = metricsViaClusterDns

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -46,6 +46,7 @@ type MissionOptions
         ingressInternalDomain: string,
         ingressExternalHost: string option,
         ingressExternalPort: int,
+        coreHttpViaPodExec: bool,
         exportToPrometheus: bool,
         probeTimeout: int,
         missions: string seq,
@@ -177,6 +178,12 @@ type MissionOptions
              Required = false,
              Default = 80)>]
     member self.IngressExternalPort = ingressExternalPort
+
+    [<Option("core-http-via-pod-exec",
+             HelpText = "Reach stellar-core's admin HTTP endpoint by exec'ing curl inside each pod (via the Kubernetes API) instead of through the ingress. Use when the ingress hostname is not reachable from where SSC runs, e.g. a runner outside a non-SDF k3s cluster.",
+             Required = false,
+             Default = false)>]
+    member self.CoreHttpViaPodExec = coreHttpViaPodExec
 
     [<Option("export-to-prometheus", HelpText = "Whether to export core metrics to prometheus")>]
     member self.ExportToPrometheus : bool = exportToPrometheus
@@ -779,6 +786,7 @@ let main argv =
                                ingressInternalDomain = mission.IngressInternalDomain
                                ingressExternalHost = mission.IngressExternalHost
                                ingressExternalPort = mission.IngressExternalPort
+                               coreHttpViaPodExec = mission.CoreHttpViaPodExec
                                exportToPrometheus = mission.ExportToPrometheus
                                probeTimeout = mission.ProbeTimeout
                                coreResources = SmallTestResources

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -46,6 +46,7 @@ type MissionOptions
         ingressInternalDomain: string,
         ingressExternalHost: string option,
         ingressExternalPort: int,
+        metricsViaClusterDns: bool,
         exportToPrometheus: bool,
         probeTimeout: int,
         missions: string seq,
@@ -177,6 +178,15 @@ type MissionOptions
              Required = false,
              Default = 80)>]
     member self.IngressExternalPort = ingressExternalPort
+
+    [<Option("metrics-via-cluster-dns",
+             HelpText =
+                 "Scrape post-mission metrics directly from the per-pod svc.cluster.local DNS name "
+                 + "instead of through the ingress hostname. Use when the ingress hostname (e.g. "
+                 + "<nonce>.local) does not resolve from where SSC runs but cluster DNS does.",
+             Required = false,
+             Default = false)>]
+    member self.MetricsViaClusterDns = metricsViaClusterDns
 
     [<Option("export-to-prometheus", HelpText = "Whether to export core metrics to prometheus")>]
     member self.ExportToPrometheus : bool = exportToPrometheus
@@ -779,6 +789,7 @@ let main argv =
                                ingressInternalDomain = mission.IngressInternalDomain
                                ingressExternalHost = mission.IngressExternalHost
                                ingressExternalPort = mission.IngressExternalPort
+                               metricsViaClusterDns = mission.MetricsViaClusterDns
                                exportToPrometheus = mission.ExportToPrometheus
                                probeTimeout = mission.ProbeTimeout
                                coreResources = SmallTestResources

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -46,7 +46,6 @@ type MissionOptions
         ingressInternalDomain: string,
         ingressExternalHost: string option,
         ingressExternalPort: int,
-        metricsViaClusterDns: bool,
         exportToPrometheus: bool,
         probeTimeout: int,
         missions: string seq,
@@ -178,12 +177,6 @@ type MissionOptions
              Required = false,
              Default = 80)>]
     member self.IngressExternalPort = ingressExternalPort
-
-    [<Option("metrics-via-cluster-dns",
-             HelpText = "Scrape post-mission metrics directly from the per-pod svc.cluster.local DNS name instead of through the ingress hostname. Use when the ingress hostname (e.g. <nonce>.local) does not resolve from where SSC runs but cluster DNS does.",
-             Required = false,
-             Default = false)>]
-    member self.MetricsViaClusterDns = metricsViaClusterDns
 
     [<Option("export-to-prometheus", HelpText = "Whether to export core metrics to prometheus")>]
     member self.ExportToPrometheus : bool = exportToPrometheus
@@ -786,7 +779,6 @@ let main argv =
                                ingressInternalDomain = mission.IngressInternalDomain
                                ingressExternalHost = mission.IngressExternalHost
                                ingressExternalPort = mission.IngressExternalPort
-                               metricsViaClusterDns = mission.MetricsViaClusterDns
                                exportToPrometheus = mission.ExportToPrometheus
                                probeTimeout = mission.ProbeTimeout
                                coreResources = SmallTestResources

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -58,7 +58,6 @@ let ctx : MissionContext =
       ingressInternalDomain = "local"
       ingressExternalHost = None
       ingressExternalPort = 80
-      metricsViaClusterDns = false
       exportToPrometheus = false
       probeTimeout = 10
       coreResources = SmallTestResources

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -58,6 +58,7 @@ let ctx : MissionContext =
       ingressInternalDomain = "local"
       ingressExternalHost = None
       ingressExternalPort = 80
+      metricsViaClusterDns = false
       exportToPrometheus = false
       probeTimeout = 10
       coreResources = SmallTestResources

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -58,6 +58,7 @@ let ctx : MissionContext =
       ingressInternalDomain = "local"
       ingressExternalHost = None
       ingressExternalPort = 80
+      coreHttpViaPodExec = false
       exportToPrometheus = false
       probeTimeout = 10
       coreResources = SmallTestResources

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -5,12 +5,16 @@
 module StellarCoreHTTP
 
 open FSharp.Data
+open k8s
+open k8s.Models
+open Microsoft.Rest.Serialization
 open StellarCoreSet
 open PollRetry
 open Logging
 open StellarMissionContext
 open StellarNetworkCfg
 open StellarCorePeer
+open System.IO
 open System.Threading
 open StellarDotnetSdk.Transactions
 open StellarDotnetSdk.Responses.Results
@@ -388,9 +392,71 @@ type Peer with
             self.PodName.StringName
             path
 
-    member self.fetch(path: string) : string =
-        let url = self.URL path
-        Http.RequestString(url, headers = self.Headers)
+    // Reach stellar-core's admin HTTP endpoint by exec'ing `curl` inside the
+    // pod (via the Kubernetes API) rather than over the ingress. This is used
+    // when --core-http-via-pod-exec is set, for environments where the ingress
+    // hostname is not reachable from where SSC runs (e.g. a runner outside a
+    // non-SDF k3s cluster). Failures are surfaced as WebException so the
+    // existing WebExceptionRetry wrappers retry transient errors (e.g. core
+    // still booting) just as they do for ingress fetches.
+    // See https://github.com/stellar/supercluster/issues/399.
+    member self.fetchViaPodExec (path: string) (query: (string * string) list) : string =
+        let kube = self.networkCfg.missionContext.kube
+        let ns = self.networkCfg.NamespaceProperty
+        let name = self.PodName
+
+        let encode (s: string) : string = System.Uri.EscapeDataString s
+
+        let queryString =
+            match query with
+            | [] -> ""
+            | _ ->
+                query
+                |> List.map (fun (k, v) -> sprintf "%s=%s" (encode k) (encode v))
+                |> String.concat "&"
+                |> sprintf "?%s"
+
+        let url = sprintf "http://localhost:%d/%s%s" StellarCoreCfg.CfgVal.httpPort path queryString
+
+        try
+            let muxedStream =
+                kube
+                    .MuxedStreamNamespacedPodExecAsync(name = name.StringName,
+                                                       ``namespace`` = ns,
+                                                       command = [| "curl"; "-sf"; url |],
+                                                       container = "stellar-core-run",
+                                                       tty = false,
+                                                       cancellationToken = CancellationToken())
+                    .GetAwaiter()
+                    .GetResult()
+
+            let stdOut =
+                muxedStream.GetStream(System.Nullable<ChannelIndex>(ChannelIndex.StdOut), System.Nullable<ChannelIndex>())
+
+            let error =
+                muxedStream.GetStream(System.Nullable<ChannelIndex>(ChannelIndex.Error), System.Nullable<ChannelIndex>())
+
+            let outReader = new StreamReader(stdOut)
+            let errReader = new StreamReader(error)
+            muxedStream.Start()
+            let outStr = outReader.ReadToEndAsync().GetAwaiter().GetResult()
+            let errStr = errReader.ReadToEndAsync().GetAwaiter().GetResult()
+            let returnMessage = SafeJsonConvert.DeserializeObject<V1Status>(errStr)
+            Kubernetes.GetExitCodeOrThrow(returnMessage) |> ignore
+            outStr
+        with
+        | :? System.Net.WebException -> reraise ()
+        | e -> raise (System.Net.WebException(sprintf "pod-exec fetch of /%s failed: %s" path e.Message))
+
+    // Single point through which all stellar-core admin HTTP GETs flow, so the
+    // transport (ingress vs. in-pod curl) is chosen in one place.
+    member self.httpGet (path: string) (query: (string * string) list) : string =
+        if self.networkCfg.missionContext.coreHttpViaPodExec then
+            self.fetchViaPodExec path query
+        else
+            Http.RequestString(url = self.URL path, httpMethod = "GET", headers = self.Headers, query = query)
+
+    member self.fetch(path: string) : string = self.httpGet path []
 
     member self.GetState() = self.GetInfo().State
 
@@ -486,15 +552,7 @@ type Peer with
 
     member self.SetUpgrades(upgrades: UpgradeParameters) =
         let res =
-            WebExceptionRetry
-                DefaultRetry
-                (fun _ ->
-                    Http.RequestString(
-                        httpMethod = "GET",
-                        url = self.URL "upgrades",
-                        headers = self.Headers,
-                        query = upgrades.ToQuery
-                    ))
+            WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "upgrades" upgrades.ToQuery)
 
         if res.ToLower().Contains("exception") then
             raise (PeerRejectedUpgradesException res)
@@ -684,68 +742,38 @@ type Peer with
             raise (ProtocolVersionNotUpgradedException(currentProtocolVersion, lastestProtocolVersion))
 
     member self.ClearMetrics() =
-        WebExceptionRetry
-            DefaultRetry
-            (fun _ -> Http.RequestString(httpMethod = "GET", headers = self.Headers, url = self.URL "clearmetrics"))
+        WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "clearmetrics" [])
         |> ignore
 
     member self.ToggleOverlayOnlyMode() =
-        WebExceptionRetry
-            DefaultRetry
-            (fun _ ->
-                Http.RequestString(httpMethod = "GET", headers = self.Headers, url = self.URL "toggleoverlayonlymode"))
+        WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "toggleoverlayonlymode" [])
 
     member self.GetTestAcc(accName: string) : TestAcc.Root =
         // NB: work around buggy JSON parser upstream, see
         // https://github.com/fsharp/FSharp.Data/pull/1262
         let s =
-            WebExceptionRetry
-                DefaultRetry
-                (fun _ ->
-                    Http.RequestString(
-                        httpMethod = "GET",
-                        url = self.URL("testacc"),
-                        headers = self.Headers,
-                        query = [ ("name", accName) ]
-                    ))
+            WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "testacc" [ ("name", accName) ])
 
         TestAcc.Parse(if s.Trim().StartsWith("null") then "{}" else s)
 
     member self.StartSurveyCollecting(nonce: int) =
-        WebExceptionRetry
-            DefaultRetry
-            (fun _ ->
-                Http.RequestString(
-                    httpMethod = "GET",
-                    url = self.URL("startsurveycollecting"),
-                    headers = self.Headers,
-                    query = [ ("nonce", nonce.ToString()) ]
-                ))
+        WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "startsurveycollecting" [ ("nonce", nonce.ToString()) ])
 
     member self.StopSurveyCollecting() =
-        WebExceptionRetry
-            DefaultRetry
-            (fun _ ->
-                Http.RequestString(httpMethod = "GET", url = self.URL("stopsurveycollecting"), headers = self.Headers))
+        WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "stopsurveycollecting" [])
 
     member self.SurveyTopologyTimeSliced (node: string) (inboundPeersIndex: int) (outboundPeersIndex: int) =
         WebExceptionRetry
             DefaultRetry
             (fun _ ->
-                Http.RequestString(
-                    httpMethod = "GET",
-                    url = self.URL("surveytopologytimesliced"),
-                    headers = self.Headers,
-                    query =
-                        [ ("node", node)
-                          ("inboundpeerindex", inboundPeersIndex.ToString())
-                          ("outboundpeerindex", outboundPeersIndex.ToString()) ]
-                ))
+                self.httpGet
+                    "surveytopologytimesliced"
+                    [ ("node", node)
+                      ("inboundpeerindex", inboundPeersIndex.ToString())
+                      ("outboundpeerindex", outboundPeersIndex.ToString()) ])
 
     member self.GetSurveyResult() =
-        WebExceptionRetry
-            DefaultRetry
-            (fun _ -> Http.RequestString(httpMethod = "GET", url = self.URL("getsurveyresult"), headers = self.Headers))
+        WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "getsurveyresult" [])
 
     member self.GetTestAccBalance(accName: string) : int64 =
         RetryUntilSome
@@ -758,22 +786,12 @@ type Peer with
             (fun _ -> LogWarn "Waiting for account %s to exist, to read seqnum" accName)
 
     member self.GenerateLoad(loadGen: LoadGen) : string =
-        WebExceptionRetry
-            DefaultRetry
-            (fun _ ->
-                Http.RequestString(
-                    httpMethod = "GET",
-                    headers = self.Headers,
-                    url = self.URL "generateload",
-                    query = loadGen.ToQuery
-                ))
+        WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "generateload" loadGen.ToQuery)
 
     member self.StopLoadGen() : string = self.GenerateLoad { LoadGen.GetDefault() with mode = StopRun }
 
     member self.ManualClose() =
-        WebExceptionRetry
-            DefaultRetry
-            (fun _ -> Http.RequestString(httpMethod = "GET", headers = self.Headers, url = self.URL "manualclose"))
+        WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "manualclose" [])
         |> ignore
 
     member self.SubmitSignedTransaction(tx: Transaction) : Tx.Root =
@@ -783,20 +801,8 @@ type Peer with
             WebExceptionRetry
                 DefaultRetry
                 (fun _ ->
-                    LogDebug
-                        "Submitting transaction: %s"
-                        ((self.URL "tx") + "?blob=" + (System.Uri.EscapeDataString b64))
-
-                    let response =
-                        Http.RequestStream(
-                            (self.URL "tx"),
-                            httpMethod = "GET",
-                            query = [ "blob", b64 ],
-                            headers = [ "Host", self.networkCfg.IngressInternalHostName ]
-                        )
-
-                    use reader = new System.IO.StreamReader(response.ResponseStream)
-                    reader.ReadToEnd())
+                    LogDebug "Submitting transaction with blob: %s" b64
+                    self.httpGet "tx" [ ("blob", b64) ])
 
         LogDebug "Transaction response: %s" s
         let res = Tx.Parse(s)

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -416,7 +416,8 @@ type Peer with
                 |> String.concat "&"
                 |> sprintf "?%s"
 
-        let url = sprintf "http://localhost:%d/%s%s" StellarCoreCfg.CfgVal.httpPort path queryString
+        let url =
+            sprintf "http://localhost:%d/%s%s" StellarCoreCfg.CfgVal.httpPort path queryString
 
         try
             let muxedStream =
@@ -431,10 +432,16 @@ type Peer with
                     .GetResult()
 
             let stdOut =
-                muxedStream.GetStream(System.Nullable<ChannelIndex>(ChannelIndex.StdOut), System.Nullable<ChannelIndex>())
+                muxedStream.GetStream(
+                    System.Nullable<ChannelIndex>(ChannelIndex.StdOut),
+                    System.Nullable<ChannelIndex>()
+                )
 
             let error =
-                muxedStream.GetStream(System.Nullable<ChannelIndex>(ChannelIndex.Error), System.Nullable<ChannelIndex>())
+                muxedStream.GetStream(
+                    System.Nullable<ChannelIndex>(ChannelIndex.Error),
+                    System.Nullable<ChannelIndex>()
+                )
 
             let outReader = new StreamReader(stdOut)
             let errReader = new StreamReader(error)
@@ -772,8 +779,7 @@ type Peer with
                       ("inboundpeerindex", inboundPeersIndex.ToString())
                       ("outboundpeerindex", outboundPeersIndex.ToString()) ])
 
-    member self.GetSurveyResult() =
-        WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "getsurveyresult" [])
+    member self.GetSurveyResult() = WebExceptionRetry DefaultRetry (fun _ -> self.httpGet "getsurveyresult" [])
 
     member self.GetTestAccBalance(accName: string) : int64 =
         RetryUntilSome

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -392,6 +392,17 @@ type Peer with
         let url = self.URL path
         Http.RequestString(url, headers = self.Headers)
 
+    // URL that reaches stellar-core's admin HTTP endpoint directly via the
+    // per-pod svc.cluster.local DNS name, bypassing the ingress. The ingress
+    // hostname (<nonce>.<ingress-internal-domain>, e.g. <nonce>.local) does not
+    // resolve in all cluster-DNS environments (for example non-SDF k3s
+    // clusters), whereas the per-pod service DNS name resolves wherever cluster
+    // DNS is reachable. See https://github.com/stellar/supercluster/issues/399.
+    member self.ClusterDnsURL(path: string) : string =
+        sprintf "http://%s:%d/%s" self.DnsName.StringName StellarCoreCfg.CfgVal.httpPort path
+
+    member self.fetchFromClusterDns(path: string) : string = Http.RequestString(self.ClusterDnsURL path)
+
     member self.GetState() = self.GetInfo().State
 
     member self.GetStatusOrState() : string =
@@ -401,7 +412,11 @@ type Peer with
     member self.GetMetrics() : Metrics.Metrics =
         WebExceptionRetry DefaultRetry (fun _ -> Metrics.Parse(self.fetch "metrics").Metrics)
 
-    member self.GetRawMetrics() = WebExceptionRetry DefaultRetry (fun _ -> self.fetch "metrics")
+    // Post-mission metrics are scraped directly from the per-pod
+    // svc.cluster.local DNS name (see ClusterDnsURL) rather than through the
+    // ingress, so the teardown dump succeeds even when the ingress hostname is
+    // not resolvable from where SSC runs.
+    member self.GetRawMetrics() = WebExceptionRetry DefaultRetry (fun _ -> self.fetchFromClusterDns "metrics")
 
     member self.GetInfo() : Info.Info =
         WebExceptionRetry

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -412,11 +412,16 @@ type Peer with
     member self.GetMetrics() : Metrics.Metrics =
         WebExceptionRetry DefaultRetry (fun _ -> Metrics.Parse(self.fetch "metrics").Metrics)
 
-    // Post-mission metrics are scraped directly from the per-pod
-    // svc.cluster.local DNS name (see ClusterDnsURL) rather than through the
-    // ingress, so the teardown dump succeeds even when the ingress hostname is
-    // not resolvable from where SSC runs.
-    member self.GetRawMetrics() = WebExceptionRetry DefaultRetry (fun _ -> self.fetchFromClusterDns "metrics")
+    // Post-mission metrics are scraped through the ingress by default. When
+    // --metrics-via-cluster-dns is set they are instead scraped directly from
+    // the per-pod svc.cluster.local DNS name (see ClusterDnsURL), so the
+    // teardown dump succeeds in environments where the ingress hostname (e.g.
+    // <nonce>.local) does not resolve from where SSC runs but cluster DNS does.
+    member self.GetRawMetrics() =
+        if self.networkCfg.missionContext.metricsViaClusterDns then
+            WebExceptionRetry DefaultRetry (fun _ -> self.fetchFromClusterDns "metrics")
+        else
+            WebExceptionRetry DefaultRetry (fun _ -> self.fetch "metrics")
 
     member self.GetInfo() : Info.Info =
         WebExceptionRetry

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -392,17 +392,6 @@ type Peer with
         let url = self.URL path
         Http.RequestString(url, headers = self.Headers)
 
-    // URL that reaches stellar-core's admin HTTP endpoint directly via the
-    // per-pod svc.cluster.local DNS name, bypassing the ingress. The ingress
-    // hostname (<nonce>.<ingress-internal-domain>, e.g. <nonce>.local) does not
-    // resolve in all cluster-DNS environments (for example non-SDF k3s
-    // clusters), whereas the per-pod service DNS name resolves wherever cluster
-    // DNS is reachable. See https://github.com/stellar/supercluster/issues/399.
-    member self.ClusterDnsURL(path: string) : string =
-        sprintf "http://%s:%d/%s" self.DnsName.StringName StellarCoreCfg.CfgVal.httpPort path
-
-    member self.fetchFromClusterDns(path: string) : string = Http.RequestString(self.ClusterDnsURL path)
-
     member self.GetState() = self.GetInfo().State
 
     member self.GetStatusOrState() : string =
@@ -412,16 +401,7 @@ type Peer with
     member self.GetMetrics() : Metrics.Metrics =
         WebExceptionRetry DefaultRetry (fun _ -> Metrics.Parse(self.fetch "metrics").Metrics)
 
-    // Post-mission metrics are scraped through the ingress by default. When
-    // --metrics-via-cluster-dns is set they are instead scraped directly from
-    // the per-pod svc.cluster.local DNS name (see ClusterDnsURL), so the
-    // teardown dump succeeds in environments where the ingress hostname (e.g.
-    // <nonce>.local) does not resolve from where SSC runs but cluster DNS does.
-    member self.GetRawMetrics() =
-        if self.networkCfg.missionContext.metricsViaClusterDns then
-            WebExceptionRetry DefaultRetry (fun _ -> self.fetchFromClusterDns "metrics")
-        else
-            WebExceptionRetry DefaultRetry (fun _ -> self.fetch "metrics")
+    member self.GetRawMetrics() = WebExceptionRetry DefaultRetry (fun _ -> self.fetch "metrics")
 
     member self.GetInfo() : Info.Info =
         WebExceptionRetry

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -450,15 +450,6 @@ type Peer with
             let errStr = errReader.ReadToEndAsync().GetAwaiter().GetResult()
             let returnMessage = SafeJsonConvert.DeserializeObject<V1Status>(errStr)
             Kubernetes.GetExitCodeOrThrow(returnMessage) |> ignore
-
-            // While core is still booting its admin HTTP server can answer with
-            // an empty body (curl exits 0). Treat that like a transient HTTP
-            // error so WebExceptionRetry retries rather than handing an empty
-            // string to a JSON parser. No core admin endpoint returns an empty
-            // body on success.
-            if System.String.IsNullOrEmpty outStr then
-                raise (System.Net.WebException(sprintf "pod-exec fetch of /%s returned an empty response" path))
-
             outStr
         with
         | :? System.Net.WebException -> reraise ()
@@ -474,6 +465,20 @@ type Peer with
 
     member self.fetch(path: string) : string = self.httpGet path []
 
+    // For endpoints that must return a (JSON) body. While core is still booting,
+    // its admin HTTP server can answer with an empty body (and curl exits 0);
+    // surface that as a WebException so the JSON-parsing callers' retry loops
+    // wait for core rather than feeding an empty string to a parser. Endpoints
+    // that legitimately return an empty body on success (e.g. upgrades) keep
+    // using fetch/httpGet directly.
+    member self.fetchNonEmpty(path: string) : string =
+        let resp = self.fetch path
+
+        if System.String.IsNullOrEmpty resp then
+            raise (System.Net.WebException(sprintf "core returned an empty response for /%s, not ready yet" path))
+
+        resp
+
     member self.GetState() = self.GetInfo().State
 
     member self.GetStatusOrState() : string =
@@ -481,15 +486,15 @@ type Peer with
         if i.Status.Length = 0 then i.State else i.Status.[0]
 
     member self.GetMetrics() : Metrics.Metrics =
-        WebExceptionRetry DefaultRetry (fun _ -> Metrics.Parse(self.fetch "metrics").Metrics)
+        WebExceptionRetry DefaultRetry (fun _ -> Metrics.Parse(self.fetchNonEmpty "metrics").Metrics)
 
-    member self.GetRawMetrics() = WebExceptionRetry DefaultRetry (fun _ -> self.fetch "metrics")
+    member self.GetRawMetrics() = WebExceptionRetry DefaultRetry (fun _ -> self.fetchNonEmpty "metrics")
 
     member self.GetInfo() : Info.Info =
         WebExceptionRetry
             DefaultRetry
             (fun _ ->
-                let resp = self.fetch "info"
+                let resp = self.fetchNonEmpty "info"
                 let parsed = Info.Parse(resp)
 
                 // stellar-core can respond with {"error":"Core is booting, try again later"}
@@ -498,7 +503,7 @@ type Peer with
                 | None -> raise (System.Net.WebException("Core is not ready, info property missing")))
 
     member self.GetSorobanInfo() : SorobanInfo.Root =
-        WebExceptionRetry DefaultRetry (fun _ -> SorobanInfo.Parse(self.fetch "sorobaninfo"))
+        WebExceptionRetry DefaultRetry (fun _ -> SorobanInfo.Parse(self.fetchNonEmpty "sorobaninfo"))
 
     member self.GetLedgerNum() : int = self.GetInfo().Ledger.Num
 

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -450,6 +450,15 @@ type Peer with
             let errStr = errReader.ReadToEndAsync().GetAwaiter().GetResult()
             let returnMessage = SafeJsonConvert.DeserializeObject<V1Status>(errStr)
             Kubernetes.GetExitCodeOrThrow(returnMessage) |> ignore
+
+            // While core is still booting its admin HTTP server can answer with
+            // an empty body (curl exits 0). Treat that like a transient HTTP
+            // error so WebExceptionRetry retries rather than handing an empty
+            // string to a JSON parser. No core admin endpoint returns an empty
+            // body on success.
+            if System.String.IsNullOrEmpty outStr then
+                raise (System.Net.WebException(sprintf "pod-exec fetch of /%s returned an empty response" path))
+
             outStr
         with
         | :? System.Net.WebException -> reraise ()

--- a/src/FSLibrary/StellarDataDump.fs
+++ b/src/FSLibrary/StellarDataDump.fs
@@ -240,10 +240,49 @@ type StellarFormation with
             Kubernetes.GetExitCodeOrThrow(returnMessage) |> ignore
         with x -> ()
 
+    // Scrape post-mission metrics by exec'ing `curl` against stellar-core's
+    // admin HTTP endpoint on the pod loopback, rather than fetching through the
+    // ingress. The ingress hostname (e.g. <nonce>.local) is not resolvable from
+    // every environment SSC runs in (for example a runner outside a non-SDF k3s
+    // cluster), whereas pod exec only needs the Kubernetes API that SSC already
+    // uses to manage the cluster. Best-effort: a failure here must not fail an
+    // otherwise-successful mission. See
+    // https://github.com/stellar/supercluster/issues/399.
     member self.DumpPeerMetrics(p: Peer) =
-        let destination = self.NetworkCfg.missionContext.destination
-        let name = p.PodName
-        destination.WriteString(sprintf "%s.metrics.json" name.StringName) (p.GetRawMetrics())
+        try
+            let ns = self.NetworkCfg.NamespaceProperty
+            let name = self.NetworkCfg.PodName p.coreSet p.peerNum
+            let metricsUrl = sprintf "http://localhost:%d/metrics" CfgVal.httpPort
+
+            self.sleepUntilNextRateLimitedApiCallTime ()
+
+            let muxedStream =
+                self
+                    .Kube
+                    .MuxedStreamNamespacedPodExecAsync(name = name.StringName,
+                                                       ``namespace`` = ns,
+                                                       command = [| "curl"; "-sf"; metricsUrl |],
+                                                       container = "stellar-core-run",
+                                                       tty = false,
+                                                       cancellationToken = CancellationToken())
+                    .GetAwaiter()
+                    .GetResult()
+
+            let stdOut =
+                muxedStream.GetStream(Nullable<ChannelIndex>(ChannelIndex.StdOut), Nullable<ChannelIndex>())
+
+            let error =
+                muxedStream.GetStream(Nullable<ChannelIndex>(ChannelIndex.Error), Nullable<ChannelIndex>())
+
+            let errorReader = new StreamReader(error)
+
+            LogInfo "Dumping metrics of peer %s" name.StringName
+            muxedStream.Start()
+            self.Destination.WriteStream(sprintf "%s.metrics.json" name.StringName) stdOut
+            let errors = errorReader.ReadToEndAsync().GetAwaiter().GetResult()
+            let returnMessage = SafeJsonConvert.DeserializeObject<V1Status>(errors)
+            Kubernetes.GetExitCodeOrThrow(returnMessage) |> ignore
+        with x -> LogWarn "Failed to dump metrics of peer %s: %s" p.PodName.StringName x.Message
 
     member self.DumpPeerData(p: Peer) =
         self.DumpPeerLogs p

--- a/src/FSLibrary/StellarDataDump.fs
+++ b/src/FSLibrary/StellarDataDump.fs
@@ -246,7 +246,7 @@ type StellarFormation with
     // GetRawMetrics based on the --core-http-via-pod-exec flag.
     member self.DumpPeerMetrics(p: Peer) =
         try
-            self.Destination.WriteString (sprintf "%s.metrics.json" p.PodName.StringName) (p.GetRawMetrics())
+            self.Destination.WriteString(sprintf "%s.metrics.json" p.PodName.StringName) (p.GetRawMetrics())
         with x -> LogWarn "Failed to dump metrics of peer %s: %s" p.PodName.StringName x.Message
 
     member self.DumpPeerData(p: Peer) =

--- a/src/FSLibrary/StellarDataDump.fs
+++ b/src/FSLibrary/StellarDataDump.fs
@@ -240,48 +240,13 @@ type StellarFormation with
             Kubernetes.GetExitCodeOrThrow(returnMessage) |> ignore
         with x -> ()
 
-    // Scrape post-mission metrics by exec'ing `curl` against stellar-core's
-    // admin HTTP endpoint on the pod loopback, rather than fetching through the
-    // ingress. The ingress hostname (e.g. <nonce>.local) is not resolvable from
-    // every environment SSC runs in (for example a runner outside a non-SDF k3s
-    // cluster), whereas pod exec only needs the Kubernetes API that SSC already
-    // uses to manage the cluster. Best-effort: a failure here must not fail an
-    // otherwise-successful mission. See
-    // https://github.com/stellar/supercluster/issues/399.
+    // Best-effort: a failed metrics scrape must not fail an otherwise-successful
+    // mission (the impact reported in #399). The transport used to reach core's
+    // admin HTTP endpoint -- ingress or in-pod `curl` -- is selected by
+    // GetRawMetrics based on the --core-http-via-pod-exec flag.
     member self.DumpPeerMetrics(p: Peer) =
         try
-            let ns = self.NetworkCfg.NamespaceProperty
-            let name = self.NetworkCfg.PodName p.coreSet p.peerNum
-            let metricsUrl = sprintf "http://localhost:%d/metrics" CfgVal.httpPort
-
-            self.sleepUntilNextRateLimitedApiCallTime ()
-
-            let muxedStream =
-                self
-                    .Kube
-                    .MuxedStreamNamespacedPodExecAsync(name = name.StringName,
-                                                       ``namespace`` = ns,
-                                                       command = [| "curl"; "-sf"; metricsUrl |],
-                                                       container = "stellar-core-run",
-                                                       tty = false,
-                                                       cancellationToken = CancellationToken())
-                    .GetAwaiter()
-                    .GetResult()
-
-            let stdOut =
-                muxedStream.GetStream(Nullable<ChannelIndex>(ChannelIndex.StdOut), Nullable<ChannelIndex>())
-
-            let error =
-                muxedStream.GetStream(Nullable<ChannelIndex>(ChannelIndex.Error), Nullable<ChannelIndex>())
-
-            let errorReader = new StreamReader(error)
-
-            LogInfo "Dumping metrics of peer %s" name.StringName
-            muxedStream.Start()
-            self.Destination.WriteStream(sprintf "%s.metrics.json" name.StringName) stdOut
-            let errors = errorReader.ReadToEndAsync().GetAwaiter().GetResult()
-            let returnMessage = SafeJsonConvert.DeserializeObject<V1Status>(errors)
-            Kubernetes.GetExitCodeOrThrow(returnMessage) |> ignore
+            self.Destination.WriteString (sprintf "%s.metrics.json" p.PodName.StringName) (p.GetRawMetrics())
         with x -> LogWarn "Failed to dump metrics of peer %s: %s" p.PodName.StringName x.Message
 
     member self.DumpPeerData(p: Peer) =

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -59,6 +59,7 @@ type MissionContext =
       ingressInternalDomain: string
       ingressExternalHost: string option
       ingressExternalPort: int
+      coreHttpViaPodExec: bool
       exportToPrometheus: bool
       probeTimeout: int
       coreResources: CoreResources

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -59,6 +59,7 @@ type MissionContext =
       ingressInternalDomain: string
       ingressExternalHost: string option
       ingressExternalPort: int
+      metricsViaClusterDns: bool
       exportToPrometheus: bool
       probeTimeout: int
       coreResources: CoreResources

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -59,7 +59,6 @@ type MissionContext =
       ingressInternalDomain: string
       ingressExternalHost: string option
       ingressExternalPort: int
-      metricsViaClusterDns: bool
       exportToPrometheus: bool
       probeTimeout: int
       coreResources: CoreResources


### PR DESCRIPTION
## Problem

Closes #399.

SSC reaches each stellar-core's admin HTTP endpoint through the ingress, whose hostname falls back to `<nonce>.<ingress-internal-domain>` (default `<nonce>.local`). On a runner that sits **outside** the cluster (e.g. a Namespace/nsc k3s runner — a local Docker container with a kubeconfig), that hostname is unreachable, and so is the per-pod `*.svc.cluster.local` name (cluster-internal DNS only). The result: missions exit non-zero even when core reached consensus — first observed as a teardown metrics-dump crash (#399), but it's the same DNS gap behind `WaitUntilReady → GetInfo` and every other HTTP call.

## Fix

Add an opt-in flag **`--core-http-via-pod-exec`** (default `false`). All stellar-core admin-HTTP GETs now funnel through a single `Peer.httpGet path query` that selects the transport:

- **default** — ingress (`http://<ingress-host>/<pod>/core/<path>`), unchanged. Preserves SDF behavior and keeps the in-mission polling hot path (`WaitFor*` poll every 1s/peer) off the k8s API.
- **`--core-http-via-pod-exec`** — exec `curl http://localhost:11626/<path>?<query>` inside the pod via the Kubernetes API (the same mechanism `DumpPeerDatabase` already uses for `sqlite3`). Needs no DNS and works from any runner that can reach the API server.

This covers everything — `GetInfo`/`GetState`/`GetMetrics`/`GetSorobanInfo`, all `WaitUntil*`/`WaitFor*` loops, `SetUpgrades`, `GenerateLoad`, surveys, `tx` submit, and the teardown metrics dump — so nothing falls back to the ingress when the flag is on.

Details:
- Pod-exec failures are surfaced as `WebException`, so the existing `WebExceptionRetry` wrappers retry transient errors (e.g. core still booting) exactly as they do for ingress.
- JSON reads (`info`/`metrics`/`sorobaninfo`) go through `fetchNonEmpty`: a booting core can answer with an empty body (curl exits 0), which is treated as "not ready yet" and retried instead of crashing a JSON parser. Endpoints that legitimately return an empty body on success (e.g. `upgrades`) are unaffected.
- `DumpPeerMetrics` stays best-effort (a failed scrape logs a warning, never fails the mission) and just calls the transport-aware `GetRawMetrics`.

## Verification in CI

The `complete` job now runs BootAndSync **twice**:
1. the existing ingress run (`--ingress-external-host localhost`) — proves the default path still works;
2. a **`--core-http-via-pod-exec` run with no resolvable ingress host** — the ingress host falls back to `<nonce>.local`, so any HTTP that leaked back to the ingress would fail with a name-resolution error. A green run proves *all* core HTTP goes through pod exec. This mirrors an out-of-cluster nsc runner.

Both runs pass. Build, unit tests, and fantomas were also validated locally.

## Usage

From an out-of-cluster runner (e.g. nsc/Namespace), add:

```
--core-http-via-pod-exec
```

Requires `curl` in the core image (present in the stock stellar-core image; already used by init containers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)