### PR TITLE
Update MissionLoadGenerationWithTxSetLimit to use UpgradeResources like the sibling MissionProtocolUpgradeWithLoad that has 1k tx rate

### DIFF
--- a/src/FSLibrary/MissionLoadGenerationWithTxSetLimit.fs
+++ b/src/FSLibrary/MissionLoadGenerationWithTxSetLimit.fs
@@ -22,7 +22,7 @@ let loadGenerationWithTxSetLimit (context: MissionContext) =
 
     let context =
         { context.WithSmallLoadgenOptions with
-              coreResources = MediumTestResources
+              coreResources = UpgradeResources
               numAccounts = 50000
               numTxs = 50000
               txRate = 1000


### PR DESCRIPTION
This is to fix a flaky test. Updating MissionLoadGenerationWithTxSetLimit to use UpgradeResources like the sibling MissionProtocolUpgradeWithLoad that has similar 1k tx rate and 50k numTxns. https://github.com/anupsdf/supercluster/blob/main/src/FSLibrary/MissionProtocolUpgradeWithLoad.fs#L25-L29