### PR TITLE
Bump catchup RAM burst limit to match other pubnet mission limit

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -126,8 +126,8 @@ let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
 
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
-    // 0.25 vCPUs, 8GB RAM and 35 GB of disk bursting to 2vCPU, 16GB and 40 GB
-    makeResourceRequirementsWithStorageLimit 250 8192 35 2000 16384 40
+    // 0.25 vCPUs, 8GB RAM and 35 GB of disk bursting to 2vCPU, 24000MB and 40 GB
+    makeResourceRequirementsWithStorageLimit 250 8192 35 2000 24000 40
 
 let NonParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing non-parallel catchup, we give each container


### PR DESCRIPTION
PR #404 bumped RAM burst limits to account for the RAM usage increase in in-memory rebuild on pubnet. However, parallel catchup uses a different resource specification and so runs in into the same OOM issue that #404 resolved. This PR bumps the catchup burst RAM limit to match the limit in #404.