### PR TITLE
http proxy: raise readiness budget for node cold-start + throttle poll log

### DIFF
--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -351,7 +351,13 @@ type Kubernetes with
 
                 // Wait for at least one proxy pod to be ready before the driver
                 // routes core HTTP through it, so mission startup doesn't spend
-                // its retry budget on 502s.
+                // its retry budget on 502s. The proxy is pinned to the mission's
+                // node pool (e.g. largetests/catchup), so first-ready can take
+                // several minutes when karpenter must cold-provision a node and
+                // the CNI assign an IP -- hence a generous budget. The overall
+                // mission timeout still bounds a genuinely stuck proxy.
+                let proxyReadyMaxAttempts = 300 // x 2s ~= 10 min
+
                 let rec waitProxyReady (n: int) =
                     ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (rps)
 
@@ -361,11 +367,22 @@ type Kubernetes with
                     // null right after creation; treat missing as 0 ready and keep polling.
                     let ready = if isNull d.Status then 0 else d.Status.ReadyReplicas.GetValueOrDefault(0)
 
-                    LogInfo "HTTP proxy %s: %d ready" proxyDep.Metadata.Name ready
+                    // Throttle the poll log to ~once a minute (every 30th attempt)
+                    // plus the terminal ready line, instead of one line every 2s.
+                    if ready >= 1 || n % 30 = 0 then
+                        LogInfo
+                            "HTTP proxy %s: %d ready (attempt %d/%d)"
+                            proxyDep.Metadata.Name
+                            ready
+                            n
+                            proxyReadyMaxAttempts
 
                     if ready < 1 then
-                        if n >= 60 then
-                            failwithf "HTTP proxy %s not ready after 60 attempts" proxyDep.Metadata.Name
+                        if n >= proxyReadyMaxAttempts then
+                            failwithf
+                                "HTTP proxy %s not ready after %d attempts"
+                                proxyDep.Metadata.Name
+                                proxyReadyMaxAttempts
 
                         System.Threading.Thread.Sleep(2000)
                         waitProxyReady (n + 1)

--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -356,7 +356,7 @@ type Kubernetes with
                 // several minutes when karpenter must cold-provision a node and
                 // the CNI assign an IP -- hence a generous budget. The overall
                 // mission timeout still bounds a genuinely stuck proxy.
-                let proxyReadyMaxAttempts = 300 // x 2s ~= 10 min
+                let proxyReadyMaxAttempts = 450 // x 2s ~= 15 min
 
                 let rec waitProxyReady (n: int) =
                     ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (rps)

--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -368,8 +368,8 @@ type Kubernetes with
                     let ready = if isNull d.Status then 0 else d.Status.ReadyReplicas.GetValueOrDefault(0)
 
                     // Throttle the poll log to ~once a minute (every 30th attempt)
-                    // plus the terminal ready line, instead of one line every 2s.
-                    if ready >= 1 || n % 30 = 0 then
+                    // plus the first and terminal ready lines, instead of one line every 2s.
+                    if ready >= 1 || n = 1 || n % 30 = 0 then
                         LogInfo
                             "HTTP proxy %s: %d ready (attempt %d/%d)"
                             proxyDep.Metadata.Name
@@ -387,7 +387,7 @@ type Kubernetes with
                         System.Threading.Thread.Sleep(2000)
                         waitProxyReady (n + 1)
 
-                waitProxyReady 0
+                waitProxyReady 1
 
                 // Best-effort wait for the gateway to mark the HTTPRoute Accepted,
                 // closing the window between pod-ready and route-programmed (404s).

--- a/src/FSLibrary/StellarSupercluster.fs
+++ b/src/FSLibrary/StellarSupercluster.fs
@@ -356,7 +356,7 @@ type Kubernetes with
                 // several minutes when karpenter must cold-provision a node and
                 // the CNI assign an IP -- hence a generous budget. The overall
                 // mission timeout still bounds a genuinely stuck proxy.
-                let proxyReadyMaxAttempts = 450 // x 2s ~= 15 min
+                let proxyReadyMaxAttempts = 300 // x 2s ~= 10 min
 
                 let rec waitProxyReady (n: int) =
                     ApiRateLimit.sleepUntilNextRateLimitedApiCallTime (rps)


### PR DESCRIPTION
## What
- Raise the HTTP proxy readiness budget in `waitProxyReady` from **60 attempts (~120s)** to **300 (~10 min)**.


## Why
- proxy pods switched to karpenter, but now have to wait for karpenter cold start times

## Testing
- `dotnet build -c Release` clean; `fantomas --check --recurse src` clean.
- **Definitive live test** on `Core/stellar-supercluster-test` with `SUPERCLUSTER_PR=<this>` + `--require-node-labels=purpose:largetests --tolerate-node-taints=largetests`, forcing a karpenter cold-start, confirming the proxy becomes ready within the new budget and the mission succeeds (see PR comment).

## Known limitations / follow-up (infra, not this PR)
- The underlying `aws-cni failed to assign an IP address` on largetests nodes is IP/ENI exhaustion when many pods land on a freshly-scaled node — a VPC-CNI / karpenter-nodeclass concern (prefix delegation / max-pods / instance ENI capacity). This PR tolerates the delay; the CNI capacity itself is worth a separate infra fix.

## Issue
- Follows #413; addresses the residual proxy-readiness timeout seen on kube001-ssc-eks (#1867/#1868).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
