### PR TITLE
Fix parallel catchup hanging on orphaned in-progress jobs

### DIFF
--- a/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
+++ b/src/FSLibrary/MissionHistoryPubnetParallelCatchupV2.fs
@@ -41,6 +41,10 @@ let jobMonitorLoggingIntervalSecs = 30 // frequency of job monitor's internal in
 let jobMonitorStatusCheckIntervalSecs = 60 // frequency of us querying job monitor's `/status` end point
 let jobMonitorMetricsCheckIntervalSecs = 60 // frequency of us querying job monitor's `/metrics` end point
 let jobMonitorStatusCheckTimeOutSecs = 600
+// Fail the mission if jobs are claimed but no worker is demonstrably alive, or if the
+// monitor's own status stops advancing
+let jobMonitorStallTimeOutSecs = 1800
+
 let mutable toPerformCleanup = true
 let failedJobLogFileLineCount = 10000
 let failedJobLogStreamLineCount = 1000
@@ -397,6 +401,8 @@ let historyPubnetParallelCatchupV2 (context: MissionContext) =
     let mutable allJobsFinished = false
     let mutable timeoutLeft = jobMonitorStatusCheckTimeOutSecs
     let mutable timeBeforeNextMetricsCheck = jobMonitorMetricsCheckIntervalSecs
+    let mutable stalledForSecs = 0
+    let mutable lastMissionDuration = -1.0
     let jobMonitorPath = "/" + context.namespaceProperty + "/" + helmReleaseName
 
     while not allJobsFinished do
@@ -423,6 +429,34 @@ let historyPubnetParallelCatchupV2 (context: MissionContext) =
                         LogInfo "<<<"
 
                     failwith "Catch up failed, check logs for more info"
+
+                // Detect if the mission is stuck from two signals: 1. job queue
+                // has in progress items but no live workers 2. the job monitor
+                // itself gets stuck unable to updating its internal metrics and
+                // status
+                let workersUp = status.Value<int>("workers_up")
+                let missionDuration = status.Value<float>("mission_duration")
+                let noLiveWorkers = JobsInProgress.Count > 0 && workersUp = 0
+                let monitorNotAdvancing = missionDuration = lastMissionDuration
+                lastMissionDuration <- missionDuration
+
+                if noLiveWorkers || monitorNotAdvancing then
+                    stalledForSecs <- stalledForSecs + jobMonitorStatusCheckIntervalSecs
+
+                    if stalledForSecs >= jobMonitorStallTimeOutSecs then
+                        LogError
+                            "Mission stalled for %d seconds: in_progress=%d, workers_up=%d, mission_duration=%f"
+                            stalledForSecs
+                            JobsInProgress.Count
+                            workersUp
+                            missionDuration
+
+                        for job in JobsInProgress do
+                            LogError "Stuck job: %s" (job.ToString())
+
+                        failwith "Catch up stalled, no progress and no live workers"
+                else
+                    stalledForSecs <- 0
 
                 if remainSize = 0 && JobsInProgress.Count = 0 then
                     // All jobs completed — perform a final query on the metrics

--- a/src/MissionParallelCatchup/job_monitor.py
+++ b/src/MissionParallelCatchup/job_monitor.py
@@ -7,6 +7,9 @@ import logging
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from redis.backoff import ExponentialBackoff
+from redis.exceptions import ConnectionError as RedisConnectionError, TimeoutError as RedisTimeoutError
+from redis.retry import Retry
 from prometheus_client import Gauge, Counter, Histogram, generate_latest, REGISTRY, CONTENT_TYPE_LATEST
 from datetime import datetime, timezone
 
@@ -17,12 +20,12 @@ from datetime import datetime, timezone
 metric_buckets = (300, 900, 1800, 3600, 5400, 7200, float("inf"))
 REDIS_HOST = os.getenv('REDIS_HOST', 'redis')
 REDIS_PORT = int(os.getenv('REDIS_PORT', '6379'))
-JOB_QUEUE = os.getenv('JOB_QUEUE', 'ranges')
-SUCCESS_QUEUE = os.getenv('SUCCESS_QUEUE', 'succeeded')
-FAILED_QUEUE = os.getenv('FAILED_QUEUE', 'failed')
-PROGRESS_QUEUE = os.getenv('PROGRESS_QUEUE', 'in_progress')
-METRICS = os.getenv('METRICS', 'metrics')
-JOB_OWNERS = os.getenv('JOB_OWNERS', 'job_owners')
+JOB_QUEUE = os.getenv('JOB_QUEUE', 'ranges') # LIST
+SUCCESS_QUEUE = os.getenv('SUCCESS_QUEUE', 'succeeded') # SET
+FAILED_QUEUE = os.getenv('FAILED_QUEUE', 'failed') # SET
+PROGRESS_QUEUE = os.getenv('PROGRESS_QUEUE', 'in_progress') #LIST
+METRICS = os.getenv('METRICS', 'metrics') # SET
+JOB_OWNERS = os.getenv('JOB_OWNERS', 'job_owners') # HASH
 WORKER_PREFIX = os.getenv('WORKER_PREFIX', 'stellar-core')
 NAMESPACE = os.getenv('NAMESPACE', 'default')
 WORKER_COUNT = int(os.getenv('WORKER_COUNT', 3))
@@ -44,8 +47,16 @@ def get_logging_level():
     else:
         return logging.INFO
 
-# Initialize Redis client
-redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
+redis_client = redis.Redis(
+    host=REDIS_HOST,
+    port=REDIS_PORT,
+    decode_responses=True,
+    socket_connect_timeout=5,
+    socket_timeout=5,
+    health_check_interval=30,
+    retry=Retry(ExponentialBackoff(cap=2, base=0.1), 3),
+    retry_on_error=[RedisConnectionError, RedisTimeoutError],
+)
 
 # Configure logging
 log_file_name = f"job_monitor_{datetime.now(timezone.utc).strftime('%Y-%m-%d_%H-%M-%S')}.log"
@@ -111,6 +122,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
 
+# Move one job from the progress queue back to the job queue and drop its owner.
+def requeue_job(job_key):
+    if redis_client.lrem(PROGRESS_QUEUE, -1, job_key) == 1:
+        redis_client.lpush(JOB_QUEUE, job_key)
+    redis_client.hdel(JOB_OWNERS, job_key)
+
 def retry_jobs_in_progress():
     while redis_client.llen(PROGRESS_QUEUE) > 0:
         job = redis_client.lmove(PROGRESS_QUEUE, JOB_QUEUE, "RIGHT", "LEFT")
@@ -138,14 +155,26 @@ def update_status_and_metrics():
         try:
             # --- Phase 1: Read queue status from Redis (fast, authoritative) ---
             queue_remain_count = redis_client.llen(JOB_QUEUE)
-            queue_succeeded_count = redis_client.llen(SUCCESS_QUEUE)
-            jobs_failed = redis_client.lrange(FAILED_QUEUE, 0, -1)
+            queue_succeeded_count = redis_client.scard(SUCCESS_QUEUE)
+            jobs_failed = list(redis_client.smembers(FAILED_QUEUE))
             jobs_in_progress = redis_client.lrange(PROGRESS_QUEUE, 0, -1)
+            job_owners = redis_client.hgetall(JOB_OWNERS)  # {job_key: pod_name}
             queue_failed_count = len(jobs_failed)
             queue_in_progress_count = len(jobs_in_progress)
 
+            # --- Phase 1b: Requeue orphaned jobs (in progress, but owned by nobody) ---
+            orphans = [job for job in jobs_in_progress if job not in job_owners]
+            for job in orphans:
+                logger.error("Requeuing orphaned job %s: in %s with no owner in %s",
+                             job, PROGRESS_QUEUE, JOB_OWNERS)
+                requeue_job(job)
+                metric_retries.inc()
+            if orphans:
+                jobs_in_progress = redis_client.lrange(PROGRESS_QUEUE, 0, -1)
+                queue_in_progress_count = len(jobs_in_progress)
+                queue_remain_count = redis_client.llen(JOB_QUEUE)
+
             # --- Phase 2: Quick single-ping check of workers that own in-progress jobs ---
-            job_owners = redis_client.hgetall(JOB_OWNERS)  # {job_key: pod_name}
             active_workers = set(job_owners.values())
             worker_statuses = []
             workers_up = 0
@@ -224,9 +253,14 @@ def update_status_and_metrics():
                     metrics['metrics'].extend(new_metrics)
                 for timing in new_metrics:
                     # Example: 36024000/8320|213|1.47073e+06ms|2965s
-                    _, _, tx_apply, full_duration = timing.split('|')
-                    metric_full_duration.observe(float(full_duration.rstrip('s')))
-                    metric_tx_apply_duration.observe(float(tx_apply.rstrip('ms'))/1000)
+                    # tx_apply is the literal "N/A" when the worker could not
+                    # read its log file
+                    try:
+                        _, _, tx_apply, full_duration = timing.split('|')
+                        metric_full_duration.observe(float(full_duration.rstrip('s')))
+                        metric_tx_apply_duration.observe(float(tx_apply.rstrip('ms'))/1000)
+                    except (ValueError, TypeError):
+                        logger.warning("Skipping unparseable metric entry: %s", timing)
             logger.info("Metrics: %s", json.dumps(metrics))
 
         except Exception as e:

--- a/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/files/worker.sh
@@ -21,21 +21,28 @@ fi
 SLEEP_INTERVAL=10
 LOG_DIR="/data"
 
+# Claim a job and register its owner atomically
+CLAIM_SCRIPT='local job = redis.call("LMOVE", KEYS[1], KEYS[2], "LEFT", "LEFT")
+if job then redis.call("HSET", KEYS[3], job, ARGV[1]) end
+return job'
+
 while true; do
-# Fetch the next job key from the Redis queue.
-# Our ranges are generated in the order we want to run them from left to right, so we always pull from the left
-JOB_KEY=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" LMOVE "$JOB_QUEUE" "$PROGRESS_QUEUE" LEFT LEFT)
-LMOVE_EXIT_CODE=$?
+# Claim the next job: atomically move it from the job queue to the progress
+# queue and record this pod as its owner. Our ranges are generated in the order
+# we want to run them from left to right, so we always pull from the left
+JOB_KEY=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" \
+    EVAL "$CLAIM_SCRIPT" 3 "$JOB_QUEUE" "$PROGRESS_QUEUE" "$JOB_OWNERS" "$POD_NAME")
+CLAIM_EXIT_CODE=$?
 
-# Only process a job if the command succeeded AND we got a non-empty job key
-if [ $LMOVE_EXIT_CODE -eq 0 ] && [ -n "$JOB_KEY" ]; then
-    # Register ownership so the monitor knows which worker owns this job
-    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" HSET "$JOB_OWNERS" "$JOB_KEY" "$POD_NAME"
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to register job ownership for $JOB_KEY. Exiting."
-        exit 1
-    fi
+# Validate the reply is a well-formed "<ledger>/<count>" job key
+case "$JOB_KEY" in
+    "" | *[!0-9/]* | */*/* | /* | */) CLAIM_VALID=false ;;
+    */*) CLAIM_VALID=true ;;
+    *) CLAIM_VALID=false ;;
+esac
 
+# Only process a job if the command succeeded AND the reply is a valid job key
+if [ $CLAIM_EXIT_CODE -eq 0 ] && [ "$CLAIM_VALID" = true ]; then
     # Start timer
     START_TIME=$(date +%s)
     echo "Processing job: $JOB_KEY"
@@ -54,26 +61,26 @@ if [ $LMOVE_EXIT_CODE -eq 0 ] && [ -n "$JOB_KEY" ]; then
     # Check if both commands succeeded
     if [ $STELLAR_CORE_EXIT_CODE -eq 0 ]; then
         echo "Successfully processed job: $JOB_KEY"
-        QUEUE_COMMAND="LPUSH $SUCCESS_QUEUE \"$JOB_KEY\""
+        QUEUE_COMMAND="SADD $SUCCESS_QUEUE \"$JOB_KEY\""
     else
         echo "Error processing job: $JOB_KEY (exit code: $STELLAR_CORE_EXIT_CODE)"
-        QUEUE_COMMAND="LPUSH $FAILED_QUEUE \"$JOB_KEY|$POD_NAME\""
+        QUEUE_COMMAND="SADD $FAILED_QUEUE \"$JOB_KEY|$POD_NAME\""
     fi
 
-    # Parse and extract the metrics from the log file
+    # Parse and extract the metrics from the log file.
     LOG_FILE=$(ls -t "$LOG_DIR"/stellar-core*.log 2>/dev/null | head -n 1)
     if [ -z "$LOG_FILE" ]; then
-        echo "No log file found in $LOG_DIR"
-        exit 1
-    fi
-
-    tx_apply_ms=$(tac "$LOG_FILE" | grep -m 1 -B 11 "metric 'ledger.transaction.apply':" | grep "sum =" | awk '{print $NF}')
-    echo "Log file: $LOG_FILE"
-    echo "ledger.transaction.apply sum: $tx_apply_ms"
-    # Validate metric was extracted successfully
-    if [ -z "$tx_apply_ms" ]; then
-        echo "Warning: Failed to extract metric 'ledger.transaction.apply' from log file"
+        echo "Warning: No log file found in $LOG_DIR"
         tx_apply_ms="N/A"
+    else
+        tx_apply_ms=$(tac "$LOG_FILE" | grep -m 1 -B 11 "metric 'ledger.transaction.apply':" | grep "sum =" | awk '{print $NF}')
+        echo "Log file: $LOG_FILE"
+        echo "ledger.transaction.apply sum: $tx_apply_ms"
+        # Validate metric was extracted successfully
+        if [ -z "$tx_apply_ms" ]; then
+            echo "Warning: Failed to extract metric 'ledger.transaction.apply' from log file"
+            tx_apply_ms="N/A"
+        fi
     fi
 
     # Push metrics to redis in a transaction to ensure data consistency. Retry for 5min on failures
@@ -110,10 +117,12 @@ EOF
     fi
 
 else
-    # Either Redis command failed OR queue is empty
-    if [ $LMOVE_EXIT_CODE -ne 0 ]; then
-        echo "Error: Failed to connect to Redis at $REDIS_HOST:$REDIS_PORT"
-        echo "Exit code=$LMOVE_EXIT_CODE, Output: $JOB_KEY"
+    # The claim failed, returned something unexpected, or the queue is empty.
+    if [ $CLAIM_EXIT_CODE -ne 0 ]; then
+        echo "Error: Failed to claim a job from Redis at $REDIS_HOST:$REDIS_PORT"
+        echo "Exit code=$CLAIM_EXIT_CODE, Output: $JOB_KEY"
+    elif [ -n "$JOB_KEY" ]; then
+        echo "Error: Unexpected claim reply, not a job key: $JOB_KEY"
     else
         echo "$(date) No more jobs in the queue."
     fi

--- a/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/templates/job_monitor.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: job-monitor
-        image: stellar/ssc-job-monitor:latest
+        image: {{ .Values.monitor.image }}
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
+++ b/src/MissionParallelCatchup/parallel_catchup_helm/values.yaml
@@ -36,6 +36,7 @@ worker:
     "curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
 
 monitor:
+  image: "stellar/ssc-job-monitor:latest"
   gateway_name: "traefik-gateway-private"
   gateway_namespace: "traefik"
   hostname: "" # to be set by the mission


### PR DESCRIPTION
### what

- Worker script: make claiming a job atomic, so it can never land in the progress queue without an owner
- Job monitor: detect and requeue jobs that nothing is working on
- PCv2 mission: fail the mission when it stops making progress, rather than waiting forever
- Some hardening along the way: redis data structure tightening, client timeouts, no hard-fail on metrics extraction

### why

A recent parallel catchup build hung due to a stale state (has job in progress but no worker working). Claiming a job and recording its owner were two separate steps, so a transient Redis failure in between left a job that no worker was running and that nothing in the system could recognize as stuck.

This removes the gap that loses the job, gives the monitor a way to recover if it happens anyway, and makes any future variant fail quickly.
