### PR TITLE
Give MaxTPSClassic its own resource sizing for one pod per node

### DIFF
--- a/src/FSLibrary/MissionMaxTPSClassic.fs
+++ b/src/FSLibrary/MissionMaxTPSClassic.fs
@@ -14,7 +14,7 @@ open StellarCoreHTTP
 let maxTPSClassic (context: MissionContext) =
     let context =
         { context with
-              coreResources = SimulatePubnetTier1PerfResources
+              coreResources = MaxTPSClassicResources
               installNetworkDelay = Some(context.installNetworkDelay |> Option.defaultValue true)
               enableTailLogging = false
               // Isolate this perf run onto its own nodes so co-tenant pods from

--- a/src/FSLibrary/StellarKubeSpecs.fs
+++ b/src/FSLibrary/StellarKubeSpecs.fs
@@ -125,6 +125,11 @@ let SimulatePubnetTier1PerfCoreResourceRequirements : V1ResourceRequirements =
     // and 128MB-2GB RAM.
     makeResourceRequirements 500 128 4000 6000
 
+let MaxTPSClassicCoreResourceRequirements : V1ResourceRequirements =
+    // Sized so one core pod plus the http-proxy fills a 2-vCPU node, since pod
+    // density dominates the reported max TPS.
+    makeResourceRequirements 1100 2560 4000 6000
+
 let ParallelCatchupCoreResourceRequirements : V1ResourceRequirements =
     // When doing parallel catchup, we give each container
     // 0.25 vCPUs, 8Gi RAM and 35 GB of disk bursting to 2vCPU, 28Gi (28672Mi) and 40 GB
@@ -173,6 +178,7 @@ let GetCoreResourceRequirements (cr: CoreResources) : V1ResourceRequirements =
     | AcceptanceTestResources -> AcceptanceTestCoreResourceRequirements
     | SimulatePubnetResources -> SimulatePubnetResources
     | SimulatePubnetTier1PerfResources -> SimulatePubnetTier1PerfCoreResourceRequirements
+    | MaxTPSClassicResources -> MaxTPSClassicCoreResourceRequirements
     | ParallelCatchupResources -> ParallelCatchupCoreResourceRequirements
     | NonParallelCatchupResources -> NonParallelCatchupCoreResourceRequirements
     | UpgradeResources -> UpgradeCoreResourceRequirements

--- a/src/FSLibrary/StellarMissionContext.fs
+++ b/src/FSLibrary/StellarMissionContext.fs
@@ -27,6 +27,7 @@ type CoreResources =
     | AcceptanceTestResources
     | SimulatePubnetResources
     | SimulatePubnetTier1PerfResources
+    | MaxTPSClassicResources
     | ParallelCatchupResources
     | NonParallelCatchupResources
     | UpgradeResources


### PR DESCRIPTION
## What

Changes the cpu and memory requests of the MaxTPSClassicMission so a 2vCPU/8GB node can fit exactly one stellar-core pod  

## Issue

None filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
