### PR TITLE
Fix home domain assignment for synthetic tier 1 creation

### DIFF
--- a/src/FSLibrary/StellarNetworkData.fs
+++ b/src/FSLibrary/StellarNetworkData.fs
@@ -367,7 +367,7 @@ let FullPubnetCoreSets (context: MissionContext) (manualclose: bool) (enforceMin
         [ for i in 1 .. context.tier1OrgsToAdd * tier1OrgSize ->
               PubnetNodeJSON.Parse(
                   sprintf
-                      """ [{ "publicKey": "%s", "radar_homeDomain": "home.domain.%d" }] """
+                      """ [{ "publicKey": "%s", "radar_homeDomain": "home-domain-%d" }] """
                       (KeyPair.Random().Address)
                       ((i - 1) / tier1OrgSize)
               ).[0]


### PR DESCRIPTION
Right now there is a suboptimal interaction between `--tier-1-orgs-to-add` and `--enable-relaxed-auto-qset-config`. Because of how we extract the relevant part of a domain by picking a component split by `.`s, all added tier1s current'y end up with a parsed home domain of `domain`, putting them all in the same organization.