### PR TITLE
Isolate perf-sensitive missions onto their own nodes

### DIFF
--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -784,6 +784,9 @@ let main argv =
                                coreResources = SmallTestResources
                                keepData = mission.KeepData
                                unevenSched = mission.UnevenSched
+                               // Off by default; perf-sensitive missions (Max TPS, Min Block Time)
+                               // turn this on themselves via their MissionContext override.
+                               dedicatedNodes = false
                                requireNodeLabels = List.map splitLabel (List.ofSeq mission.RequireNodeLabels)
                                avoidNodeLabels = List.map splitLabel (List.ofSeq mission.AvoidNodeLabels)
                                tolerateNodeTaints = List.map splitLabel (List.ofSeq mission.TolerateNodeTaints)

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -63,6 +63,7 @@ let ctx : MissionContext =
       coreResources = SmallTestResources
       keepData = true
       unevenSched = false
+      dedicatedNodes = false
       requireNodeLabels = []
       avoidNodeLabels = []
       tolerateNodeTaints = []
@@ -189,6 +190,39 @@ type Tests(output: ITestOutputHelper) =
     // REVERTME: temporarily avoid looking for HTTP_PORT=0 on InitContainers
     // let initCfg = nCfg.StellarCoreCfg(coreSet, 1, InitCoreContainer)
     // Assert.Contains("HTTP_PORT = 0", initCfg.ToString())
+
+    [<Fact>]
+    member __.``Dedicated-nodes mission gets per-run pod anti-affinity``() =
+        let nCfgDedicated =
+            MakeNetworkCfg { ctx with dedicatedNodes = true; installNetworkDelay = Some false } [ coreSet ] passOpt
+
+        let spec = (nCfgDedicated.ToPodTemplateSpec coreSet).Spec
+
+        // Pods are tagged with their run nonce, which is what the anti-affinity
+        // discriminates on.
+        Assert.Equal(nCfgDedicated.Nonce, nCfgDedicated.PodLabels().[CfgVal.runNonceLabelKey])
+
+        // A single required pod anti-affinity term repels other runs' pods.
+        Assert.NotNull(spec.Affinity)
+        Assert.NotNull(spec.Affinity.PodAntiAffinity)
+        let terms = spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+        Assert.Equal(1, terms.Count)
+        let term = terms.[0]
+        Assert.Equal("kubernetes.io/hostname", term.TopologyKey)
+        Assert.Equal("stellar-core", term.LabelSelector.MatchLabels.["app"])
+        let expr = Seq.exactlyOne term.LabelSelector.MatchExpressions
+        Assert.Equal(CfgVal.runNonceLabelKey, expr.Key)
+        Assert.Equal("NotIn", expr.OperatorProperty)
+        Assert.Equal(nCfgDedicated.Nonce, Seq.exactlyOne expr.Values)
+
+    [<Fact>]
+    member __.``Non-dedicated mission has no affinity``() =
+        // The default ctx sets no node labels and dedicatedNodes = false, so
+        // there is no affinity block at all -- but pods still carry the nonce.
+        let nCfgPlain = MakeNetworkCfg { ctx with installNetworkDelay = Some false } [ coreSet ] passOpt
+        let spec = (nCfgPlain.ToPodTemplateSpec coreSet).Spec
+        Assert.Null(spec.Affinity)
+        Assert.Equal(nCfgPlain.Nonce, nCfgPlain.PodLabels().[CfgVal.runNonceLabelKey])
 
     [<Fact>]
     member __.``Core init commands look reasonable``() =

--- a/src/FSLibrary/MissionMaxTPSClassic.fs
+++ b/src/FSLibrary/MissionMaxTPSClassic.fs
@@ -16,7 +16,10 @@ let maxTPSClassic (context: MissionContext) =
         { context with
               coreResources = SimulatePubnetTier1PerfResources
               installNetworkDelay = Some(context.installNetworkDelay |> Option.defaultValue true)
-              enableTailLogging = false }
+              enableTailLogging = false
+              // Isolate this perf run onto its own nodes so co-tenant pods from
+              // other supercluster runs cannot skew the measured TPS.
+              dedicatedNodes = true }
 
     let baseLoadGen =
         { LoadGen.GetDefault() with

--- a/src/FSLibrary/MissionMaxTPSMixed.fs
+++ b/src/FSLibrary/MissionMaxTPSMixed.fs
@@ -18,6 +18,9 @@ let maxTPSMixed (baseContext: MissionContext) =
               coreResources = SimulatePubnetTier1PerfResources
               installNetworkDelay = Some(baseContext.installNetworkDelay |> Option.defaultValue true)
               enableTailLogging = false
+              // Isolate this perf run onto its own nodes so co-tenant pods from
+              // other supercluster runs cannot skew the measured TPS.
+              dedicatedNodes = true
               // Setup distributions based on pubnet data
               wasmBytesDistribution = defaultListValue pubnetWasmBytes baseContext.wasmBytesDistribution
               dataEntriesDistribution = defaultListValue pubnetDataEntries baseContext.dataEntriesDistribution

--- a/src/FSLibrary/MissionMinBlockTimeClassic.fs
+++ b/src/FSLibrary/MissionMinBlockTimeClassic.fs
@@ -19,7 +19,10 @@ let minBlockTimeClassic (context: MissionContext) =
         { context with
               coreResources = SimulatePubnetTier1PerfResources
               installNetworkDelay = Some(context.installNetworkDelay |> Option.defaultValue true)
-              enableTailLogging = false }
+              enableTailLogging = false
+              // Isolate this perf run onto its own nodes so co-tenant pods from
+              // other supercluster runs cannot skew the measured block time.
+              dedicatedNodes = true }
 
     let baseLoadGen =
         { LoadGen.GetDefault() with

--- a/src/FSLibrary/MissionMinBlockTimeMixed.fs
+++ b/src/FSLibrary/MissionMinBlockTimeMixed.fs
@@ -34,6 +34,9 @@ let minBlockTimeMixed (baseContext: MissionContext) =
               coreResources = SimulatePubnetTier1PerfResources
               installNetworkDelay = Some(baseContext.installNetworkDelay |> Option.defaultValue true)
               enableTailLogging = false
+              // Isolate this perf run onto its own nodes so co-tenant pods from
+              // other supercluster runs cannot skew the measured block time.
+              dedicatedNodes = true
               txRate = classicTxRate + sorobanTxRate }
 
     let baseLoadGen =

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -22,6 +22,10 @@ module CfgVal =
     let prometheusExporterPort = 9473
     let labels = Map.ofSeq [ "app", "stellar-core" ]
     let labelSelector = "app = stellar-core"
+    // Per-run label key. Its value is the run's network nonce, which lets us
+    // distinguish pods belonging to different supercluster runs sharing a
+    // namespace (used for scheduling isolation; see StellarKubeSpecs.Affinity).
+    let runNonceLabelKey = "run-nonce"
     let stellarCoreBinPath = "stellar-core"
     let allCoreContainerCmds = [| "new-hist"; "new-db"; "catchup"; "run"; "test" |]
 

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -391,15 +391,31 @@ let tolerateTaint ((key: string), (value: string option)) =
     | None -> V1Toleration(key = key, operatorProperty = "Exists")
     | Some v -> V1Toleration(key = key, operatorProperty = "Equal", value = v)
 
-let affinity (requirements: V1NodeSelectorRequirement list) : V1Affinity option =
+let nodeAffinity (requirements: V1NodeSelectorRequirement list) : V1NodeAffinity option =
     if List.isEmpty requirements then
         None
     else
-        // An affinity is satisfied if _all_ matchExpressions are satisfied.
+        // A node affinity is satisfied if _all_ matchExpressions are satisfied.
         let terms = [| V1NodeSelectorTerm(matchExpressions = Array.ofList requirements) |]
         let sel = V1NodeSelector(nodeSelectorTerms = terms)
-        let na = V1NodeAffinity(requiredDuringSchedulingIgnoredDuringExecution = sel)
-        Some(V1Affinity(nodeAffinity = na))
+        Some(V1NodeAffinity(requiredDuringSchedulingIgnoredDuringExecution = sel))
+
+// A required pod anti-affinity that repels every supercluster pod belonging to
+// a _different_ run, i.e. carrying a run-nonce label other than this run's.
+// Kubernetes evaluates required anti-affinity symmetrically, so a single term
+// on this run's pods gives us both directions of isolation:
+//   * this run's pods will not schedule onto a node already hosting another
+//     run's pods, and
+//   * no other run's pods will schedule onto a node hosting this run's pods for
+//     as long as this run's pods are alive (this holds even if the other run
+//     did not opt into isolation).
+let dedicatedNodeAntiAffinity (nonce: string) : V1PodAntiAffinity =
+    let matchExprs =
+        [| V1LabelSelectorRequirement(key = CfgVal.runNonceLabelKey, operatorProperty = "NotIn", values = [| nonce |]) |]
+
+    let selector = V1LabelSelector(matchLabels = CfgVal.labels, matchExpressions = matchExprs)
+    let term = V1PodAffinityTerm(labelSelector = selector, topologyKey = "kubernetes.io/hostname")
+    V1PodAntiAffinity(requiredDuringSchedulingIgnoredDuringExecution = [| term |])
 
 
 // Apply the per-run anchor owner reference to `meta` if one has been set on
@@ -426,13 +442,25 @@ type NetworkCfg with
         V1ObjectMeta(name = name, labels = CfgVal.labels, namespaceProperty = self.NamespaceProperty)
         |> applyAnchorOwner self
 
-    member self.PodLabels() : Map<string, string> = Map.add "mission" self.missionContext.missionName CfgVal.labels
+    member self.PodLabels() : Map<string, string> =
+        CfgVal.labels
+        |> Map.add "mission" self.missionContext.missionName
+        |> Map.add CfgVal.runNonceLabelKey self.Nonce
 
     member self.Affinity() : V1Affinity option =
         let require = List.map requireNodeLabel self.missionContext.requireNodeLabels
         let avoid = List.map avoidNodeLabel self.missionContext.avoidNodeLabels
-        let both = List.append require avoid
-        affinity both
+        let na = nodeAffinity (List.append require avoid)
+
+        let paa =
+            if self.missionContext.dedicatedNodes then
+                Some(dedicatedNodeAntiAffinity self.Nonce)
+            else
+                None
+
+        match na, paa with
+        | None, None -> None
+        | _ -> Some(V1Affinity(?nodeAffinity = na, ?podAntiAffinity = paa))
 
     member self.TopologyConstraints() : V1TopologySpreadConstraint array =
         if self.missionContext.unevenSched then [||] else evenTopologyConstraints

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -414,7 +414,10 @@ let dedicatedNodeAntiAffinity (nonce: string) : V1PodAntiAffinity =
         [| V1LabelSelectorRequirement(key = CfgVal.runNonceLabelKey, operatorProperty = "NotIn", values = [| nonce |]) |]
 
     let selector = V1LabelSelector(matchLabels = CfgVal.labels, matchExpressions = matchExprs)
-    let term = V1PodAffinityTerm(labelSelector = selector, topologyKey = "kubernetes.io/hostname")
+
+    let term =
+        V1PodAffinityTerm(labelSelector = selector, topologyKey = "kubernetes.io/hostname")
+
     V1PodAntiAffinity(requiredDuringSchedulingIgnoredDuringExecution = [| term |])
 
 

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -64,6 +64,12 @@ type MissionContext =
       coreResources: CoreResources
       keepData: bool
       unevenSched: bool
+      // When set, this run requires exclusive use of its nodes: its pods will
+      // not be scheduled onto a node hosting another run's pods, and no other
+      // run's pods will be scheduled onto its nodes while it is alive. Used for
+      // performance-sensitive missions (Max TPS, Min Block Time) whose
+      // measurements would be corrupted by co-tenant workloads.
+      dedicatedNodes: bool
       requireNodeLabels: ((string * string option) list)
       avoidNodeLabels: ((string * string option) list)
       tolerateNodeTaints: ((string * string option) list)

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -65,10 +65,14 @@ type MissionContext =
       keepData: bool
       unevenSched: bool
       // When set, this run requires exclusive use of its nodes: its pods will
-      // not be scheduled onto a node hosting another run's pods, and no other
-      // run's pods will be scheduled onto its nodes while it is alive. Used for
-      // performance-sensitive missions (Max TPS, Min Block Time) whose
-      // measurements would be corrupted by co-tenant workloads.
+      // not be scheduled onto a node hosting another run's stellar-core pods,
+      // and no other run's stellar-core pods will be scheduled onto its nodes
+      // while it is alive. This only covers pods carrying the app=stellar-core
+      // label (i.e. pods built from NetworkCfg pod templates); it does not
+      // repel other workloads such as parallel-catchup-v2 helm pods, which are
+      // instead kept on their own tainted nodes. Used for performance-sensitive
+      // missions (Max TPS, Min Block Time) whose measurements would be
+      // corrupted by co-tenant workloads.
       dedicatedNodes: bool
       requireNodeLabels: ((string * string option) list)
       avoidNodeLabels: ((string * string option) list)


### PR DESCRIPTION
Give perf-sensitive missions (`MaxTPSClassic`, `MaxTPSMixed`, `MinBlockTimeClassic`, `MinBlockTimeMixed`) exclusive use of their nodes so pods from other runs can't skew their measurements. A step toward parallel runs (stellar/pod-fsr#55); does not touch the Jenkins locks.

Each pod is now labeled with its run nonce (`run-nonce`), and isolated missions get a required pod anti-affinity repelling any `stellar-core` pod with a different nonce. Kubernetes evaluates this symmetrically, so it both keeps this run off nodes with other runs' pods and keeps other runs off this run's nodes. Controlled by a new `MissionContext.dedicatedNodes` flag the four missions set themselves — no CLI/Jenkinsfile change.

Tested via new unit tests and a live run on ssc-eks (pods got the label + anti-affinity and landed on distinct dedicated nodes).