### PR TITLE
Add QuorumIntersectionChecker mission

### DIFF
--- a/doc/missions.md
+++ b/doc/missions.md
@@ -205,3 +205,11 @@ This mission simulates the full pubnet topology and tests how the network perfor
   - `--tx-size-bytes 120000 --tx-size-bytes-weights 1` - Generate only large transactions (~120KB)
   - `--tx-size-bytes 40000,120000 --tx-size-bytes-weights 1,1` - Generate a 50/50 mix of medium (~40KB) and large (~120KB) transactions
   - `--tx-size-bytes 20000,80000,120000 --tx-size-bytes-weights 3,2,1` - Weighted distribution: 50% small, 33% medium, 17% large
+
+## MissionQuorumIntersectionChecker
+
+Runs a 6-node network built around an intersection-critical "bridge" validator
+with stellar-core's V2 quorum intersection checker enabled, then restarts only
+the bridge with its quorum-set threshold relaxed from "both sides" to "either
+side", creating two disjoint quorums in configuration. Verifies that the
+self-sufficient side detects the split live.

--- a/src/FSLibrary.Tests/Tests.fs
+++ b/src/FSLibrary.Tests/Tests.fs
@@ -1,6 +1,7 @@
 module Tests
 
 open StellarDestination
+open StellarDotnetSdk.Accounts
 open StellarMissionContext
 open Xunit
 open System.Text.RegularExpressions
@@ -12,6 +13,7 @@ open StellarNetworkCfg
 open StellarKubeSpecs
 open StellarNetworkData
 open StellarNetworkDelays
+open StellarCoreHTTP
 open MissionCatchupHelpers
 open Xunit.Abstractions
 
@@ -197,6 +199,87 @@ type Tests(output: ITestOutputHelper) =
         // explicitly configured on the CoreSet or the mission context.
         Assert.DoesNotContain("FORCE_OLD_STYLE_PREPARE_START_TRIGGER_TIMER", toml)
         Assert.DoesNotContain("ARTIFICIALLY_SET_SYSTEM_CLOCK_OFFSET_FOR_TESTING", toml)
+
+    [<Fact>]
+    member __.``Quorum intersection checker config defaults to disabled``() =
+        let cfg = nCfg.StellarCoreCfg(coreSet, 1, MainCoreContainer)
+        let toml = cfg.ToString()
+        Assert.Contains("QUORUM_INTERSECTION_CHECKER = false", toml)
+        Assert.DoesNotContain("USE_QUORUM_INTERSECTION_CHECKER_V2", toml)
+        Assert.DoesNotContain("QUORUM_INTERSECTION_CHECKER_TIME_LIMIT_MS", toml)
+        Assert.DoesNotContain("QUORUM_INTERSECTION_CHECKER_MEMORY_LIMIT_BYTES", toml)
+
+    [<Fact>]
+    member __.``Quorum intersection checker config can be enabled with V2 and limits``() =
+        let opts =
+            { coreSetOptions with
+                  quorumIntersectionChecker = true
+                  useQuorumIntersectionCheckerV2 = true
+                  quorumIntersectionCheckerTimeLimitMs = Some 10000L
+                  quorumIntersectionCheckerMemoryLimitBytes = Some 209715200L }
+
+        let cs = MakeLiveCoreSet "qic" opts
+        let cfg = (MakeNetworkCfg ctx [ cs ] passOpt).StellarCoreCfg(cs, 0, MainCoreContainer)
+        let toml = cfg.ToString()
+        Assert.Contains("QUORUM_INTERSECTION_CHECKER = true", toml)
+        Assert.Contains("USE_QUORUM_INTERSECTION_CHECKER_V2 = true", toml)
+        Assert.Contains("QUORUM_INTERSECTION_CHECKER_TIME_LIMIT_MS = 10000", toml)
+        Assert.Contains("QUORUM_INTERSECTION_CHECKER_MEMORY_LIMIT_BYTES = 209715200", toml)
+
+    [<Fact>]
+    member __.``MakeLiveCoreSetWithKeys preserves supplied keys``() =
+        let keys = Array.init 3 (fun _ -> KeyPair.Random())
+        let cs = MakeLiveCoreSetWithKeys "withkeys" keys coreSetOptions
+        Assert.Equal<KeyPair array>(keys, cs.keys)
+        Assert.True(cs.live)
+        Assert.Equal(CoreSetName "withkeys", cs.name)
+
+    [<Fact>]
+    member __.``MakeLiveCoreSetWithKeys rejects key count mismatch``() =
+        let keys = Array.init 2 (fun _ -> KeyPair.Random())
+
+        Assert.Throws<System.Exception>(fun () -> MakeLiveCoreSetWithKeys "withkeys" keys coreSetOptions |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member __.``WithCoreSetOptions swaps options preserving keys and liveness``() =
+        let nCfg2 = MakeNetworkCfg ctx [ coreSet ] passOpt
+        let newOpts = { coreSetOptions with quorumIntersectionChecker = true }
+        let nCfg3 = nCfg2.WithCoreSetOptions(CoreSetName "test") newOpts
+        let before = nCfg2.FindCoreSet(CoreSetName "test")
+        let after = nCfg3.FindCoreSet(CoreSetName "test")
+        Assert.Equal<KeyPair array>(before.keys, after.keys)
+        Assert.Equal(before.live, after.live)
+        Assert.True(after.options.quorumIntersectionChecker)
+        let toml = nCfg3.StellarCoreCfg(after, 0, MainCoreContainer).ToString()
+        Assert.Contains("QUORUM_INTERSECTION_CHECKER = true", toml)
+
+    [<Fact>]
+    member __.``WithCoreSetOptions rejects nodeCount changes``() =
+        let nCfg2 = MakeNetworkCfg ctx [ coreSet ] passOpt
+        let newOpts = { coreSetOptions with nodeCount = coreSetOptions.nodeCount + 1 }
+
+        Assert.Throws<System.Exception>(fun () -> nCfg2.WithCoreSetOptions(CoreSetName "test") newOpts |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member __.``PeerConfigMap matches ToConfigMaps output``() =
+        let ctx = { ctx with installNetworkDelay = None }
+        let nCfg2 = MakeNetworkCfg ctx [ coreSet ] passOpt
+
+        let fromAll =
+            nCfg2.ToConfigMaps()
+            |> Array.find (fun cm -> cm.Metadata.Name = nCfg2.PeerCfgMapName coreSet 0)
+
+        let single = nCfg2.PeerConfigMap(coreSet, 0)
+        Assert.Equal(fromAll.Metadata.Name, single.Metadata.Name)
+
+        Assert.Equal<string seq>(
+            Seq.sort (
+                Seq.map (fun (kv: System.Collections.Generic.KeyValuePair<string, string>) -> kv.Key) fromAll.Data
+            ),
+            Seq.sort (Seq.map (fun (kv: System.Collections.Generic.KeyValuePair<string, string>) -> kv.Key) single.Data)
+        )
 
     [<Fact>]
     member __.``TOML Config emits trigger timer and per-node clock offsets``() =
@@ -551,3 +634,65 @@ type Tests(output: ITestOutputHelper) =
         Assert.Equal("51/6", jobArr3.[0].[1])
         Assert.Equal("56/6", jobArr3.[1].[1])
         Assert.Equal("61/6", jobArr3.[2].[1])
+
+    [<Fact>]
+    member __.``ParseQuorumIntersectionInfo handles intersecting result``() =
+        let json = """{ "node": "GAAA", "qset": {},
+                 "transitive": { "intersection": true, "node_count": 6,
+                                 "last_check_ledger": 12,
+                                 "critical": [["GBBB"], ["GCCC", "GDDD"]] } }"""
+
+        match ParseQuorumIntersectionInfo json with
+        | None -> failwith "expected Some"
+        | Some qi ->
+            Assert.True(qi.intersection)
+            Assert.Equal(6, qi.nodeCount)
+            Assert.Equal(12, qi.lastCheckLedger)
+            Assert.Equal<Set<string> list>([ Set.ofList [ "GBBB" ]; Set.ofList [ "GCCC"; "GDDD" ] ], qi.criticalGroups)
+            Assert.True(qi.potentialSplit.IsNone)
+
+    [<Fact>]
+    member __.``ParseQuorumIntersectionInfo handles split result``() =
+        let json = """{ "node": "GAAA", "qset": {},
+                 "transitive": { "intersection": false, "node_count": 6,
+                                 "last_check_ledger": 20, "last_good_ledger": 15,
+                                 "potential_split": [["GBBB", "GCCC"], ["GDDD"]] } }"""
+
+        match ParseQuorumIntersectionInfo json with
+        | None -> failwith "expected Some"
+        | Some qi ->
+            Assert.False(qi.intersection)
+            Assert.Equal<Set<string> list>([], qi.criticalGroups)
+
+            match qi.potentialSplit with
+            | Some (a, b) ->
+                Assert.Equal<Set<string>>(Set.ofList [ "GBBB"; "GCCC" ], a)
+                Assert.Equal<Set<string>>(Set.ofList [ "GDDD" ], b)
+            | None -> failwith "expected potential_split"
+
+    [<Fact>]
+    member __.``ParseQuorumIntersectionInfo returns None without results``() =
+        Assert.True((ParseQuorumIntersectionInfo """{ "node": "GAAA", "qset": {} }""").IsNone)
+
+        let json = """{ "transitive": { "intersection": true, "node_count": 3,
+                                 "last_check_ledger": 5, "critical": null } }"""
+
+        match ParseQuorumIntersectionInfo json with
+        | Some qi -> Assert.Equal<Set<string> list>([], qi.criticalGroups)
+        | None -> failwith "expected Some"
+
+    [<Fact>]
+    member __.``ParseMetricCount reads counter or defaults to zero``() =
+        let json = """{ "metrics": { "scp.qic.successful-run": { "type": "counter", "count": 3 },
+                              "scp.qic.result-potential-split": { "type": "counter", "count": 1 },
+                              "scp.qic.no-count": { "type": "counter" } } }"""
+
+        Assert.Equal(3, ParseMetricCount json "scp.qic.successful-run")
+        Assert.Equal(1, ParseMetricCount json "scp.qic.result-potential-split")
+        Assert.Equal(0, ParseMetricCount json "scp.qic.no-count")
+        Assert.Equal(0, ParseMetricCount json "scp.qic.failed-run")
+        Assert.Equal(0, ParseMetricCount """{ }""" "scp.qic.failed-run")
+
+    [<Fact>]
+    member __.``QuorumIntersectionChecker mission is registered``() =
+        Assert.True(StellarMission.allMissions.ContainsKey "QuorumIntersectionChecker")

--- a/src/FSLibrary/FSLibrary.fsproj
+++ b/src/FSLibrary/FSLibrary.fsproj
@@ -82,6 +82,7 @@
     <Compile Include="MissionMinBlockTimeClassic.fs" />
     <Compile Include="MissionMinBlockTimeMixed.fs" />
     <Compile Include="MissionTriggerTimerMixConsensus.fs" />
+    <Compile Include="MissionQuorumIntersectionChecker.fs" />
     <Compile Include="StellarMission.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FSLibrary/MissionQuorumIntersectionChecker.fs
+++ b/src/FSLibrary/MissionQuorumIntersectionChecker.fs
@@ -1,0 +1,246 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+module MissionQuorumIntersectionChecker
+
+// Verifies stellar-core's (V2) quorum intersection checker on a live network.
+// Topology:
+//
+//  v1 ⇄ v2            left pair: each 3-of-3 {v0,v1,v2}
+//    ⇅  ⇅
+//     v0              bridge  before: BOTH(2-of-3 {v0,v1,v2}, 2-of-3 {v3,v4,v5})
+//    ⇗⇑⇖                      after : EITHER(same two inner sets)
+//  v3 ⇄ v4 ⇄ v5       right trio: each 3-of-4 {v0,v3,v4,v5}
+//
+// The network initially enjoys quorum intersection and the checker flags the
+// bridge as intersection-critical. The mission then restarts **only** the
+// bridge with its threshold relaxed from 100% -> 50% ("both inner sets" to
+// "either"), which creates two disjoint quorums: {v0,v1,v2} and {v3,v4,v5}.
+//
+// The bridge rejoins on side-b's live lineage, so its new quorum set propagates
+// at current slots and side-b detect the split. side-a stalls during the
+// bridge's restart and can never recover: each side-a node's only quorum slice
+// contains the other stalled sibling, so neither can confirm a newer slot (but
+// since side-a is stalled but not forked, it can't crash the network, so we
+// have a clean detection). Detection is asserted through side-b's /quorum
+// reporting, including the exact potential_split contents.
+
+open Logging
+open PollRetry
+open StellarCoreSet
+open StellarCorePeer
+open StellarCoreHTTP
+open StellarFormation
+open StellarStatefulSets
+open StellarMissionContext
+open StellarSupercluster
+open StellarDotnetSdk.Accounts
+open k8s
+
+let quorumIntersectionChecker (context: MissionContext) =
+    // Keys are generated up front (rather than inside MakeLiveCoreSet) so the
+    // explicit quorum sets below can cross-reference nodes in other core sets.
+    let bridgeKeys = [| KeyPair.Random() |]
+    let sideAKeys = Array.init 2 (fun _ -> KeyPair.Random())
+    let sideBKeys = Array.init 3 (fun _ -> KeyPair.Random())
+    let v0 = bridgeKeys.[0]
+
+    let groupA = [ ("bridge-0", v0); ("side-a-0", sideAKeys.[0]); ("side-a-1", sideAKeys.[1]) ]
+
+    let groupB =
+        [ ("side-b-0", sideBKeys.[0])
+          ("side-b-1", sideBKeys.[1])
+          ("side-b-2", sideBKeys.[2]) ]
+
+    let qset (pct: int) (members: (string * KeyPair) list) (inner: ExplicitQuorumSet list) : ExplicitQuorumSet =
+        { thresholdPercent = Some pct
+          validators = members |> List.map (fun (n, k) -> (PeerShortName n, k)) |> Map.ofList
+          innerQuorumSets = Array.ofList inner }
+
+    // stellar-core converts THRESHOLD_PERCENT p over n entries to threshold
+    // 1 + (n*p - 1)/100 (round up): 66% of 3 = 2, 100% of 3 = 3, 75% of 4 = 3,
+    // 100% of 2 inner sets = both, 50% of 2 inner sets = either.
+    let bridgeQsetBoth = qset 100 [] [ qset 66 groupA []; qset 66 groupB [] ]
+    let bridgeQsetEither = qset 50 [] [ qset 66 groupA []; qset 66 groupB [] ]
+    let sideAQset = qset 100 groupA []
+    let sideBQset = qset 75 (("bridge-0", v0) :: groupB) []
+
+    let mkOptions (nodeCount: int) (q: ExplicitQuorumSet) =
+        { CoreSetOptions.GetDefault context.image with
+              nodeCount = nodeCount
+              quorumSet = ExplicitQuorum q
+              quorumSetConfigType = RequireExplicitQset
+              quorumIntersectionChecker = true
+              useQuorumIntersectionCheckerV2 = true }
+
+    let bridgeCoreSet = MakeLiveCoreSetWithKeys "bridge" bridgeKeys (mkOptions 1 bridgeQsetBoth)
+    let sideACoreSet = MakeLiveCoreSetWithKeys "side-a" sideAKeys (mkOptions 2 sideAQset)
+    let sideBCoreSet = MakeLiveCoreSetWithKeys "side-b" sideBKeys (mkOptions 3 sideBQset)
+    let allCoreSets = [ bridgeCoreSet; sideACoreSet; sideBCoreSet ]
+
+    let expectedSplit =
+        Set.ofList [ Set.ofList (List.map (fun (_, k: KeyPair) -> k.Address) groupA)
+                     Set.ofList (List.map (fun (_, k: KeyPair) -> k.Address) groupB) ]
+
+    context.ExecuteWithOptionalConsistencyCheck
+        allCoreSets
+        None
+        false
+        (fun (formation: StellarFormation) ->
+            formation.WaitUntilSynced allCoreSets
+            formation.UpgradeProtocolToLatest allCoreSets
+
+            let sideAPeers = [ for i in 0 .. 1 -> formation.NetworkCfg.GetPeer sideACoreSet i ]
+            let sideBPeers = [ for i in 0 .. 2 -> formation.NetworkCfg.GetPeer sideBCoreSet i ]
+
+            // The bridge's CoreSet record is replaced by ChangeCoreSetOptions,
+            // so always re-fetch it when constructing its Peer.
+            let bridgePeer () =
+                formation.NetworkCfg.GetPeer(formation.NetworkCfg.FindCoreSet bridgeCoreSet.name) 0
+
+            let assertOn (peer: Peer) (cond: bool) (msg: string) =
+                if not cond then failwithf "%s on %s" msg peer.ShortName.StringName
+
+            // Renders a group list (reported by /quorum) for failure messages
+            let showGroups (groups: Set<string> list) = groups |> List.map (String.concat ",") |> String.concat "; "
+
+            // Asserts a scp.qic counter, fetching it exactly once and quoting
+            // the observed value on failure.
+            let assertMetric (peer: Peer) (name: string) (ok: int -> bool) (msg: string) =
+                let observed = peer.GetQicMetricCount name
+                assertOn peer (ok observed) (sprintf "%s (%s=%d)" msg name observed)
+
+            // ---- Phase 0: every node sees a 6-node intersecting network ----
+            for peer in bridgePeer () :: sideAPeers @ sideBPeers do
+                // Since the checker recomputes whenever it detects a quorum
+                // change, we wait until the result is computed over the full 6
+                // node network.
+                RetryUntilTrue
+                    (fun _ ->
+                        match peer.TryGetQuorumIntersectionInfo() with
+                        | Some qi -> qi.nodeCount = 6
+                        | None -> false)
+                    (fun _ -> LogInfo "Waiting for full-network checker results on %s" peer.ShortName.StringName)
+
+                let qi = peer.GetQuorumIntersectionInfo()
+                assertOn peer qi.intersection "expected quorum intersection"
+
+                assertOn
+                    peer
+                    (List.contains (Set.singleton v0.Address) qi.criticalGroups)
+                    (sprintf
+                        "expected bridge node %s in intersection-critical groups, observed [%s]"
+                        v0.Address
+                        (showGroups qi.criticalGroups))
+
+                assertMetric peer "successful-run" (fun n -> n > 0) "expected successful checker runs"
+                assertMetric peer "failed-run" (fun n -> n = 0) "checker runs failed"
+                assertMetric peer "aborted-run" (fun n -> n = 0) "checker runs aborted"
+
+            LogInfo "Phase 0 verified: network enjoys quorum intersection; bridge is intersection-critical"
+
+            // Baselines. The scp.qic counters are cumulative and include
+            // bootstrap-time runs on partial quorum maps, we need to track the
+            // baseline and assert on deltas.
+            let splitBaselines = [ for p in sideBPeers -> (p, p.GetQicMetricCount "result-potential-split") ]
+
+            // side-a's verdicts are about to freeze; record where.
+            let frozenBaselines = [ for p in sideAPeers -> (p, (p.GetQuorumIntersectionInfo()).lastCheckLedger) ]
+
+            // ---- The flip: restart **only** the bridge, threshold 100% (both) -> 50% (either) ----
+            formation.Stop bridgeCoreSet.name
+            formation.ChangeCoreSetOptions bridgeCoreSet.name (mkOptions 1 bridgeQsetEither)
+            formation.Start bridgeCoreSet.name
+            formation.WaitUntilSynced [ formation.NetworkCfg.FindCoreSet bridgeCoreSet.name ]
+            LogInfo "Bridge restarted with EITHER-side quorum set"
+
+            // ---- Phase 1: detection on side-b, via /quorum (exact split contents) ----
+            for peer in sideBPeers do
+                RetryUntilTrue
+                    (fun _ ->
+                        match peer.TryGetQuorumIntersectionInfo() with
+                        | Some qi -> not qi.intersection
+                        | None -> false)
+                    (fun _ -> LogInfo "Waiting for %s to detect quorum split" peer.ShortName.StringName)
+
+                let qi = peer.GetQuorumIntersectionInfo()
+
+                match qi.potentialSplit with
+                | None -> failwithf "no potential_split reported on %s" peer.ShortName.StringName
+                | Some (a, b) ->
+                    assertOn
+                        peer
+                        (Set.ofList [ a; b ] = expectedSplit)
+                        (sprintf "unexpected potential_split [%s] vs [%s]" (String.concat "," a) (String.concat "," b))
+
+                assertMetric peer "failed-run" (fun n -> n = 0) "checker runs failed"
+                assertMetric peer "aborted-run" (fun n -> n = 0) "checker runs aborted"
+                assertMetric peer "result-unknown" (fun n -> n = 0) "checker returned unknown"
+
+            for (peer, baseline) in splitBaselines do
+                assertMetric
+                    peer
+                    "result-potential-split"
+                    (fun n -> n > baseline)
+                    (sprintf "expected result-potential-split counter to increase above baseline %d" baseline)
+
+            // ---- detection on the bridge, via scp.qic metrics ----
+            RetryUntilTrue
+                (fun _ -> (bridgePeer ()).GetQicMetricCount "result-potential-split" > 0)
+                (fun _ ->
+                    LogInfo
+                        "Waiting for %s to detect quorum split (via scp.qic metrics)"
+                        (bridgePeer ()).ShortName.StringName)
+
+            let bridge = bridgePeer ()
+            assertMetric bridge "successful-run" (fun n -> n > 0) "expected successful checker runs"
+            assertMetric bridge "failed-run" (fun n -> n = 0) "checker runs failed"
+            assertMetric bridge "aborted-run" (fun n -> n = 0) "checker runs aborted"
+            assertMetric bridge "result-unknown" (fun n -> n = 0) "checker returned unknown"
+
+            LogInfo "Phase 1 verified: side-b detected the split live via /quorum; bridge via scp.qic metrics"
+
+            // ---- Check the left side (side-a) remain frozen ----
+            // Quorum intersection checker only computes during externalize and
+            // since side A has not been closing ledger, the intersection status
+            // will be outdated (true).
+            (List.head sideBPeers).WaitForFewLedgers 5
+
+            for (peer, baseline) in frozenBaselines do
+                let qi = peer.GetQuorumIntersectionInfo()
+
+                assertOn
+                    peer
+                    qi.intersection
+                    (sprintf
+                        "expected the frozen (stale) intersection=true verdict, observed intersection=%b"
+                        qi.intersection)
+
+                assertOn
+                    peer
+                    (qi.lastCheckLedger = baseline)
+                    (sprintf "expected last_check_ledger to be frozen at %d, observed %d" baseline qi.lastCheckLedger)
+
+            LogInfo "Frozen-left verified: severed nodes keep the stale pre-change verdict"
+
+            // ---- No-harm: nobody crashed, the live side keeps closing ----
+            for peer in [ bridgePeer (); List.head sideBPeers ] do
+                peer.WaitForFewLedgers 2
+
+            for peer in bridgePeer () :: sideAPeers @ sideBPeers do
+                peer.CheckNoErrorMetrics false
+
+                let pod =
+                    formation.Kube.ReadNamespacedPod(
+                        name = peer.PodName.StringName,
+                        namespaceParameter = formation.NetworkCfg.NamespaceProperty
+                    )
+
+                for cs in pod.Status.ContainerStatuses do
+                    assertOn
+                        peer
+                        (cs.RestartCount = 0)
+                        (sprintf "container %s restarted %d times" cs.Name cs.RestartCount)
+
+            LogInfo "No-harm verified: zero restarts, no error metrics, live side advancing")

--- a/src/FSLibrary/StellarCoreCfg.fs
+++ b/src/FSLibrary/StellarCoreCfg.fs
@@ -183,6 +183,10 @@ type StellarCoreCfg =
       forceOldStyleTriggerTimer: bool option
       clockOffsetMs: int option
       surveyPhaseDuration: int option
+      quorumIntersectionChecker: bool
+      useQuorumIntersectionCheckerV2: bool
+      quorumIntersectionCheckerTimeLimitMs: int64 option
+      quorumIntersectionCheckerMemoryLimitBytes: int64 option
       containerType: CoreContainerType
       skipHighCriticalValidatorChecks: bool }
 
@@ -365,7 +369,19 @@ type StellarCoreCfg =
         t.Add("MAX_ADDITIONAL_PEER_CONNECTIONS", self.targetPeerConnections * 3)
         |> ignore
 
-        t.Add("QUORUM_INTERSECTION_CHECKER", false) |> ignore
+        t.Add("QUORUM_INTERSECTION_CHECKER", self.quorumIntersectionChecker) |> ignore
+
+        if self.useQuorumIntersectionCheckerV2 then
+            t.Add("USE_QUORUM_INTERSECTION_CHECKER_V2", true) |> ignore
+
+        match self.quorumIntersectionCheckerTimeLimitMs with
+        | Some ms -> t.Add("QUORUM_INTERSECTION_CHECKER_TIME_LIMIT_MS", ms) |> ignore
+        | None -> ()
+
+        match self.quorumIntersectionCheckerMemoryLimitBytes with
+        | Some b -> t.Add("QUORUM_INTERSECTION_CHECKER_MEMORY_LIMIT_BYTES", b) |> ignore
+        | None -> ()
+
         t.Add("MANUAL_CLOSE", self.manualClose) |> ignore
 
         if self.forceOldStyleLeaderElection then
@@ -672,6 +688,10 @@ type NetworkCfg with
               |> Option.orElse self.missionContext.forceOldStyleTriggerTimer
           clockOffsetMs = None
           surveyPhaseDuration = opts.surveyPhaseDuration
+          quorumIntersectionChecker = opts.quorumIntersectionChecker
+          useQuorumIntersectionCheckerV2 = opts.useQuorumIntersectionCheckerV2
+          quorumIntersectionCheckerTimeLimitMs = opts.quorumIntersectionCheckerTimeLimitMs
+          quorumIntersectionCheckerMemoryLimitBytes = opts.quorumIntersectionCheckerMemoryLimitBytes
           containerType = MainCoreContainer
           skipHighCriticalValidatorChecks = opts.skipHighCriticalValidatorChecks }
 
@@ -733,5 +753,9 @@ type NetworkCfg with
                   Some offsets.[i]
               | None -> None
           surveyPhaseDuration = c.options.surveyPhaseDuration
+          quorumIntersectionChecker = c.options.quorumIntersectionChecker
+          useQuorumIntersectionCheckerV2 = c.options.useQuorumIntersectionCheckerV2
+          quorumIntersectionCheckerTimeLimitMs = c.options.quorumIntersectionCheckerTimeLimitMs
+          quorumIntersectionCheckerMemoryLimitBytes = c.options.quorumIntersectionCheckerMemoryLimitBytes
           containerType = ctype
           skipHighCriticalValidatorChecks = c.options.skipHighCriticalValidatorChecks }

--- a/src/FSLibrary/StellarCoreHTTP.fs
+++ b/src/FSLibrary/StellarCoreHTTP.fs
@@ -364,6 +364,59 @@ let MeterCountOr (def: int) (m: Option<Metrics.GenericMeter>) : int =
     | None -> def
 
 
+// Result of stellar-core's quorum intersection checker as reported by the
+// `transitive` object of the /quorum endpoint.
+type QuorumIntersectionInfo =
+    { intersection: bool
+      nodeCount: int
+      lastCheckLedger: int
+      // Intersection-critical node groups; populated only when intersecting.
+      criticalGroups: Set<string> list
+      // The two disjoint quorums found; populated only when not intersecting.
+      potentialSplit: (Set<string> * Set<string>) option }
+
+let ParseQuorumIntersectionInfo (json: string) : QuorumIntersectionInfo option =
+    let root = JsonValue.Parse json
+
+    match root.TryGetProperty "transitive" with
+    | None -> None
+    | Some t ->
+        match t.TryGetProperty "intersection" with
+        | None -> None
+        | Some intersection ->
+            let strkeySet (v: JsonValue) = v.AsArray() |> Array.map (fun s -> s.AsString()) |> Set.ofArray
+
+            let criticalGroups =
+                match t.TryGetProperty "critical" with
+                | Some (JsonValue.Array groups) -> groups |> Array.map strkeySet |> List.ofArray
+                | _ -> []
+
+            let potentialSplit =
+                match t.TryGetProperty "potential_split" with
+                | Some (JsonValue.Array [| a; b |]) -> Some(strkeySet a, strkeySet b)
+                | _ -> None
+
+            Some
+                { intersection = intersection.AsBoolean()
+                  nodeCount = (t.GetProperty "node_count").AsInteger()
+                  lastCheckLedger = (t.GetProperty "last_check_ledger").AsInteger()
+                  criticalGroups = criticalGroups
+                  potentialSplit = potentialSplit }
+
+// Reads a single metric's count out of a raw /metrics JSON response,
+// defaulting to 0 when the metric has not been registered (yet).
+let ParseMetricCount (rawMetricsJson: string) (metricName: string) : int =
+    match (JsonValue.Parse rawMetricsJson).TryGetProperty "metrics" with
+    | None -> 0
+    | Some ms ->
+        match ms.TryGetProperty metricName with
+        | None -> 0
+        | Some m ->
+            match m.TryGetProperty "count" with
+            | Some c -> c.AsInteger()
+            | None -> 0
+
+
 let ConsistencyCheckIterationCount : int = 5
 
 exception PeerRejectedUpgradesException of string
@@ -402,6 +455,19 @@ type Peer with
         WebExceptionRetry DefaultRetry (fun _ -> Metrics.Parse(self.fetch "metrics").Metrics)
 
     member self.GetRawMetrics() = WebExceptionRetry DefaultRetry (fun _ -> self.fetch "metrics")
+
+    member self.TryGetQuorumIntersectionInfo() : QuorumIntersectionInfo option =
+        WebExceptionRetry DefaultRetry (fun _ -> ParseQuorumIntersectionInfo(self.fetch "quorum?fullkeys=true"))
+
+    member self.GetQuorumIntersectionInfo() : QuorumIntersectionInfo =
+        match self.TryGetQuorumIntersectionInfo() with
+        | Some qi -> qi
+        | None -> failwithf "No quorum intersection results on %s" self.ShortName.StringName
+
+    // Count of a quorum intersection checker (V2) metric, by short name,
+    // e.g. "successful-run" or "result-potential-split".
+    member self.GetQicMetricCount(shortName: string) : int =
+        ParseMetricCount(self.GetRawMetrics()) (sprintf "scp.qic.%s" shortName)
 
     member self.GetInfo() : Info.Info =
         WebExceptionRetry

--- a/src/FSLibrary/StellarCoreSet.fs
+++ b/src/FSLibrary/StellarCoreSet.fs
@@ -224,6 +224,16 @@ type CoreSetOptions =
       clockOffsets: int list option
       surveyPhaseDuration: int option
       updateSorobanCosts: bool option
+      // Enable stellar-core's quorum intersection checker
+      // (QUORUM_INTERSECTION_CHECKER). Supercluster disables it by default.
+      quorumIntersectionChecker: bool
+      // Use the V2 (Rust SAT-solver, subprocess-based) quorum intersection
+      // checker (USE_QUORUM_INTERSECTION_CHECKER_V2). Only meaningful when
+      // quorumIntersectionChecker is true.
+      useQuorumIntersectionCheckerV2: bool
+      // Optional overrides for the V2 checker's resource limits.
+      quorumIntersectionCheckerTimeLimitMs: int64 option
+      quorumIntersectionCheckerMemoryLimitBytes: int64 option
       // `skipHighCriticalValidatorChecks` exists to allow supercluster to
       // remain compatible with older stellar-core images that do not have the
       // ability to turn of validator checks for HIGH and CRITICAL validators
@@ -267,6 +277,10 @@ type CoreSetOptions =
           clockOffsets = None
           surveyPhaseDuration = None
           updateSorobanCosts = None
+          quorumIntersectionChecker = false
+          useQuorumIntersectionCheckerV2 = false
+          quorumIntersectionCheckerTimeLimitMs = None
+          quorumIntersectionCheckerMemoryLimitBytes = None
           skipHighCriticalValidatorChecks = true }
 
 type CoreSet =
@@ -283,11 +297,14 @@ type CoreSet =
         { name = self.name; options = self.options; keys = self.keys; live = live }
 
 
+let MakeLiveCoreSetWithKeys (name: string) (keys: KeyPair array) (options: CoreSetOptions) : CoreSet =
+    if keys.Length <> options.nodeCount then
+        failwithf "MakeLiveCoreSetWithKeys %s: %d keys supplied for nodeCount=%d" name keys.Length options.nodeCount
+
+    { name = CoreSetName name; options = options; keys = keys; live = true }
+
 let MakeLiveCoreSet (name: string) (options: CoreSetOptions) : CoreSet =
-    { name = CoreSetName name
-      options = options
-      keys = Array.init options.nodeCount (fun _ -> KeyPair.Random())
-      live = true }
+    MakeLiveCoreSetWithKeys name (Array.init options.nodeCount (fun _ -> KeyPair.Random())) options
 
 let MakeDeferredCoreSet (name: string) (options: CoreSetOptions) : CoreSet =
     { name = CoreSetName name

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -500,6 +500,30 @@ type NetworkCfg with
         let filedata = (self.StellarCoreCfgForJob opts).ToString()
         V1ConfigMap(metadata = self.NamespacedMeta cfgmapname, data = Map.empty.Add(filename, filedata))
 
+    // Returns the per-peer ConfigMap for peer i of the given CoreSet,
+    // containing its stellar-core.cfg (and init cfg, and optionally the
+    // network-delay script), regenerated from the CoreSet's current options.
+    member self.PeerConfigMap(coreSet: CoreSet, i: int) : V1ConfigMap =
+        let cfgMapName = (self.PeerCfgMapName coreSet i)
+        let cfgFileData = (self.StellarCoreCfg(coreSet, i, MainCoreContainer)).ToString()
+        let cfgMap = Map.empty.Add(CfgVal.peerCfgFileName, cfgFileData)
+
+        let startupCfgFileData = (self.StellarCoreCfg(coreSet, i, InitCoreContainer)).ToString()
+        let cfgMap = cfgMap.Add(CfgVal.peerInitCfgFileName, startupCfgFileData)
+
+        let cfgMap =
+            if self.NeedNetworkDelayScript then
+                let delayFileData = (self.NetworkDelayScript coreSet i).ToString()
+
+                LogInfo "Adding NetworkDelayScript to cfgMap of %s-%d" (coreSet.name.StringName) i
+                |> ignore
+
+                cfgMap.Add(CfgVal.peerDelayCfgFileName, delayFileData)
+            else
+                cfgMap
+
+        V1ConfigMap(metadata = self.NamespacedMeta cfgMapName, data = cfgMap)
+
     // Returns an array of ConfigMaps, which is either a single Job ConfigMap if
     // running a job, or a set of per-peer ConfigMaps, each of which is a volume
     // named peer-0-cfg .. peer-N-cfg, to be mounted on /peer-0-cfg ..
@@ -515,28 +539,8 @@ type NetworkCfg with
     // possibly more -- see comments in ToPodTemplateSpec), and each must then
     // figure out its own name to pick the volume(s) that contain its config(s).
     member self.ToConfigMaps() : V1ConfigMap array =
-        let peerCfgMap (coreSet: CoreSet) (i: int) =
-            let cfgMapName = (self.PeerCfgMapName coreSet i)
-            let cfgFileData = (self.StellarCoreCfg(coreSet, i, MainCoreContainer)).ToString()
-            let cfgMap = Map.empty.Add(CfgVal.peerCfgFileName, cfgFileData)
-
-            let startupCfgFileData = (self.StellarCoreCfg(coreSet, i, InitCoreContainer)).ToString()
-            let cfgMap = cfgMap.Add(CfgVal.peerInitCfgFileName, startupCfgFileData)
-
-            let cfgMap =
-                if self.NeedNetworkDelayScript then
-                    let delayFileData = (self.NetworkDelayScript coreSet i).ToString()
-
-                    LogInfo "Adding NetworkDelayScript to cfgMap of %s-%d" (coreSet.name.StringName) i
-                    |> ignore
-
-                    cfgMap.Add(CfgVal.peerDelayCfgFileName, delayFileData)
-                else
-                    cfgMap
-
-            V1ConfigMap(metadata = self.NamespacedMeta cfgMapName, data = cfgMap)
-
-        let cfgs = Array.append (self.MapAllPeers peerCfgMap) [| self.HistoryConfigMap() |]
+        let cfgs =
+            Array.append (self.MapAllPeers(fun cs i -> self.PeerConfigMap(cs, i))) [| self.HistoryConfigMap() |]
 
         match self.jobCoreSetOptions with
         | None -> cfgs

--- a/src/FSLibrary/StellarMission.fs
+++ b/src/FSLibrary/StellarMission.fs
@@ -51,6 +51,7 @@ open MissionUpgradeTxClusters
 open MissionValidatorSetup
 open MissionMinBlockTimeClassic
 open MissionMinBlockTimeMixed
+open MissionQuorumIntersectionChecker
 
 type Mission = (MissionContext -> unit)
 
@@ -103,4 +104,5 @@ let allMissions : Map<string, Mission> =
                  ("UpgradeTxClusters", upgradeTxClusters)
                  ("ValidatorSetup", validatorSetup)
                  ("MinBlockTimeClassic", minBlockTimeClassic)
-                 ("MinBlockTimeMixed", minBlockTimeMixed) |]
+                 ("MinBlockTimeMixed", minBlockTimeMixed)
+                 ("QuorumIntersectionChecker", quorumIntersectionChecker) |]

--- a/src/FSLibrary/StellarNetworkCfg.fs
+++ b/src/FSLibrary/StellarNetworkCfg.fs
@@ -143,6 +143,21 @@ type NetworkCfg =
         let coreSet = self.FindCoreSet(name).WithLive live
         { self with coreSets = self.coreSets.Add(name, coreSet) }
 
+    // Returns a NetworkCfg with the named CoreSet's options replaced, keeping
+    // its keys and liveness unchanged.
+    member self.WithCoreSetOptions (name: CoreSetName) (options: CoreSetOptions) : NetworkCfg =
+        let coreSet = self.FindCoreSet name
+
+        if options.nodeCount <> coreSet.options.nodeCount then
+            failwithf
+                "WithCoreSetOptions %s: cannot change nodeCount from %d to %d"
+                name.StringName
+                coreSet.options.nodeCount
+                options.nodeCount
+
+        { self with
+              coreSets = self.coreSets.Add(name, { coreSet with options = options }) }
+
     member self.IsJobMode : bool = if self.jobCoreSetOptions = None then false else true
 
     member self.AnchorConfigMapName : string = sprintf "%s-anchor" self.Nonce

--- a/src/FSLibrary/StellarStatefulSets.fs
+++ b/src/FSLibrary/StellarStatefulSets.fs
@@ -166,6 +166,29 @@ type StellarFormation with
 
     member self.Stop name = self.WithLive name false
 
+    // Replaces the named CoreSet's options (preserving its keys) and pushes the
+    // regenerated per-peer ConfigMaps to the cluster. Callers should Stop the
+    // core set first, call this, then Start it so the pods boot with the new
+    // configuration.
+    member self.ChangeCoreSetOptions (name: CoreSetName) (options: CoreSetOptions) =
+        let newCfg = self.NetworkCfg.WithCoreSetOptions name options
+        let coreSet = newCfg.FindCoreSet name
+
+        for i in 0 .. coreSet.keys.Length - 1 do
+            let cm = newCfg.PeerConfigMap(coreSet, i)
+            self.sleepUntilNextRateLimitedApiCallTime ()
+
+            self.Kube.ReplaceNamespacedConfigMap(
+                body = cm,
+                name = cm.Metadata.Name,
+                namespaceParameter = newCfg.NamespaceProperty
+            )
+            |> ignore
+
+            LogInfo "Replaced ConfigMap %s with reconfigured options" cm.Metadata.Name
+
+        self.SetNetworkCfg newCfg
+
     member self.WaitUntilReady() = self.NetworkCfg.EachPeer(fun p -> p.WaitUntilReady())
 
     member self.WaitUntilAllLiveSynced() = self.NetworkCfg.EachPeer(fun p -> p.WaitUntilSynced())


### PR DESCRIPTION
### What

Adds `MissionQuorumIntersectionChecker`, which verifies stellar-core's V2 quorum intersection checker on a live network (plus the config and HTTP plumbing the mission needs).

The mission runs six validators: a bridge requiring BOTH of two inner sets (2-of-3 `{v0,v1,v2}`, 2-of-3 `{v3,v4,v5}`), a strict 3-of-3 left pair, and a self-sufficient 3-of-4 right trio. Phase 0 verifies the network enjoys quorum intersection and that the checker flags the bridge as intersection-critical. The bridge is then restarted with its threshold relaxed to EITHER (100% → 50%), creating two disjoint quorums in configuration. The mission asserts: the split is detected live (exact `potential_split` via `/quorum` on the never-restarted side; `scp.qic` counters on the restarted bridge, since core withholds `/quorum` results from a node whose first run already sees a split), the severed pair keeps its frozen pre-split verdict, and no node crashes or restarts.

### Why

The quorum intersection checker is a safety-critical diagnostic, but nothing exercised it end-to-end against a real quorum-set change on a running network. The topology guarantees the second quorum can never assemble live (the severed pair deadlocks on each other), so the mission observes detection without ever forming an actual fork. Verified end-to-end on a test cluster.
