### PR TITLE
DatabaseInplaceUpgrade: bump caught-up gap to 10, use medium resources

### DIFF
--- a/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
+++ b/src/FSLibrary/MissionDatabaseInplaceUpgrade.fs
@@ -16,7 +16,8 @@ open StellarSupercluster
 let databaseInplaceUpgrade (context: MissionContext) =
     let context =
         { context.WithNominalLoad with
-              genesisTestAccountCount = Some context.WithNominalLoad.numAccounts }
+              genesisTestAccountCount = Some context.WithNominalLoad.numAccounts
+              coreResources = MediumTestResources }
 
     let newImage = context.image
     let oldImage = GetOrDefault context.oldImage context.image

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -908,7 +908,10 @@ type Peer with
     // ledgers of the reference peer's latest, proving it is actually
     // tracking the live network.
     member self.WaitUntilCaughtUpWith(other: Peer) =
-        let maxLedgerGap = 5
+        // self and other are read in two separate requests, so the network
+        // advances between them; the gap absorbs that timing skew (and the
+        // small steady lag of a watcher outside the quorum).
+        let maxLedgerGap = 10
 
         RetryUntilTrue
             (fun _ -> other.GetLedgerNum() - self.GetLedgerNum() <= maxLedgerGap)


### PR DESCRIPTION
Bumps the after-upgrade node's caught-up ledger gap from 5 to 10 (absorbs read skew + the watcher's steady lag) and switches the mission to MediumTestResources for more headroom.