### PR TITLE
Bump UpgradeCoreResourceRequirements to handle larger pubnet RAM

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -136,8 +136,8 @@ let NonParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
 
 let UpgradeCoreResourceRequirements : V1ResourceRequirements =
     // When doing upgrade tests, we give each container
-    // 256MB RAM and 1 vCPU, bursting to 4vCPU and 14GB
-    makeResourceRequirements 1000 256 4000 14000
+    // 6000MB RAM and 1 vCPU, bursting to 24000MB and 4 vCPUs
+    makeResourceRequirements 1000 6000 4000 24000
 
 let SmallTestCoreResourceRequirements : V1ResourceRequirements =
     // When running most missions, there are few core nodes, so each


### PR DESCRIPTION
`UpgradeCoreResourceRequirements` is used in both small upgrade tests and larger ones run against pubnet. This limit was last _lowered_ back in 9c2defc7a9f8d67bc6e240a102536da9b8a454f8 (when the test was changed to use a disk-backed emptyDir) but lately we've switched to storing live soroban state in memory and it seems that the peak use during in-memory state rebuild has tipped over the 14GiB limit and we're getting OOMKilled during tests. So we're just bumping it back up here.