### PR TITLE
http proxy: apply mission node affinity + tolerations to the proxy pod

### DIFF
--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -279,6 +279,41 @@ type Tests(output: ITestOutputHelper) =
         Assert.Equal(nCfgPlain.Nonce, nCfgPlain.PodLabels().[CfgVal.runNonceLabelKey])
 
     [<Fact>]
+    member __.``HTTP proxy pod inherits mission node affinity and tolerations``() =
+        // Regression: the HTTP proxy Deployment must carry the mission's node
+        // placement (self.Affinity()/self.Tolerations()) like the core pods it
+        // fronts -- otherwise it cannot schedule onto a tainted/dedicated pool
+        // and stays Pending on a busy cluster.
+        let nCfg =
+            MakeNetworkCfg
+                { ctx with
+                      requireNodeLabels = [ ("purpose", Some "largetests") ]
+                      tolerateNodeTaints = [ ("largetests", None) ]
+                      installNetworkDelay = Some false }
+                [ coreSet ]
+                passOpt
+
+        let spec = nCfg.ToHttpProxyDeployment().Spec.Template.Spec
+
+        // Node affinity requires the mission node label.
+        Assert.NotNull(spec.Affinity)
+        Assert.NotNull(spec.Affinity.NodeAffinity)
+
+        let term =
+            Seq.exactlyOne spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+
+        let expr = Seq.exactlyOne term.MatchExpressions
+        Assert.Equal("purpose", expr.Key)
+        Assert.Equal("In", expr.OperatorProperty)
+        Assert.Equal("largetests", Seq.exactlyOne expr.Values)
+
+        // Tolerates the mission node taint.
+        Assert.True(
+            spec.Tolerations
+            |> Seq.exists (fun t -> t.Key = "largetests" && t.OperatorProperty = "Exists")
+        )
+
+    [<Fact>]
     member __.``Core init commands look reasonable``() =
         let nCfgWithoutSimulateApply =
             MakeNetworkCfg { ctx with simulateApplyWeight = None; simulateApplyDuration = None } [ coreSet ] passOpt

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -974,7 +974,16 @@ type NetworkCfg with
                 configMap = V1ConfigMapVolumeSource(name = self.HttpProxyConfigMapName)
             )
 
-        let podSpec = V1PodSpec(containers = [| container |], volumes = [| volume |])
+        // Mirror the core pods' node placement so the proxy schedules onto the
+        // same (often tainted/dedicated) node pool it fronts -- otherwise it is
+        // confined to untainted capacity and can stay Pending on a busy cluster.
+        let podSpec =
+            V1PodSpec(
+                containers = [| container |],
+                volumes = [| volume |],
+                ?affinity = self.Affinity(),
+                tolerations = self.Tolerations()
+            )
 
         let podTemplate =
             V1PodTemplateSpec(metadata = V1ObjectMeta(labels = self.HttpProxyLabels), spec = podSpec)


### PR DESCRIPTION
## What
- Apply the mission's node **affinity** + **tolerations** to the HTTP proxy Deployment's pod (`ToHttpProxyDeployment`), matching the core pods it fronts.

## Why
- Proxy pods were getting provisioned on the ASG nodes, now they run on the same karpenter nodes as the core/catchup pods

## Fix
```fsharp
V1PodSpec(
    containers = [| container |],
    volumes = [| volume |],
    ?affinity = self.Affinity(),
    tolerations = self.Tolerations()
)
```

## Testing
- `dotnet build -c Release` clean; `fantomas --check --recurse src` clean.
- New test suite addition passed
- Test run on https://buildmeister-v3.stellar-ops.com/job/Core/job/stellar-supercluster-test/164/

## Validation after merge
- A large mission (e.g. LoadGenerationWithTxSetLimit) runs its proxy pod on the mission's tainted node pool; no `proxy not ready` timeouts under concurrent load.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
