### PR TITLE
Bump parallel catchup memory limit to 28Gi

### DIFF
--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -127,8 +127,8 @@ let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
 
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
-    // 0.25 vCPUs, 8GB RAM and 35 GB of disk bursting to 2vCPU, 24000MB and 40 GB
-    makeResourceRequirementsWithStorageLimit 250 8192 35 2000 24000 40
+    // 0.25 vCPUs, 8Gi RAM and 35 GB of disk bursting to 2vCPU, 28Gi (28672Mi) and 40 GB
+    makeResourceRequirementsWithStorageLimit 250 8192 35 2000 28672 40
 
 let NonParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing non-parallel catchup, we give each container


### PR DESCRIPTION
### What

Raise the parallel catchup worker memory limit from `24000Mi` (23.4 GiB) to `28672Mi` (28 GiB).

### Why

Ranges at the tip of pubnet now peak close to the old limit, leaving too little headroom.
